### PR TITLE
Add query_arrow_stream

### DIFF
--- a/clickhouse_connect/driver/httpclient.py
+++ b/clickhouse_connect/driver/httpclient.py
@@ -449,8 +449,11 @@ class HttpClient(Client):
 
     def raw_query(self, query: str,
                   parameters: Optional[Union[Sequence, Dict[str, Any]]] = None,
-                  settings: Optional[Dict[str, Any]] = None, fmt: str = None,
-                  use_database: bool = True, external_data: Optional[ExternalData] = None) -> bytes:
+                  settings: Optional[Dict[str, Any]] = None,
+                  fmt: str = None,
+                  use_database: bool = True,
+                  external_data: Optional[ExternalData] = None,
+                  stream: bool = False) -> Union[bytes, HTTPResponse]:
         """
         See BaseClient doc_string for this method
         """
@@ -469,7 +472,8 @@ class HttpClient(Client):
         else:
             body = final_query
             fields = None
-        return self._raw_request(body, params, fields=fields).data
+        response = self._raw_request(body, params, fields=fields, stream=stream)
+        return response if stream else response.data
 
     def close(self):
         if self._owns_pool_manager:

--- a/clickhouse_connect/driver/query.py
+++ b/clickhouse_connect/driver/query.py
@@ -5,6 +5,7 @@ import uuid
 import pytz
 
 from enum import Enum
+from io import IOBase
 from typing import Any, Tuple, Dict, Sequence, Optional, Union, Generator
 from datetime import date, datetime, tzinfo
 
@@ -487,6 +488,12 @@ def to_arrow(content: bytes):
     pyarrow = check_arrow()
     reader = pyarrow.ipc.RecordBatchFileReader(content)
     return reader.read_all()
+
+
+def to_arrow_batches(buffer: IOBase) -> StreamContext:
+    pyarrow = check_arrow()
+    reader = pyarrow.ipc.open_stream(buffer)
+    return StreamContext(buffer, reader)
 
 
 def arrow_buffer(table) -> Tuple[Sequence[str], bytes]:

--- a/tests/integration_tests/test_arrow.py
+++ b/tests/integration_tests/test_arrow.py
@@ -1,5 +1,6 @@
 from datetime import date
 from typing import Callable
+import string
 
 import pytest
 
@@ -21,8 +22,9 @@ def test_arrow(test_client: Client, table_context: Callable):
         result_table = test_client.query_arrow('SELECT * FROM test_arrow_insert', use_strings=False)
         arrow_schema = result_table.schema
         assert arrow_schema.field(0).name == 'animal'
-        assert arrow_schema.field(0).type.id == 14
-        assert arrow_schema.field(1).type.bit_width == 64
+        assert arrow_schema.field(0).type == arrow.binary()
+        assert arrow_schema.field(1).name == 'legs'
+        assert arrow_schema.field(1).type == arrow.int64()
         # pylint: disable=no-member
         assert arrow.compute.sum(result_table['legs']).as_py() == 111
         assert len(result_table.columns) == 2
@@ -33,6 +35,36 @@ def test_arrow(test_client: Client, table_context: Callable):
     assert arrow_schema.field(0).name == 'number'
     assert arrow_schema.field(0).type.id == 8
     assert arrow_table.num_rows == 500
+
+
+def test_arrow_stream(test_client: Client, table_context: Callable):
+    if not arrow:
+        pytest.skip('PyArrow package not available')
+    if not test_client.min_version('21'):
+        pytest.skip(f'PyArrow is not supported in this server version {test_client.server_version}')
+    with table_context('test_arrow_insert', ['counter Int64', 'letter String']):
+        counter = arrow.array(range(1000000))
+        alphabet = string.ascii_lowercase
+        letter = arrow.array([alphabet[x % 26] for x in range(1000000)])
+        names = ['counter', 'letter']
+        insert_table = arrow.Table.from_arrays([counter, letter], names=names)
+        test_client.insert_arrow('test_arrow_insert', insert_table)
+        stream = test_client.query_arrow_stream('SELECT * FROM test_arrow_insert', use_strings=True)
+        with stream:
+            result_tables = list(stream)
+        # Hopefully we made the table long enough we got multiple tables in the query
+        assert len(result_tables) > 1
+        total_rows = 0
+        for table in result_tables:
+            assert table.num_columns == 2
+            arrow_schema = table.schema
+            assert arrow_schema.field(0).name == 'counter'
+            assert arrow_schema.field(0).type == arrow.int64()
+            assert arrow_schema.field(1).name == 'letter'
+            assert arrow_schema.field(1).type == arrow.string()
+            assert table.column(1)[0].as_py() == alphabet[table.column(0)[0].as_py() % 26]
+            total_rows += table.num_rows
+        assert total_rows == 1000000
 
 
 def test_arrow_map(test_client: Client, table_context: Callable):


### PR DESCRIPTION
## Summary
Adds a `query_arrow_stream` call that returns a generator that returns pyarrow.Table objects.
Issue #155

## Checklist
Delete items not relevant to your PR:
- [x] Unit and integration tests covering the common scenarios were added
- [ ] A human-readable description of the changes was provided to include in CHANGELOG
- [ ] For significant changes, documentation in https://github.com/ClickHouse/clickhouse-docs was updated with further explanations or tutorials
