### PR TITLE
Fix CI tests with default user

### DIFF
--- a/.docker/clickhouse/single_node/config.xml
+++ b/.docker/clickhouse/single_node/config.xml
@@ -17,7 +17,7 @@
     <keep_alive_timeout>3</keep_alive_timeout>
 
     <logger>
-        <level>debug</level>
+        <level>warning</level>
         <log>/var/log/clickhouse-server/clickhouse-server.log</log>
         <errorlog>/var/log/clickhouse-server/clickhouse-server.err.log</errorlog>
         <size>1000M</size>

--- a/.docker/clickhouse/single_node_tls/config.xml
+++ b/.docker/clickhouse/single_node_tls/config.xml
@@ -17,7 +17,7 @@
     <access_control_path>/var/lib/clickhouse/access/</access_control_path>
 
     <logger>
-        <level>debug</level>
+        <level>warning</level>
         <log>/var/log/clickhouse-server/clickhouse-server.log</log>
         <errorlog>/var/log/clickhouse-server/clickhouse-server.err.log</errorlog>
         <size>1000M</size>

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,6 +2,8 @@ services:
   clickhouse:
     image: 'clickhouse/clickhouse-server:${CLICKHOUSE_CONNECT_TEST_CH_VERSION-24.8-alpine}'
     container_name: 'clickhouse-connect-clickhouse-server'
+    environment:
+      CLICKHOUSE_SKIP_USER_SETUP: 1
     ports:
       - '8123:8123'
       - '9000:9000'
@@ -18,6 +20,8 @@ services:
       context: ./
       dockerfile: .docker/clickhouse/single_node_tls/Dockerfile
     container_name: 'clickhouse-connect-clickhouse-server-tls'
+    environment:
+      CLICKHOUSE_SKIP_USER_SETUP: 1
     ports:
       - '10843:8443'
       - '10840:9440'


### PR DESCRIPTION
## Summary
Add environment variable to allow empty string password for default user

## Checklist
Delete items not relevant to your PR:
- [ ] Unit and integration tests covering the common scenarios were added
- [ ] A human-readable description of the changes was provided to include in CHANGELOG
- [ ] For significant changes, documentation in https://github.com/ClickHouse/clickhouse-docs was updated with further explanations or tutorials
