### PR TITLE
Add support of ISO8601 timestamp strings for columns with `DateTime64` type

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,10 @@ release (0.9.0), unrecognized arguments/keywords for these methods of creating a
 instead of being passed as ClickHouse server settings. This is in conjunction with some refactoring in Client construction.
 The supported method of passing ClickHouse server settings is to prefix such arguments/query parameters with`ch_`.
 
+## 0.8.11, 2024-12-17
+### Improvement
+- Support of ISO8601 strings for inserting values to columns with DateTime64 type was added.
+
 ## 0.8.10, 2024-12-14
 ### Bug Fixes
 - The experimental JSON type would break in some circumstances with ClickHouse server version 24.10 and later.  This has

--- a/clickhouse_connect/datatypes/temporal.py
+++ b/clickhouse_connect/datatypes/temporal.py
@@ -202,7 +202,7 @@ class DateTime64(DateTimeBase):
         if isinstance(first, int) or self.write_format(ctx) == 'int':
             if self.nullable:
                 column = [x if x else 0 for x in column]
-        elif isinstance(first, str) or self.write_format(ctx) == 'str':
+        elif isinstance(first, str):
             original_column = column
             column = []
 
@@ -212,7 +212,7 @@ class DateTime64(DateTimeBase):
                 else:
                     dt = datetime.fromisoformat(x)
                     v = ((int(dt.timestamp()) * 1000000 + dt.microsecond) * self.prec) // 1000000
-                
+
                 column.append(v)
         else:
             prec = self.prec

--- a/clickhouse_connect/datatypes/temporal.py
+++ b/clickhouse_connect/datatypes/temporal.py
@@ -202,6 +202,18 @@ class DateTime64(DateTimeBase):
         if isinstance(first, int) or self.write_format(ctx) == 'int':
             if self.nullable:
                 column = [x if x else 0 for x in column]
+        elif isinstance(first, str) or self.write_format(ctx) == 'str':
+            original_column = column
+            column = []
+
+            for x in original_column:
+                if not x and self.nullable:
+                    v = 0
+                else:
+                    dt = datetime.fromisoformat(x)
+                    v = ((int(dt.timestamp()) * 1000000 + dt.microsecond) * self.prec) // 1000000
+                
+                column.append(v)
         else:
             prec = self.prec
             if self.nullable:


### PR DESCRIPTION
## Summary
Support of ISO8601 datetime string is added for columns with `DateTime64` type.

Now it is possible to pass timestamps like that:
![image](https://github.com/user-attachments/assets/49f9978e-3b88-4750-9d6b-381f3916dbc0)

And it is successfully inserted into clickhouse:
![image](https://github.com/user-attachments/assets/5d2b7149-cee2-4abd-9134-3fccb68dca9c)

## Checklist
- [ ] Unit and integration tests covering the common scenarios were added
- [x] A human-readable description of the changes was provided to include in CHANGELOG
- [ ] For significant changes, documentation in https://github.com/ClickHouse/clickhouse-docs was updated with further explanations or tutorials
