### PR TITLE
refactor: pkg_resources -> importlib.metadata

### DIFF
--- a/clickhouse_connect/common.py
+++ b/clickhouse_connect/common.py
@@ -2,15 +2,15 @@ import sys
 from dataclasses import dataclass
 from typing import Any, Sequence, Optional, Dict
 
-import pkg_resources
+from importlib_metadata import PackageNotFoundError, distribution
 
 from clickhouse_connect.driver.exceptions import ProgrammingError
 
 
 def version():
     try:
-        return pkg_resources.get_distribution('clickhouse-connect').version
-    except pkg_resources.ResolutionError:
+        return distribution('clickhouse-connect').version
+    except PackageNotFoundError:
         return 'development'
 
 

--- a/clickhouse_connect/entry_points.py
+++ b/clickhouse_connect/entry_points.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python3
 
 import sys
-import pkg_resources
+from importlib_metadata import PackageNotFoundError, distribution
 
 EXPECTED_EPS = {'sqlalchemy.dialects:clickhousedb',
                 'sqlalchemy.dialects:clickhousedb.connect'}
@@ -10,8 +10,8 @@ EXPECTED_EPS = {'sqlalchemy.dialects:clickhousedb',
 def validate_entrypoints():
     expected_eps = EXPECTED_EPS.copy()
     try:
-        dist = pkg_resources.get_distribution('clickhouse-connect')
-    except pkg_resources.DistributionNotFound:
+        dist = distribution('clickhouse-connect')
+    except PackageNotFoundError:
         print ('\nClickHouse Connect package not found in this Python installation')
         return -1
     entry_map = dist.get_entry_map()

--- a/setup.py
+++ b/setup.py
@@ -49,6 +49,7 @@ def run_setup(try_c: bool = True):
         license='Apache License 2.0',
         install_requires=[
             'certifi',
+            'importlib_metadata',
             'urllib3>=1.26',
             'pytz',
             'zstandard',


### PR DESCRIPTION
pkg_resources is in the process of being deprecated in favor of
importlib.metadata and importlib.resources

importlib.metadata has been available in the standard library since 3.8

And as of 3.10 the importlib.metadata API is no longer provisional

In order to support Python version older than 3.10, the
importlib_metadata backport is used instead of the actual
importlib.metadata API.

(NOTE: There was no explicit install_require entry that needed removing
in setup.py for the setuptools package which provides the pkg_resources
module. It seems that it was merely assumed that setuptools is always
present, which is actually not the case.)
