### PR TITLE
Better error message for invalid numpy DateTime64 types

### DIFF
--- a/clickhouse_connect/datatypes/temporal.py
+++ b/clickhouse_connect/datatypes/temporal.py
@@ -5,6 +5,7 @@ from typing import Union, Sequence, MutableSequence
 
 from clickhouse_connect.datatypes.base import TypeDef, ClickHouseType
 from clickhouse_connect.driver.common import write_array, np_date_types, int_size
+from clickhouse_connect.driver.exceptions import ProgrammingError
 from clickhouse_connect.driver.ctypes import data_conv, numpy_conv
 from clickhouse_connect.driver.insert import InsertContext
 from clickhouse_connect.driver.query import QueryContext
@@ -131,7 +132,10 @@ class DateTime64(ClickHouseType):
     @property
     def np_type(self):
         opt = np_date_types.get(self.scale)
-        return f'datetime64{opt}' if opt else 'O'
+        if opt:
+            return f'datetime64{opt}'
+        raise ProgrammingError(f'Cannot use {self.name} as a numpy or Pandas datatype.  Only milliseconds(3),' +
+                               'microseconds(6) or nanoseconds(9) are supported for numpy based queries.')
 
     @property
     def nano_divisor(self):

--- a/tests/integration_tests/test_numpy.py
+++ b/tests/integration_tests/test_numpy.py
@@ -5,6 +5,7 @@ import random
 from typing import Callable
 
 import pytest
+from clickhouse_connect.driver.exceptions import ProgrammingError
 
 from clickhouse_connect.driver import Client
 from clickhouse_connect.driver.options import np
@@ -25,6 +26,13 @@ def test_numpy_dates(test_client: Client, table_context: Callable):
         new_np_array = test_client.query_np('SELECT * FROM test_numpy_dates')
         assert np.array_equal(np_array, new_np_array)
         assert np.array_equal(source_arr, np_array)
+
+
+def test_invalid_date(test_client):
+    try:
+        test_client.query_df("SELECT cast(now64(), 'DateTime64(1)')")
+    except ProgrammingError as ex:
+        assert 'milliseconds' in str(ex)
 
 
 def test_numpy_record_type(test_client: Client, table_context: Callable):


### PR DESCRIPTION
## Summary
Improve error message for invalid numpy/Pandas DateTime64 types.  https://github.com/ClickHouse/clickhouse-connect/issues/126

## Checklist
Delete items not relevant to your PR:
- [x] Unit and integration tests covering the common scenarios were added
