### PR TITLE
fix: Empty nests raising out of IndexError.

### DIFF
--- a/clickhouse_connect/datatypes/container.py
+++ b/clickhouse_connect/datatypes/container.py
@@ -180,7 +180,7 @@ class Map(ClickHouseType):
     # pylint: disable=too-many-locals
     def read_column_data(self, source: ByteSource, num_rows: int, ctx: QueryContext):
         offsets = source.read_array('Q', num_rows)
-        total_rows = offsets[-1]
+        total_rows = 0 if len(offset) == 0 else offsets[-1]
         keys = self.key_type.read_column_data(source, total_rows, ctx)
         values = self.value_type.read_column_data(source, total_rows, ctx)
         all_pairs = tuple(zip(keys, values))


### PR DESCRIPTION
## Summary
Fixes this bug: https://github.com/ClickHouse/clickhouse-connect/issues/239

When you have an empty map that has a type of nests maps, and IndexError is raise; this fixes that issue. 

Example: 
```python
client.query("select Cast(([],[]), 'Map(String, Map(String, String))')")
```

## Checklist
Delete items not relevant to your PR:
- [ ] Unit and integration tests covering the common scenarios were added
- [x] A human-readable description of the changes was provided to include in CHANGELOG

