### PR TITLE
chore(typing): improve type annotations of Client.raw_query

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,11 @@ ClickHouse Connect has been included as an official Apache Superset database con
 However, if you need compatibility with older versions of Superset, you may need clickhouse-connect
 v0.5.25, which dynamically loads the EngineSpec from the clickhouse-connect project.
 
+## UNRELEASED
+### Improvements
+- Added type `@overload`s for the `raw_query` method of `Client` for correct inference of the return
+  type based on the `stream: bool` argument. Thanks for [Martijn Thé](https://github.com/martijnthe) for the PR!
+
 ## 0.7.5, 2024-03-28
 ### Bug Fixes
 - Fixed client side binding for Python format strings using `%d` (int) and `%f` (float) format patterns.  Closes

--- a/clickhouse_connect/driver/client.py
+++ b/clickhouse_connect/driver/client.py
@@ -1,5 +1,6 @@
 import io
 import logging
+import typing
 from datetime import tzinfo, datetime
 
 import pytz
@@ -250,6 +251,40 @@ class Client(ABC):
         """
         return self._context_query(locals(), use_numpy=False, streaming=True).rows_stream
 
+    @typing.overload
+    @abstractmethod
+    def raw_query(self, query: str,
+                  parameters: Optional[Union[Sequence, Dict[str, Any]]] = None,
+                  settings: Optional[Dict[str, Any]] = None,
+                  fmt: str = None,
+                  use_database: bool = True,
+                  external_data: Optional[ExternalData] = None,
+                  stream: typing.Literal[False] = False,
+                  ) -> bytes: ...
+
+    @typing.overload
+    @abstractmethod
+    def raw_query(self, query: str,
+                  parameters: Optional[Union[Sequence, Dict[str, Any]]] = None,
+                  settings: Optional[Dict[str, Any]] = None,
+                  fmt: str = None,
+                  use_database: bool = True,
+                  external_data: Optional[ExternalData] = None,
+                  stream: typing.Literal[True] = ...,
+                  ) -> io.IOBase: ...
+
+    @typing.overload
+    @abstractmethod
+    def raw_query(self, query: str,
+                  parameters: Optional[Union[Sequence, Dict[str, Any]]] = None,
+                  settings: Optional[Dict[str, Any]] = None,
+                  fmt: str = None,
+                  use_database: bool = True,
+                  external_data: Optional[ExternalData] = None,
+                  stream: bool = ...,
+                  ) -> Union[bytes, io.IOBase]: ...
+
+
     @abstractmethod
     def raw_query(self, query: str,
                   parameters: Optional[Union[Sequence, Dict[str, Any]]] = None,
@@ -267,7 +302,9 @@ class Client(ABC):
         :param use_database  Send the database parameter to ClickHouse so the command will be executed in the client
          database context.
         :param external_data  External data to send with the query
-        :return: bytes representing raw ClickHouse return value based on format
+        :stream  True to return an object that implements io.IOBase, or False to return a bytes object.
+        :return: depending on the stream parameter, a bytes or io.IOBase representing raw ClickHouse return value based
+        on format
         """
 
     # pylint: disable=duplicate-code,too-many-arguments,unused-argument

--- a/tests/typing/client_typing.py
+++ b/tests/typing/client_typing.py
@@ -1,0 +1,21 @@
+import io
+
+from clickhouse_connect.driver import Client
+from typing import assert_type, cast, Union
+
+# Test Client.raw_query overloads:
+
+client = cast(Client, None)
+
+result = client.raw_query("")
+assert_type(result, bytes)
+
+result = client.raw_query("", stream=False)
+assert_type(result, bytes)
+
+result = client.raw_query("", stream=True)
+assert_type(result, io.IOBase)
+
+stream = cast(bool, None)
+result = client.raw_query("", stream=stream)
+assert_type(result, Union[bytes, io.IOBase])


### PR DESCRIPTION
 ## Summary

The return type of the `raw_query` method of a `Client` instance depends on the `stream: bool` argument: if it's `True`, the return type is an `io.IOBase` and if it's `False`, the return type is `bytes`.  This PR adds `@overload`s to make type checkers (such as mypy and pyright) aware of this, to avoid needing to to type-cast at the call-site.

 ## Test Plan

I started a `tests/typing/` folder for type testing and added a `client_typing.py` file with all possible type variations of the `stream` argument.

I manually ran `pyright tests/typing/client_typing.py` and observed there were no errors. Ideally, running a type checker would be part of this project's CI set up, but this is out of scope for this PR.

## Checklist
Delete items not relevant to your PR:
- [x] Unit and integration tests covering the common scenarios were added
- [x] A human-readable description of the changes was provided to include in CHANGELOG
