### PR TITLE
Added minimum version for tzlocal

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -69,7 +69,7 @@ def run_setup(try_c: bool = True):
             'pandas': ['pandas'],
             'arrow': ['pyarrow'],
             'orjson': ['orjson'],
-            'tzlocal': ['tzlocal'],
+            'tzlocal': ['tzlocal>=4.0'],
         },
         tests_require=['pytest'],
         entry_points={


### PR DESCRIPTION
## Summary
Fix for: https://github.com/ClickHouse/clickhouse-connect/issues/360
Not all versions of tzlocal support get_localzone_name()

clickhouse_connect/driver/tzutil.py
https://github.com/ClickHouse/clickhouse-connect/blob/bdad0e389d7ec46f109eccc825bc088fd2a78b6b/clickhouse_connect/driver/tzutil.py#L29
`local_name = tzlocal.get_localzone_name()`

This function is only available in tzlocal 4.0.0 and up.
See: 
https://github.com/regebro/tzlocal/blob/master/CHANGES.txt

4.0b2 (2021-09-26)
------------------

- Big refactor; Implemented get_localzone_name() functions.

- Adding a Windows OS environment variable 'TZ' will allow an override for
  setting the timezone (also see 4.0b3).

## Checklist
- [x] A human-readable description of the changes was provided to include in CHANGELOG

