### PR TITLE
Added column_oriented check to the named_results function

### DIFF
--- a/clickhouse_connect/driver/query.py
+++ b/clickhouse_connect/driver/query.py
@@ -266,7 +266,7 @@ class QueryResult(Closable):
         return StreamContext(self, stream())
 
     def named_results(self) -> Generator[dict, None, None]:
-        for row in zip(*self.result_columns):
+        for row in zip(*self.result_set) if self.column_oriented else self.result_set:
             yield dict(zip(self.column_names, row))
 
     @property

--- a/tests/integration_tests/test_client.py
+++ b/tests/integration_tests/test_client.py
@@ -23,6 +23,8 @@ def test_ping(test_client: Client):
 def test_query(test_client: Client):
     result = test_client.query('SELECT * FROM system.tables')
     assert len(result.result_set) > 0
+    assert result.row_count > 0
+    assert result.first_item == next(result.named_results())
 
 
 def test_command(test_client: Client):


### PR DESCRIPTION
## Summary
Fixed `StreamClosedError` when trying to execute `QueryResult.named_results()` after `QueryResult.row_count`

```python
result = client.query('SELECT * FROM system.tables')
print(result.row_count)
print(list(result.named_results()))  # StreamClosedError
```


## Checklist
Delete items not relevant to your PR:
- [x] Unit and integration tests covering the common scenarios were added