### PR TITLE
Add socket options for TCP keep alive to HTTP adapter

### DIFF
--- a/clickhouse_connect/driver/client.py
+++ b/clickhouse_connect/driver/client.py
@@ -19,6 +19,7 @@ class Client(metaclass=ABCMeta):
     Base ClickHouse Connect client
     """
     column_inserts = False
+    valid_transport_settings = set()
 
     def __init__(self, database: str, query_limit: int, uri: str, settings: Dict[str, Any] = None):
         """
@@ -47,7 +48,7 @@ class Client(metaclass=ABCMeta):
     def _validate_settings(self, settings: Dict[str, Any]):
         validated = {}
         for key, value in settings.items():
-            if 'session' not in key and key not in ('database', 'buffer_size'):
+            if key not in self.valid_transport_settings:
                 setting_def = self.server_settings.get(key)
                 if setting_def is None or setting_def.readonly:
                     logger.debug('Setting %s is not valid or read only, ignoring', key)

--- a/clickhouse_connect/driver/client.py
+++ b/clickhouse_connect/driver/client.py
@@ -47,7 +47,7 @@ class Client(metaclass=ABCMeta):
     def _validate_settings(self, settings: Dict[str, Any]):
         validated = {}
         for key, value in settings.items():
-            if 'session' not in key:
+            if 'session' not in key and key not in ('database', 'buffer_size'):
                 setting_def = self.server_settings.get(key)
                 if setting_def is None or setting_def.readonly:
                     logger.debug('Setting %s is not valid or read only, ignoring', key)

--- a/clickhouse_connect/driver/httpadapter.py
+++ b/clickhouse_connect/driver/httpadapter.py
@@ -1,0 +1,44 @@
+import sys
+import socket
+
+from requests.adapters import HTTPAdapter
+from urllib3 import poolmanager
+
+KEEP_INTERVAL = 30
+KEEP_COUNT = 3
+KEEP_IDLE = 30
+SOCKET_TCP = socket.IPPROTO_TCP
+
+core_socket_options = [
+    (socket.SOL_SOCKET, socket.SO_KEEPALIVE, 1),
+    (SOCKET_TCP, socket.TCP_NODELAY, 1)
+]
+
+
+class KeepAliveAdapter(HTTPAdapter):
+    """
+    Extended HTTP adapter that sets preferred keep alive options
+    """
+    def __init__(self, **kwargs):
+        self.socket_options = core_socket_options.copy()
+        interval = kwargs.pop('keep_interval', KEEP_INTERVAL)
+        count = kwargs.pop('keep_count', KEEP_COUNT)
+        idle = kwargs.pop('keep_idle', KEEP_IDLE)
+
+        if getattr(socket, 'TCP_KEEPINTVL', None) is not None:
+            self.socket_options.append((SOCKET_TCP, socket.TCP_KEEPINTVL, interval))
+        if getattr(socket, 'TCP_KEEPCNT', None) is not None:
+            self.socket_options.append((SOCKET_TCP, socket.TCP_KEEPCNT, count))
+        if getattr(socket, 'TCP_KEEPIDLE', None) is not None:
+            self.socket_options.append((SOCKET_TCP, socket.TCP_KEEPIDLE, idle))
+        if sys.platform == 'darwin':
+            self.socket_options.append((SOCKET_TCP, getattr(socket, 'TCP_KEEPALIVE', 0x10), interval))
+        super().__init__(**kwargs)
+
+    def init_poolmanager(self, connections, maxsize, block=False, **pool_kwargs):
+        self.poolmanager = poolmanager.PoolManager(
+            num_pools=connections,
+            maxsize=maxsize,
+            block=block,
+            socket_options=self.socket_options,
+            **pool_kwargs)

--- a/clickhouse_connect/driver/httpclient.py
+++ b/clickhouse_connect/driver/httpclient.py
@@ -32,6 +32,10 @@ PyHttp._MAXHEADERS = 10000  # pylint: disable=protected-access
 
 # pylint: disable=too-many-instance-attributes
 class HttpClient(Client):
+    valid_transport_settings = {'database', 'buffer_size', 'session_id', 'compress', 'decompress',
+                          'session_timeout', 'session_id', 'session_check', 'query_id',
+                          'quota_key'}
+
     # pylint: disable=too-many-arguments,too-many-locals,too-many-branches,too-many-statements
     def __init__(self, interface: str, host: str, port: int, username: str, password: str, database: str,
                  compress: bool = True, data_format: str = 'native', query_limit: int = 5000,

--- a/clickhouse_connect/driver/httpclient.py
+++ b/clickhouse_connect/driver/httpclient.py
@@ -33,8 +33,7 @@ PyHttp._MAXHEADERS = 10000  # pylint: disable=protected-access
 # pylint: disable=too-many-instance-attributes
 class HttpClient(Client):
     valid_transport_settings = {'database', 'buffer_size', 'session_id', 'compress', 'decompress',
-                          'session_timeout', 'session_id', 'session_check', 'query_id',
-                          'quota_key'}
+                                'session_timeout', 'session_check', 'query_id', 'quota_key'}
 
     # pylint: disable=too-many-arguments,too-many-locals,too-many-branches,too-many-statements
     def __init__(self, interface: str, host: str, port: int, username: str, password: str, database: str,


### PR DESCRIPTION
I believe this fixes the timeout issues reported in dbt-clickhouse.  Silly me for thinking that a requests keep alive connection would also add keep alive to the TCP socket.  See the discussion below 

https://www.finbourne.com/blog/the-mysterious-hanging-client-tcp-keep-alives
https://github.com/psf/requests/issues/3353

