### PR TITLE
Arrow inserts

### DIFF
--- a/.github/workflows/on_push.yml
+++ b/.github/workflows/on_push.yml
@@ -20,7 +20,6 @@ jobs:
         run: |
           python -m pip install --upgrade pip
           pip install setuptools wheel
-          pip install -e .
           pip install -r tests/test_requirements.txt
           pip install pylint==2.14
       - name: Run Pylint
@@ -59,7 +58,6 @@ jobs:
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
-          pip install -e .
           pip install -r tests/test_requirements.txt
       - name: Build cython extensions
         run: python setup.py build_ext --inplace

--- a/.github/workflows/on_push.yml
+++ b/.github/workflows/on_push.yml
@@ -22,6 +22,7 @@ jobs:
           pip install setuptools wheel
           pip install -r tests/test_requirements.txt
           pip install pylint==2.14
+          python setup.py build_ext --inplace
       - name: Run Pylint
         run: |
           pylint clickhouse_connect

--- a/clickhouse_connect/cc_sqlalchemy/ddl/custom.py
+++ b/clickhouse_connect/cc_sqlalchemy/ddl/custom.py
@@ -1,7 +1,7 @@
 from sqlalchemy.sql.ddl import DDL
 from sqlalchemy.exc import ArgumentError
 
-from clickhouse_connect.cc_sqlalchemy.sql import quote_id
+from clickhouse_connect.driver.query import quote_identifier
 
 
 class CreateDatabase(DDL):
@@ -20,7 +20,7 @@ class CreateDatabase(DDL):
         """
         if engine and engine not in ('Ordinary', 'Atomic', 'Lazy', 'Replicated'):
             raise ArgumentError(f'Unrecognized engine type {engine}')
-        stmt = f'CREATE DATABASE {quote_id(name)}'
+        stmt = f'CREATE DATABASE {quote_identifier(name)}'
         if engine:
             stmt += f' Engine {engine}'
             if engine == 'Replicated':
@@ -35,4 +35,4 @@ class DropDatabase(DDL):
     Alternative DDL statement for built in SqlAlchemy DropSchema DDL class
     """
     def __init__(self, name: str):
-        super().__init__(f'DROP DATABASE {quote_id(name)}')
+        super().__init__(f'DROP DATABASE {quote_identifier(name)}')

--- a/clickhouse_connect/cc_sqlalchemy/sql/__init__.py
+++ b/clickhouse_connect/cc_sqlalchemy/sql/__init__.py
@@ -2,15 +2,13 @@ from typing import Optional
 
 from sqlalchemy import Table
 
-
-def quote_id(v: str) -> str:
-    return f'`{v}`'
+from clickhouse_connect.driver.query import quote_identifier
 
 
 def full_table(table_name: str, schema: Optional[str] = None) -> str:
     if table_name.startswith('(') or '.' in table_name or not schema:
-        return quote_id(table_name)
-    return f'{quote_id(schema)}.{quote_id(table_name)}'
+        return quote_identifier(table_name)
+    return f'{quote_identifier(schema)}.{quote_identifier(table_name)}'
 
 
 def format_table(table: Table):

--- a/clickhouse_connect/cc_sqlalchemy/sql/ddlcompiler.py
+++ b/clickhouse_connect/cc_sqlalchemy/sql/ddlcompiler.py
@@ -1,16 +1,17 @@
 from sqlalchemy import Column
 from sqlalchemy.sql.compiler import DDLCompiler
 
-from clickhouse_connect.cc_sqlalchemy.sql import quote_id, format_table
+from clickhouse_connect.cc_sqlalchemy.sql import  format_table
+from clickhouse_connect.driver.query import quote_identifier
 
 
 class ChDDLCompiler(DDLCompiler):
 
     def visit_create_schema(self, create):
-        return f'CREATE DATABASE {quote_id(create.element)}'
+        return f'CREATE DATABASE {quote_identifier(create.element)}'
 
     def visit_drop_schema(self, drop):
-        return f'DROP DATABASE {quote_id(drop.element)}'
+        return f'DROP DATABASE {quote_identifier(drop.element)}'
 
     def visit_create_table(self, create):
         table = create.element
@@ -19,5 +20,5 @@ class ChDDLCompiler(DDLCompiler):
         return text + ') ' + table.engine.compile()
 
     def get_column_specification(self, column: Column, **_):
-        text = f'{quote_id(column.name)} {column.type.compile()}'
+        text = f'{quote_identifier(column.name)} {column.type.compile()}'
         return text

--- a/clickhouse_connect/cc_sqlalchemy/sql/preparer.py
+++ b/clickhouse_connect/cc_sqlalchemy/sql/preparer.py
@@ -1,11 +1,11 @@
 from sqlalchemy.sql.compiler import IdentifierPreparer
 
-from clickhouse_connect.cc_sqlalchemy.sql import quote_id
+from clickhouse_connect.driver.query import quote_identifier
 
 
 class ChIdentifierPreparer(IdentifierPreparer):
 
-    quote_identifier = staticmethod(quote_id)
+    quote_identifier = staticmethod(quote_identifier)
 
     def _requires_quotes(self, _value):
         return True

--- a/clickhouse_connect/driver/client.py
+++ b/clickhouse_connect/driver/client.py
@@ -387,14 +387,14 @@ class Client(metaclass=ABCMeta):
     @abstractmethod
     def raw_insert(self, table: str,
                    column_names: Sequence[str],
-                   insert_block: bytes,
+                   insert_block: Union[str,  bytes],
                    settings: Optional[Dict] = None,
                    fmt: Optional[str] = None):
         """
         Insert data already formatted in a bytes object
         :param table: Table name (whether or not qualified with the database name
         :param column_names: Sequence of column names
-        :param insert_block: Binary data already in a recognized ClickHouse format
+        :param insert_block: Binary or string data already in a recognized ClickHouse format
         :param settings:  Optional dictionary of ClickHouse settings (key/string values)
         :param fmt: Valid clickhouse format
         """

--- a/clickhouse_connect/driver/client.py
+++ b/clickhouse_connect/driver/client.py
@@ -9,7 +9,8 @@ from clickhouse_connect.datatypes.registry import get_from_name
 from clickhouse_connect.datatypes.base import ClickHouseType
 from clickhouse_connect.driver.exceptions import ProgrammingError, InternalError
 from clickhouse_connect.driver.models import ColumnDef, SettingDef
-from clickhouse_connect.driver.query import QueryResult, np_result, to_pandas_df, from_pandas_df, to_arrow, QueryContext
+from clickhouse_connect.driver.query import QueryResult, np_result, to_pandas_df, from_pandas_df, to_arrow, \
+    QueryContext, arrow_buffer
 
 logger = logging.getLogger(__name__)
 
@@ -289,15 +290,33 @@ class Client(metaclass=ABCMeta):
         assert len(column_names) == len(column_types)
         self.data_insert(full_table, column_names, data, column_types, settings, column_oriented)
 
-    def insert_df(self, table: str, data_frame, database: str = None):
+    def insert_df(self, table: str, data_frame, database: str = None, settings: Optional[Dict] = None):
         """
         Insert a pandas DataFrame into ClickHouse
         :param table: ClickHouse table
         :param data_frame: two-dimensional pandas dataframe
         :param database: Optional ClickHouse database
+        :param settings: Optional dictionary of ClickHouse settings (key/string values)
         :return: No return, throws an exception if the insert fails
         """
-        return self.insert(table, database=database, **from_pandas_df(data_frame))
+        return self.insert(table, database=database, settings=settings, **from_pandas_df(data_frame))
+
+    def insert_arrow(self,
+                     table: str,
+                     arrow_table,
+                     database: str = None,
+                     settings: Optional[Dict] = None):
+        """
+        Insert a PyArrow table DataFrame into ClickHouse using raw Arrow format
+        :param table: ClickHouse table
+        :param arrow_table: PyArrow Table object
+        :param database: Optional ClickHouse database
+        :param settings: Optional dictionary of ClickHouse settings (key/string values)
+        :return: No return, throws an exception if the insert fails
+        """
+        _, _, full_table = self.normalize_table(table, database)
+        column_names, insert_block = arrow_buffer(arrow_table)
+        self.raw_insert(full_table, column_names, insert_block, settings, 'Arrow')
 
     def normalize_table(self, table: str, database: Optional[str]) -> Tuple[str, str, str]:
         """
@@ -363,6 +382,21 @@ class Client(metaclass=ABCMeta):
         :param settings:  Optional dictionary of ClickHouse settings (key/string values)
         :param column_oriented: Whether the data is already pivoted as a sequence of columns
         :return: No return, throws an exception if the insert fails
+        """
+
+    @abstractmethod
+    def raw_insert(self, table: str,
+                   column_names: Sequence[str],
+                   insert_block: bytes,
+                   settings: Optional[Dict] = None,
+                   fmt: Optional[str] = None):
+        """
+        Insert data already formatted in a bytes object
+        :param table: Table name (whether or not qualified with the database name
+        :param column_names: Sequence of column names
+        :param insert_block: Binary data already in a recognized ClickHouse format
+        :param settings:  Optional dictionary of ClickHouse settings (key/string values)
+        :param fmt: Valid clickhouse format
         """
 
     def close(self):

--- a/clickhouse_connect/driver/httpclient.py
+++ b/clickhouse_connect/driver/httpclient.py
@@ -189,7 +189,7 @@ class HttpClient(Client):
 
     def raw_insert(self, table: str,
                    column_names: Sequence[str],
-                   insert_block: bytes,
+                   insert_block: Union[str, bytes],
                    settings: Optional[Dict] = None,
                    fmt: Optional[str] = None):
         """
@@ -200,6 +200,8 @@ class HttpClient(Client):
         headers = {'Content-Type': 'application/octet-stream'}
         params = {'query': f"INSERT INTO {table} ({', '.join(column_ids)}) FORMAT {write_format}",
                   'database': self.database}
+        if isinstance(insert_block, str):
+            insert_block = insert_block.encode()
         params.update(self._validate_settings(settings, True))
         response = self._raw_request(insert_block, params, headers)
         logger.debug('Insert response code: %d, content: %s', response.status_code, response.content)

--- a/clickhouse_connect/driver/httpclient.py
+++ b/clickhouse_connect/driver/httpclient.py
@@ -14,7 +14,7 @@ from clickhouse_connect.driver.client import Client
 from clickhouse_connect.driver.exceptions import DatabaseError, OperationalError, ProgrammingError
 from clickhouse_connect.driver.httpadapter import KeepAliveAdapter
 from clickhouse_connect.driver.native import NativeTransform
-from clickhouse_connect.driver.query import QueryResult, DataResult, QueryContext, finalize_query
+from clickhouse_connect.driver.query import QueryResult, DataResult, QueryContext, finalize_query, quote_identifier
 from clickhouse_connect.driver.rowbinary import RowBinaryTransform
 
 logger = logging.getLogger(__name__)
@@ -183,12 +183,24 @@ class HttpClient(Client):
         """
         See BaseClient doc_string for this method
         """
-        headers = {'Content-Type': 'application/octet-stream'}
-        params = {'query': f"INSERT INTO {table} ({', '.join(column_names)}) FORMAT {self.write_format}",
-                  'database': self.database}
-        params.update(self._validate_settings(settings, True))
         insert_block = self.transform.build_insert(data, column_types=column_types, column_names=column_names,
                                                    column_oriented=column_oriented)
+        self.raw_insert(table, column_names, insert_block, settings, self.write_format)
+
+    def raw_insert(self, table: str,
+                   column_names: Sequence[str],
+                   insert_block: bytes,
+                   settings: Optional[Dict] = None,
+                   fmt: Optional[str] = None):
+        """
+        See BaseClient doc_string for this method
+        """
+        column_ids = [quote_identifier(x) for x in column_names]
+        write_format = fmt if fmt else self.write_format
+        headers = {'Content-Type': 'application/octet-stream'}
+        params = {'query': f"INSERT INTO {table} ({', '.join(column_ids)}) FORMAT {write_format}",
+                  'database': self.database}
+        params.update(self._validate_settings(settings, True))
         response = self._raw_request(insert_block, params, headers)
         logger.debug('Insert response code: %d, content: %s', response.status_code, response.content)
 

--- a/clickhouse_connect/driver/query.py
+++ b/clickhouse_connect/driver/query.py
@@ -167,15 +167,20 @@ local_tz = datetime.now().astimezone().tzinfo
 BS = '\\'
 must_escape = (BS, '\'')
 
+
 def quote_identifier(identifier: str):
-    if identifier.startswith('`'):
+    first_char = identifier[0]
+    if first_char in ('`', '"') and identifier[-1] == first_char:
+        # Identifier is already quoted, assume that it's valid
         return identifier
     return f'`{identifier}`'
+
 
 def finalize_query(query: str, parameters: Optional[Dict[str, Any]], server_tz: Optional[tzinfo] = None) -> str:
     if not parameters:
         return query
     return query % {k: format_query_value(v, server_tz) for k, v in parameters.items()}
+
 
 # pylint: disable=too-many-return-statements
 def format_query_value(value: Any, server_tz: tzinfo = pytz.UTC):

--- a/setup.py
+++ b/setup.py
@@ -27,7 +27,7 @@ def run_setup(try_c: bool = True):
     with open(os.path.join(project_dir, 'README.md'), encoding='utf-8') as read_me:
         long_desc = read_me.read()
 
-    version = 'developer'
+    version = os.environ.get('CLICKHOUSE_CONNECT_BUILD_VERSION', 'developer_only')
 
     setup(
         name='clickhouse-connect',

--- a/setup.py
+++ b/setup.py
@@ -27,7 +27,7 @@ def run_setup(try_c: bool = True):
     with open(os.path.join(project_dir, 'README.md'), encoding='utf-8') as read_me:
         long_desc = read_me.read()
 
-    version = 'developer_only'
+    version = 'developer'
 
     setup(
         name='clickhouse-connect',

--- a/tests/integration_tests/test_client.py
+++ b/tests/integration_tests/test_client.py
@@ -32,6 +32,23 @@ def test_insert(test_client: Client, test_table_engine: str):
     test_client.insert(table='test_system_insert', column_names='*', data=tables_result.result_set)
 
 
+def test_raw_insert(test_client: Client, test_table_engine: str):
+    test_client.command('DROP TABLE IF EXISTS test_raw_insert')
+    test_client.command(f"CREATE TABLE test_raw_insert (`weir'd` String, value String) Engine {test_table_engine}" +
+                        " ORDER BY `weir'd`")
+    csv = 'value1\nvalue2'
+    test_client.raw_insert('test_raw_insert', ['"weir\'d"'], csv.encode(), fmt='CSV')
+    result = test_client.query('SELECT * FROM test_raw_insert')
+    assert result.result_set[1][0] == 'value2'
+
+    test_client.command('TRUNCATE TABLE test_raw_insert')
+    tsv = 'weird1\tvalue__`2\nweird2\tvalue77'
+    test_client.raw_insert('test_raw_insert', ["`weir'd`", 'value'], tsv, fmt='TSV')
+    result = test_client.query('SELECT * FROM test_raw_insert')
+    assert result.result_set[0][1] == 'value__`2'
+    assert result.result_set[1][1] == 'value77'
+
+
 def test_decimal_conv(test_client: Client, test_table_engine: str):
     test_client.command('DROP TABLE IF EXISTS test_num_conv')
     test_client.command('CREATE TABLE test_num_conv (col1 UInt64, col2 Int32, f1 Float64)' +

--- a/tests/integration_tests/test_data_libraries.py
+++ b/tests/integration_tests/test_data_libraries.py
@@ -4,16 +4,24 @@ from clickhouse_connect.driver import Client
 from clickhouse_connect.driver.options import HAS_NUMPY, HAS_PANDAS, HAS_ARROW
 
 
-def test_arrow(test_client: Client):
+def test_arrow(test_client: Client, test_table_engine: str):
     if not HAS_ARROW:
         pytest.skip('PyArrow package not available')
-    arrow_table = test_client.query_arrow('SELECT database, name, total_rows FROM system.tables', use_strings=False)
+    arrow_table = test_client.query_arrow('SELECT database, name, total_rows as total_rows FROM system.tables',
+                                          use_strings=False)
     arrow_schema = arrow_table.schema
     assert arrow_schema.field(0).name == 'database'
     assert arrow_schema.field(1).type.id == 14
     assert arrow_schema.field(2).type.bit_width == 64
     assert arrow_table.num_rows > 20
     assert len(arrow_table.columns) == 3
+
+    test_client.command('DROP TABLE IF EXISTS test_arrow_insert')
+    test_client.command('CREATE TABLE test_arrow_insert (database String, name String, total_rows Nullable(UInt64))' +
+                        f'ENGINE {test_table_engine} ORDER BY (database, name)')
+    test_client.insert_arrow('test_arrow_insert', arrow_table)
+    sum_total_rows = test_client.command('SELECT sum(total_rows) from test_arrow_insert')
+    assert sum_total_rows > 5
     arrow_table = test_client.query_arrow('SELECT number from system.numbers LIMIT 500',
                                           settings={'max_block_size': 50})
     arrow_schema = arrow_table.schema

--- a/tests/test_requirements.txt
+++ b/tests/test_requirements.txt
@@ -1,3 +1,5 @@
+requests
+pytz
 werkzeug==2.0.3
 sqlalchemy>1.3.21,<1.4
 apache_superset>=1.4.1


### PR DESCRIPTION
-- Always backtick quote identifiers in SQLAlchemy and client insert statements
-- Clean up push workflow to not require pip install -e (this makes tests and lint checking possible without setting an explicit version in setup.py, which we only do on release
-- Minor refactoring for inserts to cleanly support direct inserts of arrow tables