### PR TITLE
Deprecation fix

### DIFF
--- a/clickhouse_connect/datatypes/container.py
+++ b/clickhouse_connect/datatypes/container.py
@@ -1,5 +1,5 @@
 import array
-from typing import Dict, Sequence, MutableSequence, Any
+from typing import Dict, Sequence, MutableSequence
 
 from clickhouse_connect.datatypes.base import UnsupportedType, ClickHouseType, TypeDef
 from clickhouse_connect.driver.common import read_leb128, to_leb128, array_column, must_swap
@@ -199,12 +199,11 @@ class Map(ClickHouseType):
 
 
 class Nested(UnsupportedType):
-    __slots__ = 'elements',
+    __slots__ = ('elements',)
     python_type = list
 
     def __init__(self, type_def):
         super().__init__(type_def)
-
         self.elements = [get_from_name(x) for x in type_def.values]
         self._name_suffix = type_def.arg_str
 

--- a/clickhouse_connect/datatypes/container.py
+++ b/clickhouse_connect/datatypes/container.py
@@ -1,5 +1,5 @@
 import array
-from typing import Dict, Sequence, MutableSequence
+from typing import Dict, Sequence, MutableSequence, Any
 
 from clickhouse_connect.datatypes.base import UnsupportedType, ClickHouseType, TypeDef
 from clickhouse_connect.driver.common import read_leb128, to_leb128, array_column, must_swap
@@ -198,6 +198,17 @@ class Map(ClickHouseType):
         self.value_type.write_native_data(values, dest)
 
 
+class Nested(UnsupportedType):
+    __slots__ = 'elements',
+    python_type = list
+
+    def __init__(self, type_def):
+        super().__init__(type_def)
+
+        self.elements = [get_from_name(x) for x in type_def.values]
+        self._name_suffix = type_def.arg_str
+
+
 class Object(UnsupportedType):
     python_type = dict
 
@@ -208,11 +219,3 @@ class Object(UnsupportedType):
 
 class JSON(UnsupportedType):
     python_type = dict
-
-
-class Nested(UnsupportedType):
-    python_type = list
-
-    def __init__(self, type_def):
-        super().__init__(type_def)
-        self._name_suffix = type_def.arg_str

--- a/clickhouse_connect/driver/common.py
+++ b/clickhouse_connect/driver/common.py
@@ -57,6 +57,11 @@ def write_array(code: str, column: Sequence, dest: MutableSequence):
     :param column: Column of native Python values
     :param dest: Destination byte buffer
     """
+    if column and not isinstance(column[0], (int, float)):
+        if code in ('f', 'F', 'd', 'D'):
+            column = [float(x) for x in column]
+        else:
+            column = [int(x) for x in column]
     buff = array.array(code, column)
     if must_swap:
         buff.byteswap()

--- a/clickhouse_connect/driver/httpclient.py
+++ b/clickhouse_connect/driver/httpclient.py
@@ -22,7 +22,7 @@ columns_only_re = re.compile(r'LIMIT 0\s*$', re.IGNORECASE)
 # the client as thread safe as possible while sharing a single connection pool.  For the same reason we
 # don't call the Session.close() method from the client so the connection pool remains available
 retry = Retry(total=2, status_forcelist=[429, 503, 504],
-              method_whitelist=['HEAD', 'GET', 'OPTIONS', 'POST'],
+              allowed_methods=['HEAD', 'GET', 'OPTIONS', 'POST'],
               backoff_factor=1.5)
 http_adapter = HTTPAdapter(pool_connections=4, pool_maxsize=8, max_retries=retry)
 atexit.register(http_adapter.close)

--- a/tests/integration_tests/test_client.py
+++ b/tests/integration_tests/test_client.py
@@ -1,3 +1,5 @@
+from decimal import Decimal
+
 from clickhouse_connect.driver.client import Client
 from clickhouse_connect.driver.options import HAS_NUMPY, HAS_PANDAS
 from clickhouse_connect.driver.query import QueryResult
@@ -18,6 +20,16 @@ def test_insert(test_client: Client, test_table_engine: str):
     test_client.command(f'CREATE TABLE test_system_insert AS system.tables Engine {test_table_engine} ORDER BY name')
     tables_result = test_client.query('SELECT * from system.tables')
     test_client.insert(table='test_system_insert', column_names='*', data=tables_result.result_set)
+
+
+def test_decimal_conv(test_client: Client, test_table_engine: str):
+    test_client.command('DROP TABLE IF EXISTS test_number_conv')
+    test_client.command('CREATE TABLE test_num_conv (col1 UInt64, col2 Int32, f1 Float64)' +
+                        f' Engine {test_table_engine} ORDER BY col1')
+    data = [[Decimal(5), Decimal(-182), Decimal(55.2)], [Decimal(57238478234), Decimal(77), Decimal(-29.5773)]]
+    test_client.insert('test_num_conv', data)
+    result = test_client.query('SELECT * FROM test_num_conv').result_set
+    assert result == [(5, -182, 55.2), (57238478234, 77, -29.5773)]
 
 
 def test_numpy(test_client: Client):


### PR DESCRIPTION
Main fix is to the implicit conversion of Decimals to floats or ints when populating a ClickHouse column of Float/Int with Python decimals