### PR TITLE
Replace removal of ; in the loop line with rstrip

### DIFF
--- a/clickhouse_connect/driver/binding.py
+++ b/clickhouse_connect/driver/binding.py
@@ -40,8 +40,7 @@ def quote_identifier(identifier: str):
 
 def finalize_query(query: str, parameters: Optional[Union[Sequence, Dict[str, Any]]],
                    server_tz: Optional[tzinfo] = None) -> str:
-    while query.endswith(';'):
-        query = query[:-1]
+    query = query.rstrip(";")
     if not parameters:
         return query
     if hasattr(parameters, 'items'):
@@ -52,8 +51,7 @@ def finalize_query(query: str, parameters: Optional[Union[Sequence, Dict[str, An
 # pylint: disable=too-many-locals,too-many-branches
 def bind_query(query: str, parameters: Optional[Union[Sequence, Dict[str, Any]]],
                server_tz: Optional[tzinfo] = None) -> Tuple[str, Dict[str, str]]:
-    while query.endswith(';'):
-        query = query[:-1]
+    query = query.rstrip(";")
     if not parameters:
         return query, {}
 


### PR DESCRIPTION
## Summary
Replace manual ; removal loop with rstrip method

Replaced while loop with endswith(';') check and string slicing with rstrip(";") call.

Eliminated redundant code by using a built-in method for trailing character removal.
Code is more concise and explicitly conveys intent.

`rstrip` is more efficient than sequential checks and slicing in a loop.