### PR TITLE
Correct typing of create_client(host, username)

### DIFF
--- a/clickhouse_connect/driver/__init__.py
+++ b/clickhouse_connect/driver/__init__.py
@@ -13,8 +13,8 @@ from clickhouse_connect.driver.asyncclient import AsyncClient
 
 # pylint: disable=too-many-arguments,too-many-locals,too-many-branches
 def create_client(*,
-                  host: str = None,
-                  username: str = None,
+                  host: Optional[str] = None,
+                  username: Optional[str] = None,
                   password: str = '',
                   access_token: Optional[str] = None,
                   database: str = '__default__',


### PR DESCRIPTION
## Summary

The parameters `host` and `username` of `create_client` actually do accept None values, as demonstrated by their default values being `None` and the docstring explaining default behavior when not-set.

Correcting these types (by marking as Optional) allows users using `dsn` or default behavior to not see type-checking errors.

## Checklist
Delete items not relevant to your PR:
- [x] A human-readable description of the changes was provided to include in CHANGELOG

