### PR TITLE
Update experimental JSON support

### DIFF
--- a/.github/workflows/on_push.yml
+++ b/.github/workflows/on_push.yml
@@ -65,9 +65,10 @@ jobs:
           - '3.13'
         clickhouse-version:
           - '24.3'
-          - '24.7'
           - '24.8'
           - '24.9'
+          - '24.10'
+          - '24.11'
           - latest
 
     name: Local Tests Py=${{ matrix.python-version }} CH=${{ matrix.clickhouse-version }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,12 +4,27 @@
 Python 3.8 was EOL on 2024-10-07.  It is no longer tested, and versions after 2025-04-07 will not include Python
 3.8 wheel distributions.
 
+### WARNING -- JSON Incompatibility between versions 22.8 and 22.10
+The internal serialization format for experimental JSON was updated in ClickHouse version 24.10.  `clickhouse-connect`
+will set the compatibility level on a global basis based on the last client created, so multiple clients using the
+library with mixed versions 22.8/22.9 and 22.10 and later versions will break.  If you need JSON support for mixed
+versions you must use different Python interpreters for each version.
+
 ### WARNING -- Impending Breaking Change - Server Settings in DSN
 When creating a DBAPI Connection method using the Connection constructor or a SQLAlchemy DSN, the library currently
 converts any unrecognized keyword argument/query parameter to a ClickHouse server setting. Starting in the next minor
 release (0.9.0), unrecognized arguments/keywords for these methods of creating a DBAPI connection will raise an exception
 instead of being passed as ClickHouse server settings. This is in conjunction with some refactoring in Client construction.
 The supported method of passing ClickHouse server settings is to prefix such arguments/query parameters with`ch_`.
+
+## 0.8.10, 2024-12-14
+### Bug Fixes
+- The experimental JSON type would break in some circumstances with ClickHouse server version 24.10 and later.  This has
+been fixed.  The fix is incompatible with ClickHouse version 24.8 and 24.9 however, so see the above WARNING about
+mixing JSON types
+- Experimental JSON types within a Tuple was broken.  This has been fixed; however, the fix fails on ClickHouse server
+versions 24.8 and 24.9.  If you need Tuple(JSON) support, you must use ClickHouse server version 24.10 or later.
+Closes https://github.com/ClickHouse/clickhouse-connect/issues/436.
 
 ## 0.8.9, 2024-12-02
 ### Bug Fix

--- a/clickhouse_connect/__version__.py
+++ b/clickhouse_connect/__version__.py
@@ -1,1 +1,1 @@
-version = '0.8.9'
+version = '0.8.10'

--- a/clickhouse_connect/datatypes/dynamic.py
+++ b/clickhouse_connect/datatypes/dynamic.py
@@ -2,7 +2,7 @@ from typing import List, Sequence, Collection
 
 from clickhouse_connect.datatypes.base import ClickHouseType, TypeDef
 from clickhouse_connect.datatypes.registry import get_from_name
-from clickhouse_connect.driver.common import unescape_identifier, first_value
+from clickhouse_connect.driver.common import unescape_identifier, first_value, write_uint64
 from clickhouse_connect.driver.ctypes import data_conv
 from clickhouse_connect.driver.errors import handle_error
 from clickhouse_connect.driver.exceptions import DataError
@@ -70,7 +70,7 @@ class Dynamic(ClickHouseType):
 
     @property
     def insert_name(self):
-        return 'String'
+       return 'String'
 
     def __init__(self, type_def:TypeDef):
         super().__init__(type_def)
@@ -86,9 +86,11 @@ class Dynamic(ClickHouseType):
 
 
 def read_dynamic_prefix(source: ByteSource) -> List[ClickHouseType]:
-    if source.read_uint64() != 1:  # dynamic structure serialization version, currently only 1 is recognized
+    serialize_version = source.read_uint64()
+    if serialize_version == 1:
+        source.read_leb128()  # max dynamic types, we ignore this value
+    elif serialize_version != 2:
         raise DataError('Unrecognized dynamic structure version')
-    source.read_leb128()  # max dynamic types, we ignore this value
     num_variants = source.read_leb128()
     variant_types = [get_from_name(source.read_leb128_str()) for _ in range(num_variants)]
     variant_types.append(STRING_DATA_TYPE)
@@ -186,15 +188,22 @@ class JSON(ClickHouseType):
         if parts:
             self._name_suffix = f'({", ".join(parts)})'
 
-    @property
-    def insert_name(self):
-        return 'String'
+    #@property
+    #def insert_name(self):
+    #    return 'String'
+
+    def write_column_prefix(self, dest: bytearray):
+        write_uint64(0x1, dest)
+
+    def read_column_prefix(self, source: ByteSource, _ctx: QueryContext):
+        serialize_version = source.read_uint64()
+        if serialize_version == 0:
+            source.read_leb128()  # max dynamic types, we ignore this value
+        elif serialize_version != 2:
+            raise DataError(f'Unrecognized dynamic structure version: {serialize_version} column: `{ctx.column_name}`')
 
     # pylint: disable=too-many-locals
-    def read_column(self, source: ByteSource, num_rows: int, ctx: QueryContext):
-        if source.read_uint64() != 0: # object serialization version, currently only 0 is recognized
-            raise DataError(f'unrecognized object serialization version, column `{ctx.column_name}`')
-        source.read_leb128() # the max number of dynamic paths.  Used to preallocate storage in ClickHouse; we ignore it
+    def _read_column_binary(self, source: ByteSource, num_rows: int, ctx: QueryContext):
         dynamic_path_cnt = source.read_leb128()
         dynamic_paths = [source.read_leb128_str() for _ in range(dynamic_path_cnt)]
         for typed in self.typed_types:

--- a/clickhouse_connect/datatypes/dynamic.py
+++ b/clickhouse_connect/datatypes/dynamic.py
@@ -70,7 +70,7 @@ class Dynamic(ClickHouseType):
 
     @property
     def insert_name(self):
-       return 'String'
+        return 'String'
 
     def __init__(self, type_def:TypeDef):
         super().__init__(type_def)
@@ -188,14 +188,10 @@ class JSON(ClickHouseType):
         if parts:
             self._name_suffix = f'({", ".join(parts)})'
 
-    #@property
-    #def insert_name(self):
-    #    return 'String'
-
     def write_column_prefix(self, dest: bytearray):
         write_uint64(0x1, dest)
 
-    def read_column_prefix(self, source: ByteSource, _ctx: QueryContext):
+    def read_column_prefix(self, source: ByteSource, ctx: QueryContext):
         serialize_version = source.read_uint64()
         if serialize_version == 0:
             source.read_leb128()  # max dynamic types, we ignore this value

--- a/clickhouse_connect/driver/buffer.py
+++ b/clickhouse_connect/driver/buffer.py
@@ -129,10 +129,8 @@ class ResponseBuffer(ByteSource):
         return column
 
     @property
-    def last_message(self):
-        if len(self.buffer) == 0:
-            return None
-        return self.buffer.decode()
+    def last_message(self) -> bytes:
+        return self.buffer
 
     def close(self):
         if self.source:

--- a/clickhouse_connect/driver/transform.py
+++ b/clickhouse_connect/driver/transform.py
@@ -55,17 +55,7 @@ class NativeTransform:
                     # We ran out of data before it was expected, this could be ClickHouse reporting an error
                     # in the response
                     if source.last_message:
-                        message = source.last_message
-                        if len(message) > 1024:
-                            message = message[-1024:]
-                        error_start = message.find('Code: '.encode())
-                        if error_start != -1:
-                            message = message[error_start:]
-                        try:
-                            message_str = message.decode()
-                        except UnicodeError:
-                            message_str = f'unrecognized data found in stream: `{message.hex()[128:]}`'
-                        raise StreamFailureError(message_str) from None
+                        raise StreamFailureError(extract_error_message(source.last_message)) from None
                 raise
             block_num += 1
             return result_block
@@ -123,3 +113,16 @@ class NativeTransform:
                 yield footer
 
         return chunk_gen()
+
+
+def extract_error_message(message: bytes) -> str:
+    if len(message) > 1024:
+        message = message[-1024:]
+    error_start = message.find('Code: '.encode())
+    if error_start != -1:
+        message = message[error_start:]
+    try:
+        message_str = message.decode()
+    except UnicodeError:
+        message_str = f'unrecognized data found in stream: `{message.hex()[128:]}`'
+    return message_str

--- a/clickhouse_connect/driver/transform.py
+++ b/clickhouse_connect/driver/transform.py
@@ -58,10 +58,14 @@ class NativeTransform:
                         message = source.last_message
                         if len(message) > 1024:
                             message = message[-1024:]
-                        error_start = message.find('Code: ')
+                        error_start = message.find('Code: '.encode())
                         if error_start != -1:
                             message = message[error_start:]
-                        raise StreamFailureError(message) from None
+                        try:
+                            message_str = message.decode()
+                        except UnicodeError:
+                            message_str = f'unrecognized data found in stream: `{message.hex()[128:]}`'
+                        raise StreamFailureError(message_str) from None
                 raise
             block_num += 1
             return result_block

--- a/clickhouse_connect/driver/types.py
+++ b/clickhouse_connect/driver/types.py
@@ -11,7 +11,7 @@ class Closable(ABC):
 
 
 class ByteSource(Closable):
-    last_message = None
+    last_message:bytes = None
 
     @abstractmethod
     def read_leb128(self) -> int:

--- a/clickhouse_connect/driverc/buffer.pyx
+++ b/clickhouse_connect/driverc/buffer.pyx
@@ -186,7 +186,7 @@ cdef class ResponseBuffer:
 
     @cython.boundscheck(False)
     @cython.wraparound(False)
-    def  read_byte(self) -> int:
+    def read_byte(self) -> int:
         if self.buf_loc < self.buf_sz:
             b = self.buffer[self.buf_loc]
             self.buf_loc += 1
@@ -299,8 +299,8 @@ cdef class ResponseBuffer:
     @property
     def last_message(self):
         if self.buffer == NULL:
-            return None
-        return self.buffer[self.buf_sz:].decode()
+            return self.slice[0:]
+        return self.buffer[self.buf_sz:]
 
     def __dealloc__(self):
         self.close()

--- a/tests/integration_tests/test_dynamic.py
+++ b/tests/integration_tests/test_dynamic.py
@@ -105,6 +105,8 @@ def test_typed_json(test_client: Client, table_context: Callable):
 
 def test_complex_json(test_client: Client, table_context: Callable):
     type_available(test_client, 'json')
+    if not test_client.min_version('24.10'):
+        pytest.skip('Complex JSON broken before 24.10')
     with table_context('new_json_complex', [
         'key Int32',
         'value Tuple(t JSON)'


### PR DESCRIPTION
## Summary
Update for experimental JSON support in ClickHouse 24.10+.  Closes #436 

## Checklist
Delete items not relevant to your PR:
- [ ] Unit and integration tests covering the common scenarios were added
- [ ] A human-readable description of the changes was provided to include in CHANGELOG
- [ ] For significant changes, documentation in https://github.com/ClickHouse/clickhouse-docs was updated with further explanations or tutorials
