### PR TITLE
Fix precision loss in Float to Decimal conversion

### DIFF
--- a/clickhouse_connect/datatypes/numeric.py
+++ b/clickhouse_connect/datatypes/numeric.py
@@ -291,9 +291,9 @@ class Decimal(ClickHouseType):
             dec = decimal.Decimal
             mult = self._mult
             if self.nullable:
-                write_array(self._array_type, [int(dec(x) * mult) if x else 0 for x in column], dest)
+                write_array(self._array_type, [int(dec(str(x)) * mult) if x else 0 for x in column], dest)
             else:
-                write_array(self._array_type, [int(dec(x) * mult) for x in column], dest)
+                write_array(self._array_type, [int(dec(str(x)) * mult) for x in column], dest)
 
     def _active_null(self, ctx: QueryContext):
         if ctx.use_none:
@@ -335,10 +335,10 @@ class BigDecimal(Decimal, registered=False):
             if self.nullable:
                 v = self._zeros
                 for x in column:
-                    dest += v if not x else itb(int(decimal.Decimal(x) * mult), sz, 'little', signed=True)
+                    dest += v if not x else itb(int(decimal.Decimal(str(x)) * mult), sz, 'little', signed=True)
             else:
                 for x in column:
-                    dest += itb(int(decimal.Decimal(x) * mult), sz, 'little', signed=True)
+                    dest += itb(int(decimal.Decimal(str(x)) * mult), sz, 'little', signed=True)
 
 
 class Decimal32(Decimal):

--- a/tests/integration_tests/test_inserts.py
+++ b/tests/integration_tests/test_inserts.py
@@ -24,6 +24,12 @@ def test_decimal_conv(test_client: Client, table_context: Callable):
         result = test_client.query('SELECT * FROM test_num_conv').result_set
         assert result == [(5, -182, 55.2), (57238478234, 77, -29.5773)]
 
+def test_float_decimal_conv(test_client: Client, table_context: Callable):
+    with table_context('test_float_to_dec_conv', ['col1 Decimal','col2 Decimal', 'col3 Decimal32(8)', 'col4 Decimal32(6)']):
+        data = [[0.12345678, -0.12345678, 0.12345678, -0.12345678]]
+        test_client.insert('test_float_to_dec_conv', data)
+        result = test_client.query('SELECT * FROM test_float_to_dec_conv').result_set
+        assert result == [(0.12345678, -0.12345678, 0.12345678, -0.12345678)]
 
 def test_bad_data_insert(test_client: Client, table_context: Callable):
     with table_context('test_bad_insert', ['key Int32', 'float_col Float64']):

--- a/tests/integration_tests/test_inserts.py
+++ b/tests/integration_tests/test_inserts.py
@@ -25,11 +25,11 @@ def test_decimal_conv(test_client: Client, table_context: Callable):
         assert result == [(5, -182, 55.2), (57238478234, 77, -29.5773)]
 
 def test_float_decimal_conv(test_client: Client, table_context: Callable):
-    with table_context('test_float_to_dec_conv', ['col1 Decimal32(8)','col2 Decimal32(8)', 'col3 Decimal128(8)', 'col4 Decimal128(8)']):
-        data = [[0.12345678, 0.1234567890, 0.12345678, 0.1234567890]]
+    with table_context('test_float_to_dec_conv', ['col1 Decimal32(6)','col2 Decimal32(6)', 'col3 Decimal128(6)', 'col4 Decimal128(6)']):
+        data = [[0.492917, 0.492917, 0.492917, 0.492917]]
         test_client.insert('test_float_to_dec_conv', data)
         result = test_client.query('SELECT * FROM test_float_to_dec_conv').result_set
-        assert result == [(0.12345678, 0.12345678, 0.12345678, 0.12345678)]
+        assert result == [(Decimal("0.492917"), Decimal("0.492917"), Decimal("0.492917"), Decimal("0.492917"))]
 
 def test_bad_data_insert(test_client: Client, table_context: Callable):
     with table_context('test_bad_insert', ['key Int32', 'float_col Float64']):

--- a/tests/integration_tests/test_inserts.py
+++ b/tests/integration_tests/test_inserts.py
@@ -26,7 +26,7 @@ def test_decimal_conv(test_client: Client, table_context: Callable):
 
 def test_float_decimal_conv(test_client: Client, table_context: Callable):
     with table_context('test_float_to_dec_conv', ['col1 Decimal32(6)','col2 Decimal32(6)', 'col3 Decimal128(6)', 'col4 Decimal128(6)']):
-        data = [[0.492917, 0.492917, 0.492917, 0.492917]]
+        data = [[0.492917, 0.49291700, 0.492917, 0.49291700]]
         test_client.insert('test_float_to_dec_conv', data)
         result = test_client.query('SELECT * FROM test_float_to_dec_conv').result_set
         assert result == [(Decimal("0.492917"), Decimal("0.492917"), Decimal("0.492917"), Decimal("0.492917"))]

--- a/tests/integration_tests/test_inserts.py
+++ b/tests/integration_tests/test_inserts.py
@@ -25,11 +25,11 @@ def test_decimal_conv(test_client: Client, table_context: Callable):
         assert result == [(5, -182, 55.2), (57238478234, 77, -29.5773)]
 
 def test_float_decimal_conv(test_client: Client, table_context: Callable):
-    with table_context('test_float_to_dec_conv', ['col1 Decimal','col2 Decimal', 'col3 Decimal32(8)', 'col4 Decimal32(6)']):
-        data = [[0.12345678, -0.12345678, 0.12345678, -0.12345678]]
+    with table_context('test_float_to_dec_conv', ['col1 Decimal32(8)','col2 Decimal32(8)', 'col3 Decimal128(8)', 'col4 Decimal128(8)']):
+        data = [[0.12345678, 0.1234567890, 0.12345678, 0.1234567890]]
         test_client.insert('test_float_to_dec_conv', data)
         result = test_client.query('SELECT * FROM test_float_to_dec_conv').result_set
-        assert result == [(0.12345678, -0.12345678, 0.12345678, -0.12345678)]
+        assert result == [(0.12345678, 0.12345678, 0.12345678, 0.12345678)]
 
 def test_bad_data_insert(test_client: Client, table_context: Callable):
     with table_context('test_bad_insert', ['key Int32', 'float_col Float64']):


### PR DESCRIPTION
## Summary
Issue raised in [this slack discussion](https://clickhousedb.slack.com/archives/CU478UEQZ/p1716398118092689)

When converting a float value to a decimal field, values like `0.1234567` end up being `0.1234566` in clickhouse.
There seem to be two different ways of fixing this:
- casting the float as a string before passing it to the `Decimal` constructor.
- not casting the float, but rounding the conversion instead of truncating it

This PR uses string casting to fix the issue, as most examples of decimal usages pass values represented as strings to the `Decimal` constructor.

## Checklist
Delete items not relevant to your PR:
- [x] Unit and integration tests covering the common scenarios were added
- [ ] A human-readable description of the changes was provided to include in CHANGELOG
- [ ] For significant changes, documentation in https://github.com/ClickHouse/clickhouse-docs was updated with further explanations or tutorials
