### PR TITLE
Add summary field to the Cursor object

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@ ClickHouse Connect has been included as an official Apache Superset database con
 However, if you need compatibility with older versions of Superset, you may need clickhouse-connect
 v0.5.25, which dynamically loads the EngineSpec from the clickhouse-connect project.
 
+## 0.7.3, 2024-03-14
+### Improvement
+- Add summary field to Cursor object to retrieve the result of 'X-Clickhouse-Summary' header
+
 ## 0.7.2, 2024-03-07
 ### Bug Fixes
 - Inserts into columns with multibyte UTF-8 names were broken.  This has been fixed.  https://github.com/ClickHouse/clickhouse-connect/issues/312

--- a/tests/integration_tests/test_sqlalchemy/test_basics.py
+++ b/tests/integration_tests/test_sqlalchemy/test_basics.py
@@ -39,6 +39,7 @@ def test_cursor(test_engine: Engine):
     assert cursor.description[0][0] == 'database'
     assert cursor.description[1][1] == 'String'
     assert len(getattr(cursor, 'data')) == 2
+    assert cursor.summary[0]["read_rows"] == '2'
     raw_conn.close()
 
 


### PR DESCRIPTION
## Summary
<!-- A short description of the changes with a link to an open issue. -->
Add summary field to Cursor object to retrieve the result of 'X-Clickhouse-Summary' header
Fixes https://github.com/ClickHouse/clickhouse-connect/issues/316

## Checklist
Delete items not relevant to your PR:
- [x] Unit and integration tests covering the common scenarios were added
- [x] A human-readable description of the changes was provided to include in CHANGELOG
