### PR TITLE
Fix Encoding issue (Chinese character cause request to fail)

### DIFF
--- a/clickhouse_connect/driver/httpclient.py
+++ b/clickhouse_connect/driver/httpclient.py
@@ -205,7 +205,7 @@ class HttpClient(Client):
             response: Response = self.session.request(method, self.url,
                                                       headers=headers,
                                                       timeout=(self.connect_timeout, self.read_timeout),
-                                                      data=data,
+                                                      data=data.encode(),
                                                       params=params)
         except RequestException as ex:
             logger.exception('Unexpected Http Driver Exception')


### PR DESCRIPTION
For example:
UnicodeEncodeError: 'latin-1' codec can't encode character '\u7a7a' in position 57: Body ('空') is not valid Latin-1. Use body.encode('utf-8') if you want to send it encoded in UTF-8.