### PR TITLE
fix key error in connection with no available settings from server

### DIFF
--- a/clickhouse_connect/driver/client.py
+++ b/clickhouse_connect/driver/client.py
@@ -93,7 +93,7 @@ class Client(ABC):
         return str(value)
 
     def _setting_status(self, key: str) -> SettingStatus:
-        comp_setting = self.server_settings[key]
+        comp_setting = self.server_settings.get(key)
         if not comp_setting:
             return SettingStatus(False, False)
         return SettingStatus(comp_setting != '0', comp_setting.readonly != 1)


### PR DESCRIPTION
## Summary
If connection settings aren't available/exposed, any connection fails after initial settings select
```sql
SELECT name, value, readonly as readonly FROM system.settings
```

![image](https://user-images.githubusercontent.com/54457590/224709412-7e8656da-eeaf-4b5b-b183-250ec630241f.png)


## Checklist
not relevant