### PR TITLE
fix: add default value for access token in HttpClient init

### DIFF
--- a/clickhouse_connect/driver/httpclient.py
+++ b/clickhouse_connect/driver/httpclient.py
@@ -54,7 +54,7 @@ class HttpClient(Client):
                  username: str,
                  password: str,
                  database: str,
-                 access_token: Optional[str],
+                 access_token: Optional[str] = None,
                  compress: Union[bool, str] = True,
                  query_limit: int = 0,
                  query_retries: int = 2,


### PR DESCRIPTION
## Summary
0.8.12 introduced a new `access_token` parameter to the `clickhouse_connect.driver.HttpClient` class that is marked as `Optional[str]` but has no default value. It is properly defaulted in `create_client`, but if you directly create an instance of `HttpClient` in 0.8.12, it fails due to the missing new argument

This PR adds a `None` default value to the `HttpClient` `__init__` to mirror `create_client` and fix the issue

## Checklist
Delete items not relevant to your PR:
- [x] A human-readable description of the changes was provided to include in CHANGELOG: Set default value for the optional `access_token` parameter of the `HttpClient.__init__` method
