### PR TITLE
Include pip installation

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,10 +6,15 @@ ClickHouse HTTP interface.
 
 
 ### Installation
+
+```
+pip install clickhouse-connect
+```
+
 ClickHouse Connect requires Python 3.7 or higher.  The `cython` package must be installed prior to installing 
 `clickhouse_connect` to build and install the optional  Cython/C extensions used for improving read and write
 performance using the ClickHouse Native format. After installing cython if desired, clone this repository and
-run `python setup.py install`from the project directory.  
+run `python setup.py install`from the project directory.
 
 ### Getting Started
 


### PR DESCRIPTION
Since the README is serving as the only real source of documentation for the project you should include the pip installation instructions and optionally a link to PyPi.

I had members of my team run into issues with the `setup.py` installation because they didn't even know the project was available through PyPi. This is the easiest route for installation and is standard to include in documentation for Python projects.