### PR TITLE
Append unixtime millis to the test db name when using Cloud

### DIFF
--- a/.github/workflows/on_push.yml
+++ b/.github/workflows/on_push.yml
@@ -3,9 +3,9 @@ name: 'Lint and Test'
 on:
   push:
     branches-ignore:
-      - '*test*'
-      - '*dev*'
-      - '*build*'
+      - '_test*'
+      - '_dev*'
+      - '_build*'
     paths-ignore:
       - 'README.md'
       - 'CHANGELOG.md'

--- a/.github/workflows/on_push.yml
+++ b/.github/workflows/on_push.yml
@@ -3,9 +3,9 @@ name: 'Lint and Test'
 on:
   push:
     branches-ignore:
-      - '_test*'
-      - '_dev*'
-      - '_build*'
+      - '*_test'
+      - '*_dev'
+      - '*_build'
     paths-ignore:
       - 'README.md'
       - 'CHANGELOG.md'

--- a/tests/integration_tests/conftest.py
+++ b/tests/integration_tests/conftest.py
@@ -50,7 +50,7 @@ def test_config_fixture(request) -> Iterator[TestConfig]:
     elif use_docker:
         test_database = 'ch_connect_test'
     else:
-        test_database = f'ch_connect_{int(time.time())}_{random.randint(100000, 999999)}'
+        test_database = f'ch_connect__{random.randint(100000, 999999)}__{int(time.time() * 1000)}'
     yield TestConfig(interface, host, port, username, password, use_docker, test_database, cleanup, local, cloud)
 
 

--- a/tests/integration_tests/test_sqlalchemy/test_ddl.py
+++ b/tests/integration_tests/test_sqlalchemy/test_ddl.py
@@ -19,7 +19,7 @@ helpers.add_test_entry_points()
 def test_create_database(test_engine: Engine, test_db: str, test_table_engine: str):
     if test_db:
         conn = test_engine.connect()
-        create_db = f'{test_db}_create_db_test'
+        create_db = f'create_db_{test_db}'
         if not test_engine.dialect.has_database(conn, create_db):
             if test_table_engine == 'ReplicatedMergeTree':
                 conn.execute(CreateDatabase(create_db))


### PR DESCRIPTION
Append the unix time in millis at the end of the test DB name to be in line with JS and Go clients for cleanup purposes.