### PR TITLE
added missing parameter to tzname

### DIFF
--- a/clickhouse_connect/driver/client.py
+++ b/clickhouse_connect/driver/client.py
@@ -72,7 +72,7 @@ class Client(ABC):
 
         if not self.apply_server_timezone and not tzutil.local_tz_dst_safe:
             logger.warning('local timezone %s may return unexpected times due to Daylight Savings Time/' +
-                           'Summer Time differences', tzutil.local_tz.tzname())
+                           'Summer Time differences', tzutil.local_tz.tzname(None))
         readonly = 'readonly'
         if not self.min_version('19.17'):
             readonly = common.get_setting('readonly')


### PR DESCRIPTION
## Summary
Fixed error on warning message when indicating that a timezone may create nonsensical timezones.

## Checklist
Delete items not relevant to your PR:
- [x] A human-readable description of the changes was provided to include in CHANGELOG