### PR TITLE
Fix QueryResult "with" statement context

### DIFF
--- a/clickhouse_connect/driver/query.py
+++ b/clickhouse_connect/driver/query.py
@@ -240,6 +240,7 @@ class QueryResult:
 
     def __enter__(self):
         self._in_context = True
+        return self
 
     def __exit__(self, exc_type, exc_val, exc_tb):
         self.close()

--- a/tests/unit_tests/test_driver/test_query.py
+++ b/tests/unit_tests/test_driver/test_query.py
@@ -1,4 +1,13 @@
 from clickhouse_connect.driver.query import QueryContext
+from clickhouse_connect.driver.query import QueryResult
+
+
+def test_query_result_context():
+    """
+    Verify that the "with" statements work with QueryResult
+    """
+    with QueryResult() as query_result:
+        assert isinstance(query_result, QueryResult)
 
 
 def test_copy_context():


### PR DESCRIPTION
# Problem:

"with" statement with `QueryResult` is currently broken. You can reproduce the issue with this:

```python
from clickhouse_connect.driver.query import QueryResult
with QueryResult() as query_result:
     print('query_result =', query_result)
```

results in:

```text
query_result = None
```

`query_result` should not be `None` here. It breaks "with" context for queries (which is the recommended way now). The problem is that [clickhouse_connect.driver.query.QueryResult.__enter__](https://github.com/ClickHouse/clickhouse-connect/blob/097415b998133db143ae63fc541a7e506e6ff357/clickhouse_connect/driver/query.py#L241) does not return anything. So from the documentation, the [query streaming example](https://clickhouse.com/docs/en/integrations/language-clients/python/advanced#query-streaming) simply does not work. You get an: `AttributeError: 'NoneType' object has no attribute 'stream_row_blocks'`.

# Solution:

The value returned by `__enter__` is what the "as" variable is set to in a "with" clause. [It is actually why van Rossum went with `as` instead of `=` for the with statement](https://peps.python.org/pep-0343/#motivation-and-summary).

The `clickhouse_connect.driver.query.QueryResult.__enter__` just needs to return self for with statements to work as intended. I have also added a very simple unit test to make sure this doesn't end up in a production release again.
