### PR TITLE
Fixes #159 - quoting and escaping string literals inside lists

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,10 @@ in a future release.  Starting with 0.5.9 the driver now requests ClickHouse pro
 The secondary effect of the `send_progress` argument -- to set `wait_end_of_query=1` -- is now handled automatically based
 on whether the query is streaming or not.
 
+## [next release]
+### Fix quoting and escaping of array literals in server parameters
+See [#159](https://github.com/ClickHouse/clickhouse-connect/issues/159)
+
 ## 0.5.18, 2023-03-30
 ### Performance Improvement
 - The server timezone will not be applied (and Python datetime types will be timezone naive) if the client and server timezones match

--- a/tests/unit_tests/test_driver/test_parameters.py
+++ b/tests/unit_tests/test_driver/test_parameters.py
@@ -1,6 +1,8 @@
 from datetime import datetime
 
-from clickhouse_connect.driver.query import finalize_query
+import pytest
+
+from clickhouse_connect.driver.query import finalize_query, format_bind_value
 
 
 def test_finalize():
@@ -14,3 +16,19 @@ def test_finalize():
     parameters = [hash_id, timestamp]
     query = finalize_query('SELECT hash_id FROM db.mytable WHERE hash_id = %s AND dt = %s', parameters)
     assert query == expected
+
+
+@pytest.mark.parametrize("value, expected", [
+    ("a", "a"),
+    ("a'", r"a\'"),
+    ("'a'", r"\'a\'"),
+    ("''a'", r"\'\'a\'"),
+    ([], "[]"),
+    ([1], "[1]"),
+    (["a"], "['a']"),
+    (["a'"], r"['a\'']"),
+    ([["a"]], "[['a']]"),
+
+])
+def test_format_bind_value(value, expected):
+    assert format_bind_value(value) == expected


### PR DESCRIPTION
## Summary
Fixes #159 - quoting and escaping string literals inside lists

## Note

The PR could be completed with more tests (e.g. tuples, dicts, etc) and more scoped tests (e.g. unit testing `format_str` and `escape_str` themselves). Feel free to take over the PR and do it.

## Checklist
Delete items not relevant to your PR:
- [x] Unit and integration tests covering the common scenarios were added
- [x] A human-readable description of the changes was provided to include in CHANGELOG
