### PR TITLE
Include the column name in the error message for an unexpected NULL

### DIFF
--- a/clickhouse_connect/datatypes/base.py
+++ b/clickhouse_connect/datatypes/base.py
@@ -274,7 +274,7 @@ class ClickHouseType(ABC):
         write_uint64(len(index), dest)
         self._write_column_binary(index, dest, ctx)
         write_uint64(len(keys), dest)
-        write_array(array_type(1 << ix_type, False), keys, dest)
+        write_array(array_type(1 << ix_type, False), keys, dest, ctx)
 
     def _active_null(self, _ctx: QueryContext) -> Any:
         return None
@@ -338,7 +338,7 @@ class ArrayType(ClickHouseType, ABC, registered=False):
     def _write_column_binary(self, column: Union[Sequence, MutableSequence], dest: bytearray, ctx: InsertContext):
         if len(column) and self.nullable:
             column = [0 if x is None else x for x in column]
-        write_array(self._array_type, column, dest)
+        write_array(self._array_type, column, dest, ctx)
 
     def _active_null(self, ctx: QueryContext):
         if ctx.as_pandas and ctx.use_extended_dtypes:

--- a/clickhouse_connect/datatypes/network.py
+++ b/clickhouse_connect/datatypes/network.py
@@ -39,7 +39,7 @@ class IPv4(ClickHouseType):
                 column = [x._ip if x else 0 for x in column]
             else:
                 column = [x._ip for x in column]
-        write_array(self._array_type, column, dest)
+        write_array(self._array_type, column, dest, ctx)
 
     def _active_null(self, ctx: QueryContext):
         fmt = self.read_format(ctx)

--- a/clickhouse_connect/datatypes/numeric.py
+++ b/clickhouse_connect/datatypes/numeric.py
@@ -189,8 +189,8 @@ class Bool(ClickHouseType):
             return np.array(column)
         return column
 
-    def _write_column_binary(self, column, dest, _ctx):
-        write_array('B', [1 if x else 0 for x in column], dest)
+    def _write_column_binary(self, column, dest, ctx):
+        write_array('B', [1 if x else 0 for x in column], dest, ctx)
 
 
 class Boolean(Bool):
@@ -218,15 +218,15 @@ class Enum(ClickHouseType):
         lookup = self._int_map.get
         return [lookup(x, None) for x in column]
 
-    def _write_column_binary(self, column: Union[Sequence, MutableSequence], dest: bytearray, _ctx):
+    def _write_column_binary(self, column: Union[Sequence, MutableSequence], dest: bytearray, ctx):
         first = self._first_value(column)
         if first is None or not isinstance(first, str):
             if self.nullable:
                 column = [0 if not x else x for x in column]
-            write_array(self._array_type, column, dest)
+            write_array(self._array_type, column, dest, ctx)
         else:
             lookup = self._name_map.get
-            write_array(self._array_type, [lookup(x, 0) for x in column], dest)
+            write_array(self._array_type, [lookup(x, 0) for x in column], dest, ctx)
 
 
 class Enum8(Enum):
@@ -291,9 +291,9 @@ class Decimal(ClickHouseType):
             dec = decimal.Decimal
             mult = self._mult
             if self.nullable:
-                write_array(self._array_type, [int(dec(str(x)) * mult) if x else 0 for x in column], dest)
+                write_array(self._array_type, [int(dec(str(x)) * mult) if x else 0 for x in column], dest, ctx)
             else:
-                write_array(self._array_type, [int(dec(str(x)) * mult) for x in column], dest)
+                write_array(self._array_type, [int(dec(str(x)) * mult) for x in column], dest, ctx)
 
     def _active_null(self, ctx: QueryContext):
         if ctx.use_none:

--- a/clickhouse_connect/datatypes/string.py
+++ b/clickhouse_connect/datatypes/string.py
@@ -4,7 +4,6 @@ from clickhouse_connect.driver.ctypes import data_conv
 
 from clickhouse_connect.datatypes.base import ClickHouseType, TypeDef
 from clickhouse_connect.driver.errors import handle_error
-from clickhouse_connect.driver.exceptions import DataError
 from clickhouse_connect.driver.insert import InsertContext
 from clickhouse_connect.driver.query import QueryContext
 from clickhouse_connect.driver.types import ByteSource

--- a/clickhouse_connect/datatypes/string.py
+++ b/clickhouse_connect/datatypes/string.py
@@ -104,7 +104,7 @@ class FixedString(ClickHouseType):
                         except UnicodeEncodeError:
                             b = empty
                         if len(b) > sz:
-                            raise DataError(f'UTF-8 encoded FixedString value {b.hex(" ")} exceeds column size {sz}')
+                            raise ctx.make_data_error(f'UTF-8 encoded FixedString value {b.hex(" ")} exceeds column size {sz}')
                         ext(b)
                         ext(empty[:sz - len(b)])
             else:
@@ -114,7 +114,7 @@ class FixedString(ClickHouseType):
                     except UnicodeEncodeError:
                         b = empty
                     if len(b) > sz:
-                        raise DataError(f'UTF-8 encoded FixedString value {b.hex(" ")} exceeds column size {sz}')
+                        raise ctx.make_data_error(f'UTF-8 encoded FixedString value {b.hex(" ")} exceeds column size {sz}')
                     ext(b)
                     ext(empty[:sz - len(b)])
         elif self.nullable:
@@ -122,11 +122,11 @@ class FixedString(ClickHouseType):
                 if not b:
                     ext(empty)
                 elif len(b) != sz:
-                    raise DataError(f'Fixed String binary value {b.hex(" ")} does not match column size {sz}')
+                    raise ctx.make_data_error(f'Fixed String binary value {b.hex(" ")} does not match column size {sz}')
                 else:
                     ext(b)
         else:
             for b in column:
                 if len(b) != sz:
-                    raise DataError(f'Fixed String binary value {b.hex(" ")} does not match column size {sz}')
+                    raise ctx.make_data_error(f'Fixed String binary value {b.hex(" ")} does not match column size {sz}')
                 ext(b)

--- a/clickhouse_connect/datatypes/temporal.py
+++ b/clickhouse_connect/datatypes/temporal.py
@@ -45,7 +45,7 @@ class Date(ClickHouseType):
                 column = [0 if x is None else (x - esd).days for x in column]
             else:
                 column = [(x - esd).days for x in column]
-        write_array(self._array_type, column, dest)
+        write_array(self._array_type, column, dest, ctx)
 
     def _active_null(self, ctx: QueryContext):
         fmt = self.read_format(ctx)
@@ -136,7 +136,7 @@ class DateTime(DateTimeBase):
                 column = [int(x.timestamp()) if x else 0 for x in column]
             else:
                 column = [int(x.timestamp()) for x in column]
-        write_array(self._array_type, column, dest)
+        write_array(self._array_type, column, dest, ctx)
 
 
 class DateTime64(DateTimeBase):
@@ -213,4 +213,4 @@ class DateTime64(DateTimeBase):
                           for x in column]
             else:
                 column = [((int(x.timestamp()) * 1000000 + x.microsecond) * prec) // 1000000 for x in column]
-        write_array('q', column, dest)
+        write_array('q', column, dest, ctx)

--- a/clickhouse_connect/driver/common.py
+++ b/clickhouse_connect/driver/common.py
@@ -38,12 +38,13 @@ def array_type(size: int, signed: bool):
     return code if signed else code.upper()
 
 
-def write_array(code: str, column: Sequence, dest: MutableSequence):
+def write_array(code: str, column: Sequence, dest: MutableSequence, ctx):
     """
     Write a column of native Python data matching the array.array code
     :param code: Python array.array code matching the column data type
     :param column: Column of native Python values
     :param dest: Destination byte buffer
+    :param ctx: The InsertContext
     """
     if len(column) and not isinstance(column[0], (int, float)):
         if code in ('f', 'F', 'd', 'D'):
@@ -54,8 +55,8 @@ def write_array(code: str, column: Sequence, dest: MutableSequence):
         buff = struct.Struct(f'<{len(column)}{code}')
         dest += buff.pack(*column)
     except (TypeError, OverflowError, struct.error) as ex:
-        raise DataError('Unable to create Python array.  This is usually caused by trying to insert None ' +
-                        'values into a ClickHouse column that is not Nullable') from ex
+        raise ctx.make_data_error('Unable to create Python array.  This is usually caused by trying to insert None ' +
+                                  'values into a ClickHouse column that is not Nullable') from ex
 
 
 def write_uint64(value: int, dest: MutableSequence):

--- a/clickhouse_connect/driver/common.py
+++ b/clickhouse_connect/driver/common.py
@@ -2,11 +2,13 @@ import array
 import struct
 import sys
 
-from typing import Sequence, MutableSequence, Dict, Optional, Union, Generator
+from typing import Sequence, MutableSequence, Dict, Optional, Union, Generator, TYPE_CHECKING
 
 from clickhouse_connect.driver.exceptions import ProgrammingError, StreamClosedError
-from clickhouse_connect.driver.insert import InsertContext
 from clickhouse_connect.driver.types import Closable
+
+if TYPE_CHECKING:
+    from clickhouse_connect.driver.insert import InsertContext
 
 # pylint: disable=invalid-name
 must_swap = sys.byteorder == 'big'
@@ -39,7 +41,7 @@ def array_type(size: int, signed: bool):
     return code if signed else code.upper()
 
 
-def write_array(code: str, column: Sequence, dest: MutableSequence, ctx: InsertContext):
+def write_array(code: str, column: Sequence, dest: MutableSequence, ctx: 'InsertContext'):
     """
     Write a column of native Python data matching the array.array code
     :param code: Python array.array code matching the column data type

--- a/clickhouse_connect/driver/common.py
+++ b/clickhouse_connect/driver/common.py
@@ -4,7 +4,8 @@ import sys
 
 from typing import Sequence, MutableSequence, Dict, Optional, Union, Generator
 
-from clickhouse_connect.driver.exceptions import ProgrammingError, StreamClosedError, DataError
+from clickhouse_connect.driver.exceptions import ProgrammingError, StreamClosedError
+from clickhouse_connect.driver.insert import InsertContext
 from clickhouse_connect.driver.types import Closable
 
 # pylint: disable=invalid-name
@@ -38,7 +39,7 @@ def array_type(size: int, signed: bool):
     return code if signed else code.upper()
 
 
-def write_array(code: str, column: Sequence, dest: MutableSequence, ctx):
+def write_array(code: str, column: Sequence, dest: MutableSequence, ctx: InsertContext):
     """
     Write a column of native Python data matching the array.array code
     :param code: Python array.array code matching the column data type

--- a/clickhouse_connect/driver/context.py
+++ b/clickhouse_connect/driver/context.py
@@ -41,8 +41,10 @@ class BaseQueryContext:
         self.use_extended_dtypes = use_extended_dtypes
         self._active_col_fmt = None
         self._active_col_type_fmts = _empty_map
+        self._column_name = None
 
     def start_column(self, name: str):
+        self._column_name = name
         self._active_col_fmt = self.col_simple_formats.get(name)
         self._active_col_type_fmts = self.col_type_formats.get(name, _empty_map)
 

--- a/clickhouse_connect/driver/insert.py
+++ b/clickhouse_connect/driver/insert.py
@@ -200,6 +200,4 @@ class InsertContext(BaseQueryContext):
         return data
 
     def make_data_error(self, error_message: str) -> DataError:
-        if self._column_name is not None:
-            return DataError(f"Failed to write column '{self._column_name}': {error_message}")
-        return DataError(error_message)
+        return DataError(f"Failed to write column '{self._column_name}': {error_message}")

--- a/clickhouse_connect/driver/insert.py
+++ b/clickhouse_connect/driver/insert.py
@@ -53,7 +53,6 @@ class InsertContext(BaseQueryContext):
         self.block_row_count = DEFAULT_BLOCK_BYTES
         self.data = data
         self.insert_exception = None
-        self._column_name = None
 
     @property
     def empty(self) -> bool:
@@ -199,10 +198,6 @@ class InsertContext(BaseQueryContext):
                 data[ix] = data[ix].tolist()
         self.column_oriented = True
         return data
-
-    def start_column(self, name: str):
-        super().start_column(name)
-        self._column_name = name
 
     def make_data_error(self, error_message: str) -> DataError:
         if self._column_name is not None:


### PR DESCRIPTION
Previously if you inserted a NULL into a column that isn't Nullable, the error you got was 

> Unable to create Python array. This is usually caused by trying to insert None values into a ClickHouse column that is not Nullable

which is unhelpful for working out *which* column is the problem. I've modified that error path so it can include the column name in the error, like so:

> Failed to write column 'bus_voltage': Unable to create Python array. This is usually caused by trying to insert None values into a ClickHouse column that is not Nullable

I felt like this was a pretty small change so I didn't add tests or file an issue, I hope that's okay.
