### PR TITLE
Optional max_error_chars parameter added to HTTP Client class 

### DIFF
--- a/clickhouse_connect/common.py
+++ b/clickhouse_connect/common.py
@@ -66,3 +66,5 @@ _init_common('readonly', (0, 1), 0)  # Implied "read_only" ClickHouse settings f
 # Use the client protocol version  This is needed for DateTime timezone columns but breaks with current version of
 # chproxy
 _init_common('use_protocol_version', (True, False), True)
+
+_init_common('max_error_size', (), 240)

--- a/clickhouse_connect/driver/httpclient.py
+++ b/clickhouse_connect/driver/httpclient.py
@@ -66,7 +66,6 @@ class HttpClient(Client):
                  http_proxy: Optional[str] = None,
                  https_proxy: Optional[str] = None,
                  server_host_name: Optional[str] = None,
-                 max_error_chars: Optional[int] = 240,
                  apply_server_timezone: Optional[Union[str, bool]] = True):
         """
         Create an HTTP ClickHouse Connect client
@@ -120,7 +119,6 @@ class HttpClient(Client):
         self._send_comp_setting = False
         self._progress_interval = None
         self._active_session = None
-        self.max_error_chars = max_error_chars
 
         if session_id:
             ch_settings['session_id'] = session_id
@@ -327,11 +325,14 @@ class HttpClient(Client):
     def _error_handler(self, response: HTTPResponse, retried: bool = False) -> None:
         err_str = f'HTTPDriver for {self.url} returned response code {response.status})'
         err_content = get_response_data(response)
-        max_error_size = self.max_error_chars
+        max_error_size = common.get_setting('max_error_size')
         if err_content:
             err_msg = err_content.decode(errors='backslashreplace')
             logger.error(err_msg)
+        if max_error_size > 0:
             err_str = f':{err_str}\n {err_msg[0:max_error_size]}'
+        else:
+            err_str = f':{err_str}\n {err_msg}'
         raise OperationalError(err_str) if retried else DatabaseError(err_str) from None
 
     def _raw_request(self,


### PR DESCRIPTION
## Summary
An optional parameter added to HTTP Client class to allow user to decide how long they want the database error messages to be when returned. Fixes this [issue](https://github.com/ClickHouse/clickhouse-connect/issues/198)

## Checklist
Delete items not relevant to your PR:
- [x] A human-readable description of the changes was provided to include in CHANGELOG