### PR TITLE
Fix memory leak in AsyncClient

### DIFF
--- a/clickhouse_connect/driver/asyncclient.py
+++ b/clickhouse_connect/driver/asyncclient.py
@@ -69,6 +69,7 @@ class AsyncClient:
         Subclass implementation to close the connection to the server/deallocate the client
         """
         self.client.close()
+        self.executor.shutdown(wait=False)
 
     async def query(self,
                     query: Optional[str] = None,

--- a/clickhouse_connect/driver/asyncclient.py
+++ b/clickhouse_connect/driver/asyncclient.py
@@ -64,12 +64,12 @@ class AsyncClient:
         """
         return self.client.min_version(version_str)
 
-    def close(self):
+    async def close(self):
         """
         Subclass implementation to close the connection to the server/deallocate the client
         """
         self.client.close()
-        self.executor.shutdown(wait=False)
+        await asyncio.to_thread(self.executor.shutdown, True)
 
     async def query(self,
                     query: Optional[str] = None,
@@ -677,3 +677,9 @@ class AsyncClient:
         loop = asyncio.get_running_loop()
         result = await loop.run_in_executor(self.executor, _raw_insert)
         return result
+
+    async def __aenter__(self) -> "AsyncClient":
+        return self
+
+    async def __aexit__(self, exc_type, exc_val, exc_tb) -> None:
+        await self.close()

--- a/examples/run_async.py
+++ b/examples/run_async.py
@@ -41,7 +41,7 @@ async def concurrent_queries():
 
     semaphore = asyncio.Semaphore(SEMAPHORE)
     await asyncio.gather(*[semaphore_wrapper(semaphore, num) for num in range(QUERIES)])
-    client.close()
+    await client.close()
 
 
 async def main():

--- a/examples/run_async.py
+++ b/examples/run_async.py
@@ -41,6 +41,7 @@ async def concurrent_queries():
 
     semaphore = asyncio.Semaphore(SEMAPHORE)
     await asyncio.gather(*[semaphore_wrapper(semaphore, num) for num in range(QUERIES)])
+    client.close()
 
 
 async def main():

--- a/tests/integration_tests/conftest.py
+++ b/tests/integration_tests/conftest.py
@@ -130,7 +130,7 @@ def test_client_fixture(test_config: TestConfig, test_create_client: Callable) -
 
 
 @fixture(scope='session', autouse=True, name='test_async_client')
-def test_async_client_fixture(test_client: Client) -> Iterator[AsyncClient]:
+async def test_async_client_fixture(test_client: Client) -> Iterator[AsyncClient]:
     async with AsyncClient(client=test_client):
         yield
 

--- a/tests/integration_tests/conftest.py
+++ b/tests/integration_tests/conftest.py
@@ -3,7 +3,7 @@ import os
 import random
 import time
 from subprocess import Popen, PIPE
-from typing import Iterator, NamedTuple, Sequence, Optional, Callable
+from typing import Iterator, NamedTuple, Sequence, Optional, Callable, AsyncContextManager
 
 from pytest import fixture
 
@@ -130,9 +130,9 @@ def test_client_fixture(test_config: TestConfig, test_create_client: Callable) -
 
 
 @fixture(scope='session', autouse=True, name='test_async_client')
-async def test_async_client_fixture(test_client: Client) -> Iterator[AsyncClient]:
-    async with AsyncClient(client=test_client):
-        yield
+async def test_async_client_fixture(test_client: Client) -> AsyncContextManager[AsyncClient]:
+    async with AsyncClient(client=test_client) as client:
+        yield client
 
 
 @fixture(scope='session', name='table_context')

--- a/tests/integration_tests/conftest.py
+++ b/tests/integration_tests/conftest.py
@@ -131,7 +131,8 @@ def test_client_fixture(test_config: TestConfig, test_create_client: Callable) -
 
 @fixture(scope='session', autouse=True, name='test_async_client')
 def test_async_client_fixture(test_client: Client) -> Iterator[AsyncClient]:
-    yield AsyncClient(client=test_client)
+    async with AsyncClient(client=test_client):
+        yield
 
 
 @fixture(scope='session', name='table_context')

--- a/tests/integration_tests/conftest.py
+++ b/tests/integration_tests/conftest.py
@@ -5,6 +5,7 @@ import time
 from subprocess import Popen, PIPE
 from typing import Iterator, NamedTuple, Sequence, Optional, Callable, AsyncContextManager
 
+import pytest_asyncio
 from pytest import fixture
 
 from clickhouse_connect import common
@@ -129,7 +130,7 @@ def test_client_fixture(test_config: TestConfig, test_create_client: Callable) -
             sys.stderr.write('Successfully stopped docker compose')
 
 
-@fixture(scope='session', autouse=True, name='test_async_client')
+@pytest_asyncio.fixture(scope='session', autouse=True, name='test_async_client')
 async def test_async_client_fixture(test_client: Client) -> AsyncContextManager[AsyncClient]:
     async with AsyncClient(client=test_client) as client:
         yield client

--- a/tests/integration_tests/test_session_id.py
+++ b/tests/integration_tests/test_session_id.py
@@ -46,7 +46,7 @@ async def test_async_client_default_session_id(test_config: TestConfig):
                                              user=test_config.username,
                                              password=test_config.password)
     assert async_client.get_client_setting(SESSION_KEY) is None
-    async_client.close()
+    await async_client.close()
 
 
 @pytest.mark.asyncio
@@ -62,7 +62,7 @@ async def test_async_client_autogenerate_session_id(test_config: TestConfig):
         uuid.UUID(session_id)
     except ValueError:
         pytest.fail(f"Invalid session_id: {session_id}")
-    async_client.close()
+    await async_client.close()
 
 
 @pytest.mark.asyncio
@@ -75,4 +75,4 @@ async def test_async_client_custom_session_id(test_config: TestConfig):
                                              password=test_config.password,
                                              session_id=session_id)
     assert async_client.get_client_setting(SESSION_KEY) == session_id
-    async_client.close()
+    await async_client.close()


### PR DESCRIPTION
## Summary
It's known that ThreadPoolExecutor doesn't deallocate memory without .shutdown being called. Python's GC doesn't stop running thread pools, so the code like
```python
while True:
    client = await get_async_client(...)
    ...
    client.close()
```
will be leaking memory since each new AsyncClient instance will have a new executor.

Closes https://github.com/ClickHouse/clickhouse-connect/issues/424

## Checklist
Delete items not relevant to your PR:
- [ ] Unit and integration tests covering the common scenarios were added
- [ ] A human-readable description of the changes was provided to include in CHANGELOG
- [ ] For significant changes, documentation in https://github.com/ClickHouse/clickhouse-docs was updated with further explanations or tutorials
