### PR TITLE
Add py.typed file (PEP 561)

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -50,7 +50,7 @@ def run_setup(try_c: bool = True):
         version=version,
         long_description=long_desc,
         long_description_content_type='text/markdown',
-        package_data={'clickhouse_connect': ['VERSION']},
+        package_data={'clickhouse_connect': ['VERSION', 'py.typed']},
         url='https://github.com/ClickHouse/clickhouse-connect',
         packages=find_packages(exclude=['tests*']),
         python_requires='~=3.7',


### PR DESCRIPTION
## Summary
PEP 561 introduced the idea of a "py.typed" file that when present,
denotes a package as having type hints. Including this file into
ClickHouse-Connect means that users of it can use the type hints
provided and statically analyse their own code.

PEP 561 source:
https://peps.python.org/pep-0561/#packaging-type-information

I tested this with the following:
```
$ python3.11 -m build | grep py.typed
...
copying clickhouse_connect/py.typed -> clickhouse-connect-0.6.12/clickhouse_connect
copying clickhouse_connect/py.typed -> build/lib.macosx-12-arm64-cpython-311/clickhouse_connect
...
copying build/lib.macosx-12-arm64-cpython-311/clickhouse_connect/py.typed -> build/bdist.macosx-12-arm64/wheel/clickhouse_connect
adding 'clickhouse_connect/py.typed'
$ tar tzf dist/clickhouse-connect-0.6.12.tar.gz | grep 'typed'
clickhouse-connect-0.6.12/clickhouse_connect/py.typed
```

In another virtual environment, confirmed that the installed package now
has `py.typed` present.

Before this change:
```
$ mypy -c 'from clickhouse_connect import get_client;get_client()'
<string>:1: error: Skipping analyzing "clickhouse_connect": module is installed, but missing library stubs or py.typed marker  [import]
```

After this change
```
$ mypy -c 'from clickhouse_connect import get_client;get_client()'
Success: no issues found in 1 source file
```

Resolves #226 

## Checklist
Delete items not relevant to your PR:
- [x] A human-readable description of the changes was provided to include in CHANGELOG
