### PR TITLE
Add missing Nothing datatype for SQLAlchemy

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,10 @@ In any case, this should not affect the basic usage of Superset with ClickHouse.
 your Superset installation, the ClickHouse datasource will be available with either the enhanced connection dialog
 or a standard SqlAlchemy DSN in the form of `clickhousedb://{username}:{password}@{host}:{port}`.
 
+## 0.6.23, 2023-12-15
+### Bug Fix
+- Add missing Nothing SQLAlchemy datatype
+
 ## 0.6.22, 2023-12-01
 ### Improvements
 - Fix typo in log message for bad inserts.  Thanks to [Stas](https://github.com/reijnnn) for the fix.

--- a/clickhouse_connect/cc_sqlalchemy/datatypes/sqltypes.py
+++ b/clickhouse_connect/cc_sqlalchemy/datatypes/sqltypes.py
@@ -198,6 +198,10 @@ class UUID(ChSqlaType, UserDefinedType):
     python_type = None
 
 
+class Nothing(ChSqlaType, UserDefinedType):
+    python_type = None
+
+
 class Point(ChSqlaType, UserDefinedType):
     python_type = None
 


### PR DESCRIPTION
## Summary
Fixes https://github.com/ClickHouse/clickhouse-connect/issues/278 by adding Nothing datatype for SQLAlchemy

## Checklist
Delete items not relevant to your PR:
- [ ] Unit and integration tests covering the common scenarios were added
- [x] A human-readable description of the changes was provided to include in CHANGELOG
- [ ] For significant changes, documentation in https://github.com/ClickHouse/clickhouse-docs was updated with further explanations or tutorials
