### PR TITLE
Add param extra_http_headers to query/command methods

### DIFF
--- a/clickhouse_connect/driver/client.py
+++ b/clickhouse_connect/driver/client.py
@@ -211,7 +211,8 @@ class Client(ABC):
               context: QueryContext = None,
               query_tz: Optional[Union[str, tzinfo]] = None,
               column_tzs: Optional[Dict[str, Union[str, tzinfo]]] = None,
-              external_data: Optional[ExternalData] = None) -> QueryResult:
+              external_data: Optional[ExternalData] = None,
+              extra_http_headers: Optional[Dict[str, str]] = None) -> QueryResult:
         """
         Main query method for SELECT, DESCRIBE and other SQL statements that return a result matrix.  For
         parameters, see the create_query_context method
@@ -227,7 +228,8 @@ class Client(ABC):
             response = self.command(query,
                                     parameters=query_context.parameters,
                                     settings=query_context.settings,
-                                    external_data=query_context.external_data)
+                                    external_data=query_context.external_data,
+                                    extra_http_headers=query_context.extra_http_headers)
             if isinstance(response, QuerySummary):
                 return response.as_query_result()
             return QueryResult([response] if isinstance(response, list) else [[response]])
@@ -244,7 +246,8 @@ class Client(ABC):
                                   context: QueryContext = None,
                                   query_tz: Optional[Union[str, tzinfo]] = None,
                                   column_tzs: Optional[Dict[str, Union[str, tzinfo]]] = None,
-                                  external_data: Optional[ExternalData] = None) -> StreamContext:
+                                  external_data: Optional[ExternalData] = None,
+                                  extra_http_headers: Optional[Dict[str, str]] = None) -> StreamContext:
         """
         Variation of main query method that returns a stream of column oriented blocks. For
         parameters, see the create_query_context method.
@@ -263,7 +266,8 @@ class Client(ABC):
                                context: QueryContext = None,
                                query_tz: Optional[Union[str, tzinfo]] = None,
                                column_tzs: Optional[Dict[str, Union[str, tzinfo]]] = None,
-                               external_data: Optional[ExternalData] = None) -> StreamContext:
+                               external_data: Optional[ExternalData] = None,
+                               extra_http_headers: Optional[Dict[str, str]] = None) -> StreamContext:
         """
         Variation of main query method that returns a stream of row oriented blocks. For
         parameters, see the create_query_context method.
@@ -282,7 +286,8 @@ class Client(ABC):
                           context: QueryContext = None,
                           query_tz: Optional[Union[str, tzinfo]] = None,
                           column_tzs: Optional[Dict[str, Union[str, tzinfo]]] = None,
-                          external_data: Optional[ExternalData] = None) -> StreamContext:
+                          external_data: Optional[ExternalData] = None,
+                          extra_http_headers: Optional[Dict[str, str]] = None) -> StreamContext:
         """
         Variation of main query method that returns a stream of row oriented blocks. For
         parameters, see the create_query_context method.
@@ -296,16 +301,19 @@ class Client(ABC):
                   settings: Optional[Dict[str, Any]] = None,
                   fmt: str = None,
                   use_database: bool = True,
-                  external_data: Optional[ExternalData] = None) -> bytes:
+                  external_data: Optional[ExternalData] = None,
+                  extra_http_headers: Optional[Dict[str, str]] = None) -> bytes:
         """
         Query method that simply returns the raw ClickHouse format bytes
         :param query: Query statement/format string
         :param parameters: Optional dictionary used to format the query
         :param settings: Optional dictionary of ClickHouse settings (key/string values)
         :param fmt: ClickHouse output format
-        :param use_database  Send the database parameter to ClickHouse so the command will be executed in the client
+        :param use_database: Send the database parameter to ClickHouse so the command will be executed in the client
          database context.
-        :param external_data  External data to send with the query
+        :param external_data: External data to send with the query
+        :param extra_http_headers: Optional dictionary of extra HTTP headers to pass to ClickHouse,
+          useful if using Proxy.
         :return: bytes representing raw ClickHouse return value based on format
         """
 
@@ -315,7 +323,8 @@ class Client(ABC):
                    settings: Optional[Dict[str, Any]] = None,
                    fmt: str = None,
                    use_database: bool = True,
-                   external_data: Optional[ExternalData] = None) -> io.IOBase:
+                   external_data: Optional[ExternalData] = None,
+                   extra_http_headers: Optional[Dict[str, str]] = None) -> io.IOBase:
         """
        Query method that returns the result as an io.IOBase iterator
        :param query: Query statement/format string
@@ -324,7 +333,9 @@ class Client(ABC):
        :param fmt: ClickHouse output format
        :param use_database  Send the database parameter to ClickHouse so the command will be executed in the client
         database context.
-       :param external_data  External data to send with the query
+       :param external_data: External data to send with the query.
+       :param extra_http_headers: Optional dictionary of extra HTTP headers to pass to ClickHouse,
+          useful if using Proxy.
        :return: io.IOBase stream/iterator for the result
        """
 
@@ -339,7 +350,8 @@ class Client(ABC):
                  use_none: Optional[bool] = None,
                  max_str_len: Optional[int] = None,
                  context: QueryContext = None,
-                 external_data: Optional[ExternalData] = None):
+                 external_data: Optional[ExternalData] = None,
+                 extra_http_headers: Optional[Dict[str, str]] = None):
         """
         Query method that returns the results as a numpy array.  For parameter values, see the
         create_query_context method
@@ -359,7 +371,8 @@ class Client(ABC):
                         use_none: Optional[bool] = None,
                         max_str_len: Optional[int] = None,
                         context: QueryContext = None,
-                        external_data: Optional[ExternalData] = None) -> StreamContext:
+                        external_data: Optional[ExternalData] = None,
+                        extra_http_headers: Optional[Dict[str, str]] = None) -> StreamContext:
         """
         Query method that returns the results as a stream of numpy arrays.  For parameter values, see the
         create_query_context method
@@ -383,7 +396,8 @@ class Client(ABC):
                  column_tzs: Optional[Dict[str, Union[str, tzinfo]]] = None,
                  context: QueryContext = None,
                  external_data: Optional[ExternalData] = None,
-                 use_extended_dtypes: Optional[bool] = None):
+                 use_extended_dtypes: Optional[bool] = None,
+                 extra_http_headers: Optional[Dict[str, str]] = None):
         """
         Query method that results the results as a pandas dataframe.  For parameter values, see the
         create_query_context method
@@ -407,7 +421,8 @@ class Client(ABC):
                         column_tzs: Optional[Dict[str, Union[str, tzinfo]]] = None,
                         context: QueryContext = None,
                         external_data: Optional[ExternalData] = None,
-                        use_extended_dtypes: Optional[bool] = None) -> StreamContext:
+                        use_extended_dtypes: Optional[bool] = None,
+                        extra_http_headers: Optional[Dict[str, str]] = None) -> StreamContext:
         """
         Query method that returns the results as a StreamContext.  For parameter values, see the
         create_query_context method
@@ -436,7 +451,8 @@ class Client(ABC):
                              streaming: bool = False,
                              as_pandas: bool = False,
                              external_data: Optional[ExternalData] = None,
-                             use_extended_dtypes: Optional[bool] = None) -> QueryContext:
+                             use_extended_dtypes: Optional[bool] = None,
+                             extra_http_headers: Optional[Dict[str, str]] = None) -> QueryContext:
         """
         Creates or updates a reusable QueryContext object
         :param query: Query statement/format string
@@ -454,10 +470,10 @@ class Client(ABC):
           structured array even with ClickHouse variable length String columns.  If 0, Numpy arrays for
           String columns will always be object arrays
         :param context: An existing QueryContext to be updated with any provided parameter values
-        :param query_tz  Either a string or a pytz tzinfo object.  (Strings will be converted to tzinfo objects).
+        :param query_tz: Either a string or a pytz tzinfo object.  (Strings will be converted to tzinfo objects).
           Values for any DateTime or DateTime64 column in the query will be converted to Python datetime.datetime
           objects with the selected timezone.
-        :param column_tzs A dictionary of column names to tzinfo objects (or strings that will be converted to
+        :param column_tzs: A dictionary of column names to tzinfo objects (or strings that will be converted to
           tzinfo objects).  The timezone will be applied to datetime objects returned in the query
         :param use_na_values: Deprecated alias for use_advanced_dtypes
         :param as_pandas Return the result columns as pandas.Series objects
@@ -466,6 +482,8 @@ class Client(ABC):
         :param use_extended_dtypes:  Only relevant to Pandas Dataframe queries.  Use Pandas "missing types", such as
           pandas.NA and pandas.NaT for ClickHouse NULL values, as well as extended Pandas dtypes such as IntegerArray
           and StringArray.  Defaulted to True for query_df methods
+        :param extra_http_headers: Optional dictionary of extra HTTP headers to pass to ClickHouse,
+          useful if using Proxy.
         :return: Reusable QueryContext
         """
         if context:
@@ -509,21 +527,25 @@ class Client(ABC):
                             as_pandas=as_pandas,
                             streaming=streaming,
                             apply_server_tz=self.apply_server_timezone,
-                            external_data=external_data)
+                            external_data=external_data,
+                            extra_http_headers=extra_http_headers)
 
     def query_arrow(self,
                     query: str,
                     parameters: Optional[Union[Sequence, Dict[str, Any]]] = None,
                     settings: Optional[Dict[str, Any]] = None,
                     use_strings: Optional[bool] = None,
-                    external_data: Optional[ExternalData] = None):
+                    external_data: Optional[ExternalData] = None,
+                    extra_http_headers: Optional[Dict[str, str]] = None):
         """
         Query method using the ClickHouse Arrow format to return a PyArrow table
         :param query: Query statement/format string
         :param parameters: Optional dictionary used to format the query
         :param settings: Optional dictionary of ClickHouse settings (key/string values)
-        :param use_strings:  Convert ClickHouse String type to Arrow string type (instead of binary)
-        :param external_data ClickHouse "external data" to send with query
+        :param use_strings: Convert ClickHouse String type to Arrow string type (instead of binary)
+        :param external_data: ClickHouse "external data" to send with query
+        :param extra_http_headers: Optional dictionary of extra HTTP headers to pass to ClickHouse,
+          useful if using Proxy.
         :return: PyArrow.Table
         """
         check_arrow()
@@ -532,21 +554,25 @@ class Client(ABC):
                                        parameters,
                                        settings,
                                        fmt='Arrow',
-                                       external_data=external_data))
+                                       external_data=external_data,
+                                       extra_http_headers=extra_http_headers))
 
     def query_arrow_stream(self,
                            query: str,
                            parameters: Optional[Union[Sequence, Dict[str, Any]]] = None,
                            settings: Optional[Dict[str, Any]] = None,
                            use_strings: Optional[bool] = None,
-                           external_data: Optional[ExternalData] = None) -> StreamContext:
+                           external_data: Optional[ExternalData] = None,
+                           extra_http_headers: Optional[Dict[str, str]] = None) -> StreamContext:
         """
         Query method that returns the results as a stream of Arrow tables
         :param query: Query statement/format string
         :param parameters: Optional dictionary used to format the query
         :param settings: Optional dictionary of ClickHouse settings (key/string values)
-        :param use_strings:  Convert ClickHouse String type to Arrow string type (instead of binary)
-        :param external_data ClickHouse "external data" to send with query
+        :param use_strings: Convert ClickHouse String type to Arrow string type (instead of binary)
+        :param external_data: ClickHouse "external data" to send with query
+        :param extra_http_headers: Optional dictionary of extra HTTP headers to pass to ClickHouse,
+          useful if using Proxy.
         :return: Generator that yields a PyArrow.Table for per block representing the result set
         """
         check_arrow()
@@ -555,7 +581,8 @@ class Client(ABC):
                                                 parameters,
                                                 settings,
                                                 fmt='ArrowStream',
-                                                external_data=external_data))
+                                                external_data=external_data,
+                                                extra_http_headers=extra_http_headers))
 
     def _update_arrow_settings(self,
                                settings: Optional[Dict[str, Any]],
@@ -580,7 +607,8 @@ class Client(ABC):
                 data: Union[str, bytes] = None,
                 settings: Dict[str, Any] = None,
                 use_database: bool = True,
-                external_data: Optional[ExternalData] = None) -> Union[str, int, Sequence[str], QuerySummary]:
+                external_data: Optional[ExternalData] = None,
+                extra_http_headers: Optional[Dict[str, str]] = None) -> Union[str, int, Sequence[str], QuerySummary]:
         """
         Client method that returns a single value instead of a result set
         :param cmd: ClickHouse query/command as a python format string
@@ -588,9 +616,11 @@ class Client(ABC):
         :param data: Optional 'data' for the command (for INSERT INTO in particular)
         :param settings: Optional dictionary of ClickHouse settings (key/string values)
         :param use_database: Send the database parameter to ClickHouse so the command will be executed in the client
-         database context.  Otherwise, no database will be specified with the command.  This is useful for determining
+         database context. Otherwise, no database will be specified with the command.  This is useful for determining
          the default user database
-        :param external_data ClickHouse "external data" to send with command/query
+        :param external_data: ClickHouse "external data" to send with command/query
+        :param extra_http_headers: Optional dictionary of extra HTTP headers to pass to ClickHouse,
+          useful if using Proxy.
         :return: Decoded response from ClickHouse as either a string, int, or sequence of strings, or QuerySummary
         if no data returned
         """

--- a/clickhouse_connect/driver/httpclient.py
+++ b/clickhouse_connect/driver/httpclient.py
@@ -200,7 +200,7 @@ class HttpClient(Client):
         return final_query + fmt
 
     def _query_with_context(self, context: QueryContext) -> QueryResult:
-        headers = {}
+        headers = {**context.extra_http_headers}
         params = {}
         if self.database:
             params['database'] = self.database
@@ -328,7 +328,8 @@ class HttpClient(Client):
                 data: Union[str, bytes] = None,
                 settings: Optional[Dict] = None,
                 use_database: int = True,
-                external_data: Optional[ExternalData] = None) -> Union[str, int, Sequence[str], QuerySummary]:
+                external_data: Optional[ExternalData] = None,
+                extra_http_headers: Optional[Dict[str, str]] = None) -> Union[str, int, Sequence[str], QuerySummary]:
         """
         See BaseClient doc_string for this method
         """
@@ -478,24 +479,27 @@ class HttpClient(Client):
                   settings: Optional[Dict[str, Any]] = None,
                   fmt: str = None,
                   use_database: bool = True,
-                  external_data: Optional[ExternalData] = None) -> bytes:
+                  external_data: Optional[ExternalData] = None,
+                  extra_http_headers: Optional[Dict[str, str]] = None) -> bytes:
         """
         See BaseClient doc_string for this method
         """
         body, params, fields = self._prep_raw_query(query, parameters, settings, fmt, use_database, external_data)
-        return self._raw_request(body, params, fields=fields).data
+        return self._raw_request(body, params, fields=fields, headers=extra_http_headers).data
 
     def raw_stream(self, query: str,
                    parameters: Optional[Union[Sequence, Dict[str, Any]]] = None,
                    settings: Optional[Dict[str, Any]] = None,
                    fmt: str = None,
                    use_database: bool = True,
-                   external_data: Optional[ExternalData] = None) -> io.IOBase:
+                   external_data: Optional[ExternalData] = None,
+                   extra_http_headers: Optional[Dict[str, str]] = None) -> io.IOBase:
         """
         See BaseClient doc_string for this method
         """
         body, params, fields = self._prep_raw_query(query, parameters, settings, fmt, use_database, external_data)
-        return self._raw_request(body, params, fields=fields, stream=True, server_wait=False)
+        return self._raw_request(body, params, fields=fields, stream=True, server_wait=False,
+                                 headers=extra_http_headers)
 
     def _prep_raw_query(self, query: str,
                         parameters: Optional[Union[Sequence, Dict[str, Any]]],

--- a/clickhouse_connect/driver/query.py
+++ b/clickhouse_connect/driver/query.py
@@ -52,7 +52,8 @@ class QueryContext(BaseQueryContext):
                  as_pandas: bool = False,
                  streaming: bool = False,
                  apply_server_tz: bool = False,
-                 external_data: Optional[ExternalData] = None):
+                 external_data: Optional[ExternalData] = None,
+                 extra_http_headers: Optional[Dict[str, str]] = None):
         """
         Initializes various configuration settings for the query context
 
@@ -116,6 +117,7 @@ class QueryContext(BaseQueryContext):
         self.as_pandas = as_pandas
         self.use_pandas_na = as_pandas and pd_extended_dtypes
         self.streaming = streaming
+        self.extra_http_headers = extra_http_headers
         self._update_query()
 
     @property
@@ -189,7 +191,8 @@ class QueryContext(BaseQueryContext):
                      use_extended_dtypes: Optional[bool] = None,
                      as_pandas: bool = False,
                      streaming: bool = False,
-                     external_data: Optional[ExternalData] = None) -> 'QueryContext':
+                     external_data: Optional[ExternalData] = None,
+                     extra_http_headers: Optional[Dict[str, str]] = None) -> 'QueryContext':
         """
         Creates Query context copy with parameters overridden/updated as appropriate.
         """
@@ -210,7 +213,8 @@ class QueryContext(BaseQueryContext):
                             as_pandas,
                             streaming,
                             self.apply_server_tz,
-                            self.external_data if external_data is None else external_data)
+                            self.external_data if external_data is None else external_data,
+                            self.extra_http_headers if extra_http_headers is None else extra_http_headers)
 
     def _update_query(self):
         self.final_query, self.bind_params = bind_query(self.query, self.parameters, self.server_tz)


### PR DESCRIPTION
## Summary

Allow specifying extra params when sending a query to ClickHouse.

Use case: when one have multiple replicas and want to separate traffic at the proxy level or queue queries.
Allows to pass headers: `X-Workload: online`, `X-Customer-Id: 123`.

## Checklist
Delete items not relevant to your PR:
- [ ] Unit and integration tests covering the common scenarios were added
- [X] A human-readable description of the changes was provided to include in CHANGELOG
- [ ] For significant changes, documentation in https://github.com/ClickHouse/clickhouse-docs was updated with further explanations or tutorials
