### PR TITLE
Return empty df instead of list

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,12 @@ Using QueryResult as a context is unintuitive, and that usage pattern is depreca
 a future release.  Instead, streaming query results should be obtained using the new Client `*stream` methods described
 under New Features, below.
 
+## 0.5.8, Not yet released
+
+### Bug Fix
+- Return empty dataframe instead of empty list when no records returned from `query_df` method  Fixes
+https://github.com/ClickHouse/clickhouse-connect/issues/118
+
 ## 0.5.7, 2023-02-01
 
 ### Bug Fix

--- a/clickhouse_connect/driver/npquery.py
+++ b/clickhouse_connect/driver/npquery.py
@@ -99,7 +99,7 @@ class NumpyResult(Closable):
         elif len(pieces) == 1:
             self._df_result = pieces[0]
         else:
-            self._df_result = []
+            self._df_result = pd.DataFrame()
         self.close()
         return self
 

--- a/tests/integration_tests/test_pandas.py
+++ b/tests/integration_tests/test_pandas.py
@@ -27,6 +27,7 @@ def test_pandas_basic(test_client: Client, test_table_engine: str):
     assert df.equals(source_df)
     df = test_client.query_df("SELECT * FROM system.tables WHERE engine = 'not_a_thing'")
     assert len(df) == 0
+    assert isinstance(df, pd.DataFrame)
 
 
 def test_pandas_nulls(test_client: Client, table_context: Callable):


### PR DESCRIPTION
## Summary
Return empty dataframe instead of list for query_df result with no records.  https://github.com/ClickHouse/clickhouse-connect/issues/118

## Checklist
Delete items not relevant to your PR:
- [X] Unit and integration tests covering the common scenarios were added
- [X] A human-readable description of the changes was provided to include in CHANGELOG

