### PR TITLE
Remove forced `enable_http_compression=1` on the HTTP request level

### DIFF
--- a/clickhouse_connect/driver/httpclient.py
+++ b/clickhouse_connect/driver/httpclient.py
@@ -134,7 +134,6 @@ class HttpClient(Client):
             settings['http_headers_progress_interval_ms'] = str(progress_interval)
         if compress:
             session.headers['Accept-Encoding'] = 'gzip'
-            settings['enable_http_compression'] = '1'
         super().__init__(database=database, query_limit=query_limit, uri=self.url)
         self.session.params = self._validate_settings(settings, True)
 


### PR DESCRIPTION
Do not enforce `enable_http_compression=1` setting if `HttpClient(compress)` is set to `True` - it is now required to have it either in the server's `users.xml` or supply it separately on the query level.
