### PR TITLE
Removing sql comments from query before removing all new lines.

### DIFF
--- a/tests/integration_tests/test_client.py
+++ b/tests/integration_tests/test_client.py
@@ -45,3 +45,30 @@ def test_get_columns_only(test_client):
     result: QueryResult = test_client.query('SELECT database, engine FROM system.tables',
                                             settings={'metadata_only': True})
     assert result.column_names == ('database', 'engine')
+
+
+def test_multiline_query(test_client: Client):
+    result = test_client.query("""
+    SELECT *
+    FROM system.tables
+    """)
+    assert len(result.result_set) > 0
+
+
+def test_query_with_inline_comment(test_client: Client):
+    result = test_client.query("""
+    SELECT *
+    -- This is just a comment
+    FROM system.tables
+    """)
+    assert len(result.result_set) > 0
+
+
+def test_query_with_comment(test_client: Client):
+    result = test_client.query("""
+    SELECT *
+    /* This is:
+    a multiline comment */
+    FROM system.tables
+    """)
+    assert len(result.result_set) > 0


### PR DESCRIPTION
Reason: In line comments in sql are declared using '--' identifier. Once we remove all new lines from the command, inline comments will comment out all the trailing sql commands after the comment line. This is why it is important to remove all inline comments before removing all the new lines.