### PR TITLE
fix(external-data): allow empty data external data

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,11 @@ ClickHouse Connect has been included as an official Apache Superset database con
 However, if you need compatibility with older versions of Superset, you may need clickhouse-connect
 v0.5.25, which dynamically loads the EngineSpec from the clickhouse-connect project.
 
+## 0.7.5, 2024-03-28
+### Bug Fixes
+- Allows empty `data` argument in the initializer of `ExternalFile` / `ExternalData` objects. Thanks to
+  [martijnthe](https://github.com/martijnthe) for the PR!
+
 ## 0.7.4, 2024-03-24
 ### Improvement
 - Added the new client method `query_arrow_stream` for streaming PyArrow queries from ClickHouse.  Big thanks to

--- a/clickhouse_connect/__version__.py
+++ b/clickhouse_connect/__version__.py
@@ -1,1 +1,1 @@
-version = '0.7.4'
+version = '0.7.5'

--- a/clickhouse_connect/driver/external.py
+++ b/clickhouse_connect/driver/external.py
@@ -35,7 +35,7 @@ class ExternalFile:
                 self.file_name = file_name
                 if file_name != path_name and path_base != self.name:
                     logger.warning('External data name %s and file_path %s use different names', file_name, path_name)
-        elif data:
+        elif data is not None:
             if not file_name:
                 raise ProgrammingError('Name is required for query external data')
             self.data = data
@@ -85,7 +85,7 @@ class ExternalData:
                  structure: Optional[Union[str, Sequence[str]]] = None,
                  mime_type: Optional[str] = None):
         self.files: list[ExternalFile] = []
-        if file_path or data:
+        if file_path or data is not None:
             first_file = ExternalFile(file_path=file_path,
                                       file_name=file_name,
                                       data=data,

--- a/tests/integration_tests/test_external_data.py
+++ b/tests/integration_tests/test_external_data.py
@@ -82,6 +82,11 @@ def test_external_binary(test_client: Client):
     assert len(result) == 2
     assert result[1][2] == 'The Sting'
 
+def test_external_empty_binary(test_client: Client):
+    data = ExternalData(file_name='empty.csv', data=b'', structure='name String')
+    result = test_client.query('SELECT * FROM empty', external_data=data).result_rows
+    assert len(result) == 0
+
 
 def test_external_raw(test_client: Client):
     movies_file = f'{Path(__file__).parent}/movies.parquet'


### PR DESCRIPTION
 ### Summary

Before this patch, the `ExternalData` / `ExternalFile` APIs would not create an empty table when `data=b''` was being passed, because `data` would be checked for truthiness. This PR fixes this bug by using `data is not None` checks instead.

 ### Test Plan

Added an integration test to cover this case.

## Checklist

- [x] Unit and integration tests covering the common scenarios were added
- [x] A human-readable description of the changes was provided to include in CHANGELOG
