### PR TITLE
Alias get_client directly instead of via a function

### DIFF
--- a/clickhouse_connect/__init__.py
+++ b/clickhouse_connect/__init__.py
@@ -3,6 +3,4 @@ from clickhouse_connect.driver import create_client
 
 driver_name = 'clickhousedb'
 
-
-def get_client(**kwargs):
-    return create_client(**kwargs)
+get_client = create_client

--- a/clickhouse_connect/driver/__init__.py
+++ b/clickhouse_connect/driver/__init__.py
@@ -10,7 +10,8 @@ from clickhouse_connect.driver.httpclient import HttpClient
 
 
 # pylint: disable=too-many-arguments,too-many-locals,too-many-branches
-def create_client(host: str = None,
+def create_client(*,
+                  host: str = None,
                   username: str = None,
                   password: str = '',
                   database: str = '__default__',


### PR DESCRIPTION

## Summary

`get_client` is the main entrypoint to getting a Client instance. Currently, it
is merely a wrapper for `create_client`, taking only `**kwargs`. Due to the
wrapping and use of `**kwargs`, all type hints are lost.

To improve the situation without breaking existing code, `get_client` is
redefined as a simple alias of `create_client`. Additionally, `create_client` is
altered to force the use of keyword arguments according to the PEP 3102 [0]
asterisk. This combination of changes improves the usability of the `get_client`
function while preserving all existing functionality.

[0] - https://peps.python.org/pep-3102/

## Checklist
Delete items not relevant to your PR:
- [x] Unit and integration tests covering the common scenarios were ~added~ already included
- [x] A human-readable description of the changes was provided to include in CHANGELOG

