### PR TITLE
Fix unhandled type '<class 'pyarrow.lib.Buffer'>' in send method

### DIFF
--- a/clickhouse_connect/driver/query.py
+++ b/clickhouse_connect/driver/query.py
@@ -382,4 +382,4 @@ def arrow_buffer(table, compression: Optional[str] = None) -> Tuple[Sequence[str
     sink = pyarrow.BufferOutputStream()
     with pyarrow.RecordBatchFileWriter(sink, table.schema, options=options) as writer:
         writer.write(table)
-    return table.schema.names, sink.getvalue()
+    return table.schema.names, sink.getvalue().to_pybytes()


### PR DESCRIPTION
## Summary

`pyarrow.RecordBatchFileWriter.getvalue()` returns `pyarrow.Buffer`, and downstream call expects bytes.  This commit fixes that for `pyarrow==19.0.1`
