### PR TITLE
Fix Pandas Concatenation Warning

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -128,12 +128,12 @@ on importlib_metadata.
 
 ### Improvement
 - Add compression parameter to the clickhouse `tools.insert_file` method.  '.gz' and '.gzip' extensions are automatically
-recognized.
+recognized.  
 
 ## 0.6.7, 2023-07-18
 ### Bug Fixes
 - Fixed an issue for older versions of ClickHouse where the server would send an initial block of 0 rows for larger queries.
-This would break some queries with LowCardinality columns.  Closes https://github.com/ClickHouse/clickhouse-connect/issues/221
+This would break some queries with LowCardinality columns.  Closes https://github.com/ClickHouse/clickhouse-connect/issues/221 
 - Fixed the`compression` alias for the `compress` client setting in SQLAlchemy/Superset DSN urls.
 
 ### Improvements
@@ -256,7 +256,7 @@ can help with certain load balancing issues.  It defaults to 10 minutes
 in the case of many small inserts.  It can still be added using the `settings` dictionary of the client `*insert` methods if needed for some reason.
 - The query setting `use_na_values` has been renamed to `use_extended_dtypes` and now applies to all extended/special Pandas dtypes (except the Pandas Timestamp type).
 Set this to `False` to limit  the dtypes returned in Pandas dataframes to the "basic" numpy types.  (Note that this will force the use of numpy object arrays
-for most "nullable types")  This should allow creating "basic" dataframes for greater compatibility. Closes https://github.com/ClickHouse/clickhouse-connect/issues/172.
+for most "nullable types")  This should allow creating "basic" dataframes for greater compatibility. Closes https://github.com/ClickHouse/clickhouse-connect/issues/172.  
 
 ## 0.5.20, 2023-04-06
 ### Bug Fixes
@@ -386,7 +386,7 @@ raise a StreamClosedError.  Thanks to [Stas](https://github.com/reijnnn) for the
 - A better error message is returned when trying to read a "non-standard" DateTime64 column function for a numpy array
 or Pandas DataFrame.  "non-standard" means a DateTime64 precision not conforming to seconds, milliseconds, microseconds,
 or nanoseconds (0, 3, 6, or 9 respectively).  These DateTime64 types are not supported for numpy or Pandas because there is
-no corresponding standard numpy datetime64 type and conversion would be unacceptably slow (supported numpy types are
+no corresponding standard numpy datetime64 type and conversion would be unacceptably slow (supported numpy types are 
 `datetime64[s]`, `datetime64[ms]`, `datetime64[us]`, and `datetime64[ns]`).  A workaround is to cast the DateTime64 type
 to a supported type, i.e. `SELECT toDateTime64(col_name, 3)` for a millisecond column.
 - The base configuration required for a urllib PoolManager has been broken out into its own help method,
@@ -534,7 +534,7 @@ Dependency Changes below).  Instead, the HttpClient constructor now accepts an o
 can be used to set a custom `urllib.poolmanager.PoolManager` for the client.  In most cases the default PoolManager is
 all that is needed, but multiple PoolManagers may be required for advanced server/proxy applications with many client instances.
 
-### Dependency Changes
+### Dependency Changes 
 * ClickHouse Connect no longer requires the popular `requests` library.  The `requests` library is built on
 [urllib3](https://pypi.org/project/urllib3/), but ClickHouse Connect was utilizing very little of the added functionality.
 Requests also has very restricted access to the `urllib3` streaming API, which made adding additional compression methods
@@ -549,7 +549,7 @@ is optimized to work with them, so ClickHouse Connect now takes advantages of th
   * `stream_column_blocks` - returns a generator of smaller result sets matching the ClickHouse blocks returned by the native interface.
   * `stream_row_blocks` - returns a generator of smaller result sets matching the ClickHouse blocks returned by the native interface,
 but "pivoted" to return data rows.
-  * `stream_rows` - returns a generator that returns a row of data with each iteration.
+  * `stream_rows` - returns a generator that returns a row of data with each iteration.  
 These methods should be used within a `with` context to ensure the stream is properly closed when done.  In addition, two new properties
 `result_columns` and `result_rows` have been added to `QueryResult`.  Referencing either of these properties will consume the stream
 and return the full dataset.  Note that these properties should be used instead of the ambiguous `result_set`, which returns
@@ -579,9 +579,9 @@ https://github.com/ClickHouse/clickhouse-connect/issues/94. This has been fixed.
 ### New Features
 * [Documentation](https://clickhouse.com/docs/en/integrations/language-clients/python/intro) has been expanded to cover recent updates.
 * File upload support.  The new `driver.tools` module adds the function `insert_file` to simplify
-directly inserting data files into a table.  See the [test file](https://github.com/ClickHouse/clickhouse-connect/blob/main/tests/integration_tests/test_tools.py)
+directly inserting data files into a table.  See the [test file](https://github.com/ClickHouse/clickhouse-connect/blob/main/tests/integration_tests/test_tools.py) 
 for examples.  This closes https://github.com/ClickHouse/clickhouse-connect/issues/41.
-* Added support for server side [http query parameters](https://clickhouse.com/docs/en/interfaces/http/#cli-queries-with-parameters)
+* Added support for server side [http query parameters](https://clickhouse.com/docs/en/interfaces/http/#cli-queries-with-parameters) 
 For queries that contain bindings of the form `{<name>:<datatype>}`, the client will automatically convert the query* method
 `parameters` dictionary to the appropriate http query parameters.  Closes https://github.com/ClickHouse/clickhouse-connect/issues/49.
 * The main `clickhouse_connect.get_client` command will now accept a standard Python `dsn` argument and extract host, port,
@@ -612,7 +612,7 @@ precedence over values extracted from the dsn.
 ## 0.4.4, 2022-11-22
 
 ### Bug Fixes
-* Ignore all "transport settings" when validating settings.  This should fix https://github.com/ClickHouse/clickhouse-connect/issues/80
+* Ignore all "transport settings" when validating settings.  This should fix https://github.com/ClickHouse/clickhouse-connect/issues/80 
 for older ClickHouse versions
 
 
@@ -771,7 +771,7 @@ clickhouse-sqlalchemy to clickhouse-connect.  Thanks to [Eugene Torap](https://g
 ## 0.2.5, 2022-08-30
 
 ### Bug Fixes
-* Fixed an issue where DBAPI cursors returned an invalid description object for columns.  This would cause `'property' object has no attribute 'startswith'` errors for some SqlAlchemy and SuperSet queries.
+* Fixed an issue where DBAPI cursors returned an invalid description object for columns.  This would cause `'property' object has no attribute 'startswith'` errors for some SqlAlchemy and SuperSet queries.  
 * Fixed an issue where datetime parameters would not be correctly rendered as ClickHouse compatible strings
 
 ### New Features

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,6 @@
 # ClickHouse Connect ChangeLog
 
 ### Improvements
-
 - Avoid concatenation of empty dataframes during `query_df` due to Pandas future warning.
 
 ### WARNING -- Python 3.7 EOL

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # ClickHouse Connect ChangeLog
 
+### Improvements
+
+- Avoid concatenation of empty dataframes during `query_df` due to Pandas future warning.
+
 ### WARNING -- Python 3.7 EOL
 Official support for Python 3.7 ended on June 27, 2023.  As of the 0.6.5 release, clickhouse-connect will not test against
 Python 3.7, and in releases after January 1, 2024, all support for Python 3.7 will end, including 3.7 binary wheels.
@@ -125,12 +129,12 @@ on importlib_metadata.
 
 ### Improvement
 - Add compression parameter to the clickhouse `tools.insert_file` method.  '.gz' and '.gzip' extensions are automatically
-recognized.  
+recognized.
 
 ## 0.6.7, 2023-07-18
 ### Bug Fixes
 - Fixed an issue for older versions of ClickHouse where the server would send an initial block of 0 rows for larger queries.
-This would break some queries with LowCardinality columns.  Closes https://github.com/ClickHouse/clickhouse-connect/issues/221 
+This would break some queries with LowCardinality columns.  Closes https://github.com/ClickHouse/clickhouse-connect/issues/221
 - Fixed the`compression` alias for the `compress` client setting in SQLAlchemy/Superset DSN urls.
 
 ### Improvements
@@ -253,7 +257,7 @@ can help with certain load balancing issues.  It defaults to 10 minutes
 in the case of many small inserts.  It can still be added using the `settings` dictionary of the client `*insert` methods if needed for some reason.
 - The query setting `use_na_values` has been renamed to `use_extended_dtypes` and now applies to all extended/special Pandas dtypes (except the Pandas Timestamp type).
 Set this to `False` to limit  the dtypes returned in Pandas dataframes to the "basic" numpy types.  (Note that this will force the use of numpy object arrays
-for most "nullable types")  This should allow creating "basic" dataframes for greater compatibility. Closes https://github.com/ClickHouse/clickhouse-connect/issues/172.  
+for most "nullable types")  This should allow creating "basic" dataframes for greater compatibility. Closes https://github.com/ClickHouse/clickhouse-connect/issues/172.
 
 ## 0.5.20, 2023-04-06
 ### Bug Fixes
@@ -383,7 +387,7 @@ raise a StreamClosedError.  Thanks to [Stas](https://github.com/reijnnn) for the
 - A better error message is returned when trying to read a "non-standard" DateTime64 column function for a numpy array
 or Pandas DataFrame.  "non-standard" means a DateTime64 precision not conforming to seconds, milliseconds, microseconds,
 or nanoseconds (0, 3, 6, or 9 respectively).  These DateTime64 types are not supported for numpy or Pandas because there is
-no corresponding standard numpy datetime64 type and conversion would be unacceptably slow (supported numpy types are 
+no corresponding standard numpy datetime64 type and conversion would be unacceptably slow (supported numpy types are
 `datetime64[s]`, `datetime64[ms]`, `datetime64[us]`, and `datetime64[ns]`).  A workaround is to cast the DateTime64 type
 to a supported type, i.e. `SELECT toDateTime64(col_name, 3)` for a millisecond column.
 - The base configuration required for a urllib PoolManager has been broken out into its own help method,
@@ -531,7 +535,7 @@ Dependency Changes below).  Instead, the HttpClient constructor now accepts an o
 can be used to set a custom `urllib.poolmanager.PoolManager` for the client.  In most cases the default PoolManager is
 all that is needed, but multiple PoolManagers may be required for advanced server/proxy applications with many client instances.
 
-### Dependency Changes 
+### Dependency Changes
 * ClickHouse Connect no longer requires the popular `requests` library.  The `requests` library is built on
 [urllib3](https://pypi.org/project/urllib3/), but ClickHouse Connect was utilizing very little of the added functionality.
 Requests also has very restricted access to the `urllib3` streaming API, which made adding additional compression methods
@@ -546,7 +550,7 @@ is optimized to work with them, so ClickHouse Connect now takes advantages of th
   * `stream_column_blocks` - returns a generator of smaller result sets matching the ClickHouse blocks returned by the native interface.
   * `stream_row_blocks` - returns a generator of smaller result sets matching the ClickHouse blocks returned by the native interface,
 but "pivoted" to return data rows.
-  * `stream_rows` - returns a generator that returns a row of data with each iteration.  
+  * `stream_rows` - returns a generator that returns a row of data with each iteration.
 These methods should be used within a `with` context to ensure the stream is properly closed when done.  In addition, two new properties
 `result_columns` and `result_rows` have been added to `QueryResult`.  Referencing either of these properties will consume the stream
 and return the full dataset.  Note that these properties should be used instead of the ambiguous `result_set`, which returns
@@ -576,9 +580,9 @@ https://github.com/ClickHouse/clickhouse-connect/issues/94. This has been fixed.
 ### New Features
 * [Documentation](https://clickhouse.com/docs/en/integrations/language-clients/python/intro) has been expanded to cover recent updates.
 * File upload support.  The new `driver.tools` module adds the function `insert_file` to simplify
-directly inserting data files into a table.  See the [test file](https://github.com/ClickHouse/clickhouse-connect/blob/main/tests/integration_tests/test_tools.py) 
+directly inserting data files into a table.  See the [test file](https://github.com/ClickHouse/clickhouse-connect/blob/main/tests/integration_tests/test_tools.py)
 for examples.  This closes https://github.com/ClickHouse/clickhouse-connect/issues/41.
-* Added support for server side [http query parameters](https://clickhouse.com/docs/en/interfaces/http/#cli-queries-with-parameters) 
+* Added support for server side [http query parameters](https://clickhouse.com/docs/en/interfaces/http/#cli-queries-with-parameters)
 For queries that contain bindings of the form `{<name>:<datatype>}`, the client will automatically convert the query* method
 `parameters` dictionary to the appropriate http query parameters.  Closes https://github.com/ClickHouse/clickhouse-connect/issues/49.
 * The main `clickhouse_connect.get_client` command will now accept a standard Python `dsn` argument and extract host, port,
@@ -609,7 +613,7 @@ precedence over values extracted from the dsn.
 ## 0.4.4, 2022-11-22
 
 ### Bug Fixes
-* Ignore all "transport settings" when validating settings.  This should fix https://github.com/ClickHouse/clickhouse-connect/issues/80 
+* Ignore all "transport settings" when validating settings.  This should fix https://github.com/ClickHouse/clickhouse-connect/issues/80
 for older ClickHouse versions
 
 
@@ -768,7 +772,7 @@ clickhouse-sqlalchemy to clickhouse-connect.  Thanks to [Eugene Torap](https://g
 ## 0.2.5, 2022-08-30
 
 ### Bug Fixes
-* Fixed an issue where DBAPI cursors returned an invalid description object for columns.  This would cause `'property' object has no attribute 'startswith'` errors for some SqlAlchemy and SuperSet queries.  
+* Fixed an issue where DBAPI cursors returned an invalid description object for columns.  This would cause `'property' object has no attribute 'startswith'` errors for some SqlAlchemy and SuperSet queries.
 * Fixed an issue where datetime parameters would not be correctly rendered as ClickHouse compatible strings
 
 ### New Features

--- a/clickhouse_connect/driver/npquery.py
+++ b/clickhouse_connect/driver/npquery.py
@@ -94,6 +94,7 @@ class NumpyResult(Closable):
 
     def close_df(self):
         pieces = list(self._df_stream())
+        pieces = [piece for piece in pieces if not piece.empty]
         if len(pieces) > 1:
             self._df_result = pd.concat(pieces, ignore_index=True)
         elif len(pieces) == 1:


### PR DESCRIPTION
## Summary
Pandas 2.1.0 introduced a FutureWarning when concatenating empty DataFrames (or those with all-NA entries). 

```
.../clickhouse_connect/driver/npquery.py:99: FutureWarning: The behavior of DataFrame concatenation with empty or all-NA entries is deprecated. In a future version, this will no longer exclude empty or all-NA columns when determining the result dtypes. To retain the old behavior, exclude the relevant entries before the concat operation.
  self._df_result = pd.concat(pieces, ignore_index=True)
```

This PR filters empty pieces before concatenation is performed; it does not remove empty pieces from the data frame stream. 

## Checklist
- [x] A human-readable description of the changes was provided to include in CHANGELOG
