### PR TITLE
apply_server_timezone - condition change

### DIFF
--- a/clickhouse_connect/driver/client.py
+++ b/clickhouse_connect/driver/client.py
@@ -64,7 +64,7 @@ class Client(ABC):
         except UnknownTimeZoneError:
             logger.warning('Warning, server is using an unrecognized timezone %s, will use UTC default', server_tz)
         offsets_differ = datetime.now().astimezone().utcoffset() != datetime.now(tz=self.server_tz).utcoffset()
-        self.apply_server_timezone = apply_server_timezone == 'always' or (
+        self.apply_server_timezone = apply_server_timezone == True or (
                 coerce_bool(apply_server_timezone) and offsets_differ)
         readonly = 'readonly'
         if not self.min_version('19.17'):


### PR DESCRIPTION
## Summary
`apply_server_timezone` was evaluated to `FALSE`, because first condition was checking if `apply_server_timezone` is equal to `"always"`. However, when you initiate class `HttpClient`, that inherits form `Client` class, you set `apply_server_timezone` to `True`. 

Second condition (line 68 after `or`) was evaluated to `False` in my case. The function `coerce_bool` returns `True`, because you check if `apply_server_timezone` is `True`, but  `offset_differ` is evaluated in my system as `False`. My local TZ == server TZ and you check for the difference.

Please look on the example produced by the current code:

```Python
client.command("SELECT serverTimeZone()")
'Europe/Warsaw'
```

For 2024-04-01 result is as expected.

```Python
client.command("SELECT toDateTime('2024-04-01')")
2024-04-01 00:00:00'
```
```Python
client.query("SELECT toDateTime('2024-04-01')").result_rows
[(datetime.datetime(2024, 4, 1, 0, 0, tzinfo=datetime.timezone(datetime.timedelta(seconds=7200), 'CEST')),)]
```

But for 2024-02-01 `command` is correct, but `query` is wrong - it returns `2024, 2, 1, 1, 0` instead of `2024, 2, 1, 0, 0`:
```Python
client.command("SELECT toDateTime('2024-02-01')")
2024-02-01 00:00:00'
```
```Python
client.query("SELECT toDateTime('2024-02-01')").result_rows
[(datetime.datetime(2024, 2, 1, 1, 0, tzinfo=datetime.timezone(datetime.timedelta(seconds=7200), 'CEST')),)]