### PR TITLE
Arrow compression plus another http buffer tweak

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,13 @@ release (0.9.0), unrecognized arguments/keywords for these methods of creating a
 instead of being passed as ClickHouse server settings. This is in conjunction with some refactoring in Client construction.
 The supported method of passing ClickHouse server settings is to prefix such arguments/query parameters with`ch_`.  
 
+## 0.8.2, 2024-10-04
+### Bug Fix
+- Ensure lz4 compression does not exit on an empty block.  May fix https://github.com/ClickHouse/clickhouse-connect/issues/403.
+
+### Improvement
+- Compress Arrow inserts (using pyarrow compression) if compression is set to `lz4` or `zstd`.  Closes https://github.com/ClickHouse/clickhouse-connect/issues/267.
+
 ## 0.8.1, 2024-09-29
 ### Bug Fix
 - Fixed an edge case where the HTTP buffer could theoretically return empty blocks.  

--- a/clickhouse_connect/__version__.py
+++ b/clickhouse_connect/__version__.py
@@ -1,1 +1,1 @@
-version = '0.8.1'
+version = '0.8.2'

--- a/clickhouse_connect/driver/httputil.py
+++ b/clickhouse_connect/driver/httputil.py
@@ -244,7 +244,8 @@ class ResponseSource:
                 else:
                     chunk = chunks.popleft()
                     current_size -= len(chunk)
-                yield chunk
+                if chunk:
+                    yield chunk
 
         self.gen = buffered()
 

--- a/tests/integration_tests/test_arrow.py
+++ b/tests/integration_tests/test_arrow.py
@@ -14,8 +14,8 @@ def test_arrow(test_client: Client, table_context: Callable):
     if not test_client.min_version('21'):
         pytest.skip(f'PyArrow is not supported in this server version {test_client.server_version}')
     with table_context('test_arrow_insert', ['animal String', 'legs Int64']):
-        n_legs = arrow.array([2, 4, 5, 100])
-        animals = arrow.array(['Flamingo', 'Horse', 'Brittle stars', 'Centipede'])
+        n_legs = arrow.array([2, 4, 5, 100] * 50)
+        animals = arrow.array(['Flamingo', 'Horse', 'Brittle stars', 'Centipede'] * 50)
         names = ['legs', 'animal']
         insert_table = arrow.Table.from_arrays([n_legs, animals], names=names)
         test_client.insert_arrow('test_arrow_insert', insert_table)
@@ -26,7 +26,7 @@ def test_arrow(test_client: Client, table_context: Callable):
         assert arrow_schema.field(1).name == 'legs'
         assert arrow_schema.field(1).type == arrow.int64()
         # pylint: disable=no-member
-        assert arrow.compute.sum(result_table['legs']).as_py() == 111
+        assert arrow.compute.sum(result_table['legs']).as_py() == 5550
         assert len(result_table.columns) == 2
 
     arrow_table = test_client.query_arrow('SELECT number from system.numbers LIMIT 500',


### PR DESCRIPTION
## Summary
Add built in Arrow compression for inserts.  Closes #267.
One more http buffer tweak.  May close #403.

## Checklist
Delete items not relevant to your PR:
- [x] Unit and integration tests covering the common scenarios were added
- [x] A human-readable description of the changes was provided to include in CHANGELOG

