### PR TITLE
Use CaseInsensitiveDict for sqla_type_map

### DIFF
--- a/clickhouse_connect/cc_sqlalchemy/datatypes/base.py
+++ b/clickhouse_connect/cc_sqlalchemy/datatypes/base.py
@@ -115,7 +115,7 @@ class CaseInsensitiveDict(dict):
         return super().__getitem__(item.lower())
 
 
-sqla_type_map: CaseInsensitiveDict[str, Type[ChSqlaType]] = CaseInsensitiveDict()
+sqla_type_map: Dict[str, Type[ChSqlaType]] = CaseInsensitiveDict()
 schema_types = []
 
 

--- a/clickhouse_connect/cc_sqlalchemy/datatypes/base.py
+++ b/clickhouse_connect/cc_sqlalchemy/datatypes/base.py
@@ -107,7 +107,15 @@ class ChSqlaType:
         return self.name
 
 
-sqla_type_map: Dict[str, Type[ChSqlaType]] = {}
+class CaseInsensitiveDict(dict):
+    def __setitem__(self, key, value):
+        super().__setitem__(key.lower(), value)
+
+    def __getitem__(self, item):
+        return super().__getitem__(item.lower())
+
+
+sqla_type_map: CaseInsensitiveDict[str, Type[ChSqlaType]] = CaseInsensitiveDict()
 schema_types = []
 
 


### PR DESCRIPTION
Hi @genzgd
We use ClickHouse in apache/superset. Before `clickhouse-connect` we used `clickhouse-sqlalchemy` driver.
When we migrated to `clickhouse-connect` we noticed that ClickHouse type name is changed from UPPER to Pascal case.
All our superset datasets columns have UPPER case types in superset DB and we have the next error:

> error: "Unrecognized ClickHouse type base: UINT64 name: UINT64"

We need to write a flexible logic to ignore case of type name.
I prepare `CaseInsensitiveDict` class in order to make all item keys lowercase and get it also by lowercase key.
This PR resolves our problem of migrating from `clickhouse-sqlalchemy` to `clickhouse-connect`