### PR TITLE
Sercurity issue: remove clickhouse server ip & port in the exception

### DIFF
--- a/clickhouse_connect/driver/httpclient.py
+++ b/clickhouse_connect/driver/httpclient.py
@@ -426,7 +426,7 @@ class HttpClient(Client):
                         logger.debug('Retrying remotely closed connection')
                         continue
                 logger.warning('Unexpected Http Driver Exception')
-                raise OperationalError(f'Error {ex} executing HTTP request attempt {attempts} {self.url}') from ex
+                raise OperationalError(f'Error {ex} executing HTTP request attempt {attempts}') from ex
             finally:
                 if query_session:
                     self._active_session = None  # Make sure we always clear this

--- a/clickhouse_connect/driver/httpclient.py
+++ b/clickhouse_connect/driver/httpclient.py
@@ -349,7 +349,7 @@ class HttpClient(Client):
         return QuerySummary(self._summary(response))
 
     def _error_handler(self, response: HTTPResponse, retried: bool = False) -> None:
-        err_str = f'HTTPDriver returned response code {response.status})'
+        err_str = f'HTTPDriver for {self.url} returned response code {response.status})'
         try:
             err_content = get_response_data(response)
         except Exception: # pylint: disable=broad-except
@@ -426,7 +426,8 @@ class HttpClient(Client):
                         logger.debug('Retrying remotely closed connection')
                         continue
                 logger.warning('Unexpected Http Driver Exception')
-                raise OperationalError(f'Error {ex} executing HTTP request attempt {attempts}') from ex
+                err_str = f'Error {ex} executing HTTP request attempt {attempts} {self.url}' if self.show_clickhouse_errors else f'Error {ex} executing HTTP request attempt {attempts}'
+                raise OperationalError(err_str) from ex
             finally:
                 if query_session:
                     self._active_session = None  # Make sure we always clear this

--- a/clickhouse_connect/driver/httpclient.py
+++ b/clickhouse_connect/driver/httpclient.py
@@ -349,7 +349,7 @@ class HttpClient(Client):
         return QuerySummary(self._summary(response))
 
     def _error_handler(self, response: HTTPResponse, retried: bool = False) -> None:
-        err_str = f'HTTPDriver for {self.url} returned response code {response.status})'
+        err_str = f'HTTPDriver returned response code {response.status})'
         try:
             err_content = get_response_data(response)
         except Exception: # pylint: disable=broad-except

--- a/clickhouse_connect/driver/httpclient.py
+++ b/clickhouse_connect/driver/httpclient.py
@@ -15,17 +15,17 @@ from urllib3.response import HTTPResponse
 from clickhouse_connect import common
 from clickhouse_connect.datatypes import registry
 from clickhouse_connect.datatypes.base import ClickHouseType
-from clickhouse_connect.driver.ctypes import RespBuffCls
 from clickhouse_connect.driver.client import Client
 from clickhouse_connect.driver.common import dict_copy, coerce_bool, coerce_int
 from clickhouse_connect.driver.compression import available_compression
+from clickhouse_connect.driver.ctypes import RespBuffCls
 from clickhouse_connect.driver.exceptions import DatabaseError, OperationalError, ProgrammingError
 from clickhouse_connect.driver.external import ExternalData
 from clickhouse_connect.driver.httputil import ResponseSource, get_pool_manager, get_response_data, \
     default_pool_manager, get_proxy_manager, all_managers, check_env_proxy, check_conn_expiration
 from clickhouse_connect.driver.insert import InsertContext
-from clickhouse_connect.driver.summary import QuerySummary
 from clickhouse_connect.driver.query import QueryResult, QueryContext, quote_identifier, bind_query
+from clickhouse_connect.driver.summary import QuerySummary
 from clickhouse_connect.driver.transform import NativeTransform
 
 logger = logging.getLogger(__name__)
@@ -352,7 +352,7 @@ class HttpClient(Client):
         if self.show_clickhouse_errors:
             try:
                 err_content = get_response_data(response)
-            except Exception: # pylint: disable=broad-except
+            except Exception:  # pylint: disable=broad-except
                 err_content = None
             finally:
                 response.close()
@@ -427,7 +427,10 @@ class HttpClient(Client):
                         logger.debug('Retrying remotely closed connection')
                         continue
                 logger.warning('Unexpected Http Driver Exception')
-                err_str = f'Error {ex} executing HTTP request attempt {attempts} {self.url}' if self.show_clickhouse_errors else f'Error {ex} executing HTTP request attempt {attempts}'
+                if self.show_clickhouse_errors:
+                    err_str = f'Error {ex} executing HTTP request attempt {attempts} {self.url}'
+                else:
+                    err_str = f'Error {ex} executing HTTP request attempt {attempts}'
                 raise OperationalError(err_str) from ex
             finally:
                 if query_session:


### PR DESCRIPTION
Hi,
The issue is the HTTPDriver return the Clickhouse server sensitive detail: **IP & Port** in the error exception.
Example:
```
Error: HTTPDriver for http://10.15.27.43:8123 returned response code 404)
 Code: 60. DB::Exception: Table test.users_1 does not exist. Maybe you meant test.users? (UNKNOWN_TABLE) (version 23.12.3.40 (official build))
```
Expected:
```
Error: HTTPDriver returned response code 404)
 Code: 60. DB::Exception: Table test.users_1 does not exist. Maybe you meant test.users?. (UNKNOWN_TABLE) (version 23.12.3.40 (official build))
```

This will lead to an issue that the downstream application using this Clickhouse Connect driver, 
They will return the details to the client side and the UI will show the **IP & Port** then the hacker may use this to attack. 
We might run into these 2 cases:
+ They will wrap the exception and not return the detailed error to the client side => This is a bad practice cause the user will not know the message details.
+ They will try to manipulate the message string to search in the string to remove **IP & Port** ==> This is also an ad-hoc fix since the message string may have many different templates and formats, that they can not cover every case.

 ## Summary
<!-- A short description of the changes with a link to an open issue. -->

## Checklist
Delete items not relevant to your PR:
- [ ] Unit and integration tests covering the common scenarios were added
- [ ] A human-readable description of the changes was provided to include in CHANGELOG
- [ ] For significant changes, documentation in https://github.com/ClickHouse/clickhouse-docs was updated with further explanations or tutorials
