### PR TITLE
Fix thread safety in http pool manager

### DIFF
--- a/clickhouse_connect/driver/httpclient.py
+++ b/clickhouse_connect/driver/httpclient.py
@@ -20,7 +20,7 @@ from clickhouse_connect.driver.client import Client
 from clickhouse_connect.driver.common import dict_copy, coerce_bool, coerce_int
 from clickhouse_connect.driver.compression import available_compression
 from clickhouse_connect.driver.exceptions import DatabaseError, OperationalError, ProgrammingError
-from clickhouse_connect.driver.httputil import ResponseSource, get_pool_manager, get_response_data, default_pool_manager
+from clickhouse_connect.driver.httputil import ResponseSource, get_pool_manager, get_response_data
 from clickhouse_connect.driver.insert import InsertContext
 from clickhouse_connect.driver.query import QueryResult, QueryContext, quote_identifier, bind_query
 from clickhouse_connect.driver.transform import NativeTransform
@@ -106,7 +106,7 @@ class HttpClient(Client):
                                              verify=verify,
                                              client_cert_key=client_cert_key)
         if not self.http:
-            self.http = default_pool_manager
+            self.http = get_pool_manager()
 
         if not client_cert and username:
             self.headers['Authorization'] = 'Basic ' + b64encode(f'{username}:{password}'.encode()).decode()

--- a/clickhouse_connect/driver/httpclient.py
+++ b/clickhouse_connect/driver/httpclient.py
@@ -3,6 +3,7 @@ import logging
 import platform
 import re
 import uuid
+import threading
 from base64 import b64encode
 from http.client import RemoteDisconnected
 from typing import Optional, Dict, Any, Sequence, Union, List, Callable, Generator, BinaryIO
@@ -134,7 +135,7 @@ class HttpClient(Client):
         if session_id:
             ch_settings['session_id'] = session_id
         elif 'session_id' not in ch_settings and common.get_setting('autogenerate_session_id'):
-            ch_settings['session_id'] = str(uuid.uuid1())
+            ch_settings['session_id'] = str(uuid.uuid4())
 
         if coerce_bool(compress):
             compression = ','.join(available_compression)

--- a/clickhouse_connect/driver/httputil.py
+++ b/clickhouse_connect/driver/httputil.py
@@ -72,10 +72,6 @@ def get_response_data(response: HTTPResponse) -> bytes:
         return lz4_decom.decompress(response.data, len(response.data))
     return response.data
 
-
-default_pool_manager = get_pool_manager()
-
-
 class ResponseSource:
     def __init__(self, response: HTTPResponse, chunk_size: int = 1024 * 1024):
         self.response = response


### PR DESCRIPTION
# Problem 

There is a thread safety issue in the way the HttpClient initializes. Here is a snippet to trigger it:

```python
import multiprocessing

import clickhouse_connect


def get_client() -> clickhouse_connect.driver.client.Client:
    return clickhouse_connect.get_client(host='localhost')


def test_client(*_):
    client = get_client()
    client.command('SELECT version();')
    client.close()


def test_concurrency():
    # Call test client in original thread, before creating new
    # process. This ensures that any globals that may be initialized
    # in the library are initialized before forking next
    test_client()

    # Fork 8 processes, each initializing a fresh client. Any globals
    # from this process that end up being used in child processes may
    # very well become broken.
    with multiprocessing.Pool(8) as pool:
        pool.map(test_client, range(100))


if __name__ == '__main__':
    test_concurrency()
```

1. We initialize a client in the parent process, make a request for the version and close the client
2. We fork 8 times, and run the same version request _all with fresh clients that are closed at the end_

This gives us this lovely error:

```
Traceback (most recent call last):
  File "/home/jc/vola/git/experimental/data1backup/tests/clickhouse-connect/clickhouse_connect/driver/httpclient.py", line 322, in _raw_request
    response: HTTPResponse = self.http.request(method, url,
  File "/opt/conda/envs/py310_64/lib/python3.10/site-packages/urllib3/request.py", line 78, in request
    return self.request_encode_body(
  File "/opt/conda/envs/py310_64/lib/python3.10/site-packages/urllib3/request.py", line 170, in request_encode_body
    return self.urlopen(method, url, **extra_kw)
  File "/opt/conda/envs/py310_64/lib/python3.10/site-packages/urllib3/poolmanager.py", line 376, in urlopen
    response = conn.urlopen(method, u.request_uri, **kw)
  File "/opt/conda/envs/py310_64/lib/python3.10/site-packages/urllib3/connectionpool.py", line 785, in urlopen
    retries = retries.increment(
  File "/opt/conda/envs/py310_64/lib/python3.10/site-packages/urllib3/util/retry.py", line 550, in increment
    raise six.reraise(type(error), error, _stacktrace)
  File "/opt/conda/envs/py310_64/lib/python3.10/site-packages/urllib3/packages/six.py", line 769, in reraise
    raise value.with_traceback(tb)
  File "/opt/conda/envs/py310_64/lib/python3.10/site-packages/urllib3/connectionpool.py", line 703, in urlopen
    httplib_response = self._make_request(
  File "/opt/conda/envs/py310_64/lib/python3.10/site-packages/urllib3/connectionpool.py", line 449, in _make_request
    six.raise_from(e, None)
  File "<string>", line 3, in raise_from
  File "/opt/conda/envs/py310_64/lib/python3.10/site-packages/urllib3/connectionpool.py", line 444, in _make_request
    httplib_response = conn.getresponse()
  File "/opt/conda/envs/py310_64/lib/python3.10/http/client.py", line 1374, in getresponse
    response.begin()
  File "/opt/conda/envs/py310_64/lib/python3.10/http/client.py", line 318, in begin
    version, status, reason = self._read_status()
  File "/opt/conda/envs/py310_64/lib/python3.10/http/client.py", line 300, in _read_status
    raise BadStatusLine(line)
urllib3.exceptions.ProtocolError: ('Connection aborted.', BadStatusLine('\r\n'))

The above exception was the direct cause of the following exception:

Traceback (most recent call last):
  File "/opt/conda/envs/py310_64/lib/python3.10/multiprocessing/pool.py", line 125, in worker
    result = (True, func(*args, **kwds))
  File "/opt/conda/envs/py310_64/lib/python3.10/multiprocessing/pool.py", line 48, in mapstar
    return list(map(*args))
  File "/home/jc/vola/git/experimental/data1backup/tests/test-concurrency.py", line 11, in test_client
    client = get_client()
  File "/home/jc/vola/git/experimental/data1backup/tests/test-concurrency.py", line 7, in get_client
    return clickhouse_connect.get_client(host='localhost')
  File "/home/jc/vola/git/experimental/data1backup/tests/clickhouse-connect/clickhouse_connect/__init__.py", line 8, in get_client
    return create_client(**kwargs)
  File "/home/jc/vola/git/experimental/data1backup/tests/clickhouse-connect/clickhouse_connect/driver/__init__.py", line 69, in create_client
    return HttpClient(interface, host, port, username, password, database, settings=settings, **kwargs)
  File "/home/jc/vola/git/experimental/data1backup/tests/clickhouse-connect/clickhouse_connect/driver/httpclient.py", line 150, in __init__
    super().__init__(database=database, query_limit=coerce_int(query_limit), uri=self.url)
  File "/home/jc/vola/git/experimental/data1backup/tests/clickhouse-connect/clickhouse_connect/driver/client.py", line 45, in __init__
    tuple(self.command('SELECT version(), timezone(), database()', use_database=False))
  File "/home/jc/vola/git/experimental/data1backup/tests/clickhouse-connect/clickhouse_connect/driver/httpclient.py", line 288, in command
    response = self._raw_request(payload, params, headers, method)
  File "/home/jc/vola/git/experimental/data1backup/tests/clickhouse-connect/clickhouse_connect/driver/httpclient.py", line 341, in _raw_request
    raise OperationalError(f'Error executing HTTP request {self.url}') from ex
clickhouse_connect.driver.exceptions.OperationalError: Error executing HTTP request http://localhost:8123
```

The problem is the global [clickhouse_connect.driver.httputil.default_pool_manager](https://github.com/ClickHouse/clickhouse-connect/blob/b0ba61f17baa73b2619d4088e4ccb1f7d4056f8c/clickhouse_connect/driver/httputil.py#L76), which is used only as the default http pool in [clickhouse_connect.driver.httpclient.HttpClient.__init__](https://github.com/ClickHouse/clickhouse-connect/blob/b0ba61f17baa73b2619d4088e4ccb1f7d4056f8c/clickhouse_connect/driver/httpclient.py#L109)

When this global is initialized in one process, then referenced in another it completely breaks any attempt at concurrency.

# Solution

Remove the [clickhouse_connect.driver.httputil.default_pool_manager](https://github.com/ClickHouse/clickhouse-connect/blob/b0ba61f17baa73b2619d4088e4ccb1f7d4056f8c/clickhouse_connect/driver/httputil.py#L76) global, and initialize a new pool manager on each new HttpClient.

Unless there is some huge perfomance cost to initializing new pool managers that I am unaware of, this should be the way it is done.


