### PR TITLE
Change extra_http_headers to transport_settings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,15 +22,20 @@ instead of being passed as ClickHouse server settings. This is in conjunction wi
 The supported method of passing ClickHouse server settings is to prefix such arguments/query parameters with`ch_`.
 
 ## 0.8.17, 2025-04-10
-### Bug Fix
-- Version 0.8.16 introduced a bug where changing a Client setting value and then changing that setting value back to the
-original server value would fail to restore the original setting.  This has been fixed.  Closes
-https://github.com/ClickHouse/clickhouse-connect/issues/487
 
-### Improvement
+### Improvements
+- The parameter `transport_settings` has been added to the Client query and insert methods.  For the HTTP client (currently
+the only  option), this dictionary of string is directly translated into additional HTTP headers at a query level.  This can
+be used to provide additional proxy directives or other extra 'non-ClickHouse' information that is passed via headers.
+Thanks to [Paweł Szczur](https://github.com/orian) of PostHog for the original PR!
 - There was previously no way to add a path to the ClickHouse server host in cases where the ClickHouse server was
 behind a proxy that used path based routing (such as `https://big_proxy:8080/clickhouse).  The new `proxy_path`
 `get_client` argument can now be used to set that path.  Closes https://github.com/ClickHouse/clickhouse-connect/issues/486
+
+### Bug Fix
+- Version 0.8.16 introduced a bug where changing a Client setting value and then changing that setting value back to the
+  original server value would fail to restore the original setting.  This has been fixed.  Closes
+  https://github.com/ClickHouse/clickhouse-connect/issues/487
 
 ## 0.8.16, 2025-03-28
 ### Bug Fixes

--- a/clickhouse_connect/driver/asyncclient.py
+++ b/clickhouse_connect/driver/asyncclient.py
@@ -85,7 +85,8 @@ class AsyncClient:
                     context: QueryContext = None,
                     query_tz: Optional[Union[str, tzinfo]] = None,
                     column_tzs: Optional[Dict[str, Union[str, tzinfo]]] = None,
-                    external_data: Optional[ExternalData] = None) -> QueryResult:
+                    external_data: Optional[ExternalData] = None,
+                    transport_settings: Optional[Dict[str, str]] = None) -> QueryResult:
         """
         Main query method for SELECT, DESCRIBE and other SQL statements that return a result matrix.
         For parameters, see the create_query_context method.
@@ -97,7 +98,7 @@ class AsyncClient:
                                      column_formats=column_formats, encoding=encoding, use_none=use_none,
                                      column_oriented=column_oriented, use_numpy=use_numpy, max_str_len=max_str_len,
                                      context=context, query_tz=query_tz, column_tzs=column_tzs,
-                                     external_data=external_data)
+                                     external_data=external_data, transport_settings=transport_settings)
 
         loop = asyncio.get_running_loop()
         result = await loop.run_in_executor(self.executor, _query)
@@ -114,7 +115,9 @@ class AsyncClient:
                                         context: QueryContext = None,
                                         query_tz: Optional[Union[str, tzinfo]] = None,
                                         column_tzs: Optional[Dict[str, Union[str, tzinfo]]] = None,
-                                        external_data: Optional[ExternalData] = None) -> StreamContext:
+                                        external_data: Optional[ExternalData] = None,
+                                        transport_settings: Optional[Dict[str, str]] = None,
+                                        ) -> StreamContext:
         """
         Variation of main query method that returns a stream of column oriented blocks.
         For parameters, see the create_query_context method.
@@ -126,7 +129,7 @@ class AsyncClient:
                                                          query_formats=query_formats, column_formats=column_formats,
                                                          encoding=encoding, use_none=use_none, context=context,
                                                          query_tz=query_tz, column_tzs=column_tzs,
-                                                         external_data=external_data)
+                                                         external_data=external_data, transport_settings=transport_settings)
 
         loop = asyncio.get_running_loop()
         result = await loop.run_in_executor(self.executor, _query_column_block_stream)
@@ -143,7 +146,8 @@ class AsyncClient:
                                      context: QueryContext = None,
                                      query_tz: Optional[Union[str, tzinfo]] = None,
                                      column_tzs: Optional[Dict[str, Union[str, tzinfo]]] = None,
-                                     external_data: Optional[ExternalData] = None) -> StreamContext:
+                                     external_data: Optional[ExternalData] = None,
+                                     transport_settings: Optional[Dict[str, str]] = None) -> StreamContext:
         """
         Variation of main query method that returns a stream of row oriented blocks.
         For parameters, see the create_query_context method.
@@ -155,7 +159,7 @@ class AsyncClient:
                                                       query_formats=query_formats, column_formats=column_formats,
                                                       encoding=encoding, use_none=use_none, context=context,
                                                       query_tz=query_tz, column_tzs=column_tzs,
-                                                      external_data=external_data)
+                                                      external_data=external_data, transport_settings=transport_settings)
 
         loop = asyncio.get_running_loop()
         result = await loop.run_in_executor(self.executor, _query_row_block_stream)
@@ -172,7 +176,8 @@ class AsyncClient:
                                 context: QueryContext = None,
                                 query_tz: Optional[Union[str, tzinfo]] = None,
                                 column_tzs: Optional[Dict[str, Union[str, tzinfo]]] = None,
-                                external_data: Optional[ExternalData] = None) -> StreamContext:
+                                external_data: Optional[ExternalData] = None,
+                                transport_settings: Optional[Dict[str, str]] = None) -> StreamContext:
         """
         Variation of main query method that returns a stream of row oriented blocks.
         For parameters, see the create_query_context method.
@@ -184,7 +189,7 @@ class AsyncClient:
                                                  query_formats=query_formats, column_formats=column_formats,
                                                  encoding=encoding, use_none=use_none, context=context,
                                                  query_tz=query_tz, column_tzs=column_tzs,
-                                                 external_data=external_data)
+                                                 external_data=external_data, transport_settings=transport_settings)
 
         loop = asyncio.get_running_loop()
         result = await loop.run_in_executor(self.executor, _query_rows_stream)
@@ -196,7 +201,8 @@ class AsyncClient:
                         settings: Optional[Dict[str, Any]] = None,
                         fmt: str = None,
                         use_database: bool = True,
-                        external_data: Optional[ExternalData] = None) -> bytes:
+                        external_data: Optional[ExternalData] = None,
+                        transport_settings: Optional[Dict[str, str]] = None) -> bytes:
         """
         Query method that simply returns the raw ClickHouse format bytes.
         :param query: Query statement/format string
@@ -206,12 +212,14 @@ class AsyncClient:
         :param use_database  Send the database parameter to ClickHouse so the command will be executed in the client
          database context
         :param external_data  External data to send with the query
+        :param transport_settings: Optional dictionary of transport level settings (HTTP headers, etc.)
         :return: bytes representing raw ClickHouse return value based on format
         """
 
         def _raw_query():
             return self.client.raw_query(query=query, parameters=parameters, settings=settings, fmt=fmt,
-                                         use_database=use_database, external_data=external_data)
+                                         use_database=use_database, external_data=external_data,
+                                         transport_settings=transport_settings)
 
         loop = asyncio.get_running_loop()
         result = await loop.run_in_executor(self.executor, _raw_query)
@@ -222,7 +230,8 @@ class AsyncClient:
                          settings: Optional[Dict[str, Any]] = None,
                          fmt: str = None,
                          use_database: bool = True,
-                         external_data: Optional[ExternalData] = None) -> io.IOBase:
+                         external_data: Optional[ExternalData] = None,
+                         transport_settings: Optional[Dict[str, str]] = None) -> io.IOBase:
         """
         Query method that returns the result as an io.IOBase iterator.
         :param query: Query statement/format string
@@ -232,12 +241,13 @@ class AsyncClient:
         :param use_database  Send the database parameter to ClickHouse so the command will be executed in the client
          database context
         :param external_data  External data to send with the query
+        :param transport_settings: Optional dictionary of transport level settings (HTTP headers, etc.)
         :return: io.IOBase stream/iterator for the result
         """
 
         def _raw_stream():
             return self.client.raw_stream(query=query, parameters=parameters, settings=settings, fmt=fmt,
-                                          use_database=use_database, external_data=external_data)
+                                          use_database=use_database, external_data=external_data, transport_settings=transport_settings)
 
         loop = asyncio.get_running_loop()
         result = await loop.run_in_executor(self.executor, _raw_stream)
@@ -253,7 +263,8 @@ class AsyncClient:
                        use_none: Optional[bool] = None,
                        max_str_len: Optional[int] = None,
                        context: QueryContext = None,
-                       external_data: Optional[ExternalData] = None):
+                       external_data: Optional[ExternalData] = None,
+                       transport_settings: Optional[Dict[str, str]] = None):
         """
         Query method that returns the results as a numpy array.
         For parameter values, see the create_query_context method.
@@ -264,7 +275,7 @@ class AsyncClient:
             return self.client.query_np(query=query, parameters=parameters, settings=settings,
                                         query_formats=query_formats, column_formats=column_formats, encoding=encoding,
                                         use_none=use_none, max_str_len=max_str_len, context=context,
-                                        external_data=external_data)
+                                        external_data=external_data, transport_settings=transport_settings)
 
         loop = asyncio.get_running_loop()
         result = await loop.run_in_executor(self.executor, _query_np)
@@ -280,7 +291,8 @@ class AsyncClient:
                               use_none: Optional[bool] = None,
                               max_str_len: Optional[int] = None,
                               context: QueryContext = None,
-                              external_data: Optional[ExternalData] = None) -> StreamContext:
+                              external_data: Optional[ExternalData] = None,
+                              transport_settings: Optional[Dict[str, str]] = None) -> StreamContext:
         """
         Query method that returns the results as a stream of numpy arrays.
         For parameter values, see the create_query_context method.
@@ -291,7 +303,7 @@ class AsyncClient:
             return self.client.query_np_stream(query=query, parameters=parameters, settings=settings,
                                                query_formats=query_formats, column_formats=column_formats,
                                                encoding=encoding, use_none=use_none, max_str_len=max_str_len,
-                                               context=context, external_data=external_data)
+                                               context=context, external_data=external_data, transport_settings=transport_settings)
 
         loop = asyncio.get_running_loop()
         result = await loop.run_in_executor(self.executor, _query_np_stream)
@@ -311,7 +323,8 @@ class AsyncClient:
                        column_tzs: Optional[Dict[str, Union[str, tzinfo]]] = None,
                        context: QueryContext = None,
                        external_data: Optional[ExternalData] = None,
-                       use_extended_dtypes: Optional[bool] = None):
+                       use_extended_dtypes: Optional[bool] = None,
+                       transport_settings: Optional[Dict[str, str]] = None):
         """
         Query method that results the results as a pandas dataframe.
         For parameter values, see the create_query_context method.
@@ -323,7 +336,8 @@ class AsyncClient:
                                         query_formats=query_formats, column_formats=column_formats, encoding=encoding,
                                         use_none=use_none, max_str_len=max_str_len, use_na_values=use_na_values,
                                         query_tz=query_tz, column_tzs=column_tzs, context=context,
-                                        external_data=external_data, use_extended_dtypes=use_extended_dtypes)
+                                        external_data=external_data, use_extended_dtypes=use_extended_dtypes,
+                                        transport_settings=transport_settings)
 
         loop = asyncio.get_running_loop()
         result = await loop.run_in_executor(self.executor, _query_df)
@@ -343,7 +357,8 @@ class AsyncClient:
                               column_tzs: Optional[Dict[str, Union[str, tzinfo]]] = None,
                               context: QueryContext = None,
                               external_data: Optional[ExternalData] = None,
-                              use_extended_dtypes: Optional[bool] = None) -> StreamContext:
+                              use_extended_dtypes: Optional[bool] = None,
+                              transport_settings: Optional[Dict[str, str]] = None) -> StreamContext:
         """
         Query method that returns the results as a StreamContext.
         For parameter values, see the create_query_context method.
@@ -356,7 +371,8 @@ class AsyncClient:
                                                encoding=encoding,
                                                use_none=use_none, max_str_len=max_str_len, use_na_values=use_na_values,
                                                query_tz=query_tz, column_tzs=column_tzs, context=context,
-                                               external_data=external_data, use_extended_dtypes=use_extended_dtypes)
+                                               external_data=external_data, use_extended_dtypes=use_extended_dtypes,
+                                               transport_settings=transport_settings)
 
         loop = asyncio.get_running_loop()
         result = await loop.run_in_executor(self.executor, _query_df_stream)
@@ -380,7 +396,8 @@ class AsyncClient:
                              streaming: bool = False,
                              as_pandas: bool = False,
                              external_data: Optional[ExternalData] = None,
-                             use_extended_dtypes: Optional[bool] = None) -> QueryContext:
+                             use_extended_dtypes: Optional[bool] = None,
+                             transport_settings: Optional[Dict[str, str]] = None) -> QueryContext:
         """
         Creates or updates a reusable QueryContext object
         :param query: Query statement/format string
@@ -410,6 +427,7 @@ class AsyncClient:
         :param use_extended_dtypes:  Only relevant to Pandas Dataframe queries.  Use Pandas "missing types", such as
           pandas.NA and pandas.NaT for ClickHouse NULL values, as well as extended Pandas dtypes such as IntegerArray
           and StringArray.  Defaulted to True for query_df methods
+        :param transport_settings: Optional dictionary of transport level settings (HTTP headers, etc.)
         :return: Reusable QueryContext
         """
 
@@ -422,14 +440,16 @@ class AsyncClient:
                                                 use_na_values=use_na_values,
                                                 streaming=streaming, as_pandas=as_pandas,
                                                 external_data=external_data,
-                                                use_extended_dtypes=use_extended_dtypes)
+                                                use_extended_dtypes=use_extended_dtypes,
+                                                transport_settings=transport_settings)
 
     async def query_arrow(self,
                           query: str,
                           parameters: Optional[Union[Sequence, Dict[str, Any]]] = None,
                           settings: Optional[Dict[str, Any]] = None,
                           use_strings: Optional[bool] = None,
-                          external_data: Optional[ExternalData] = None):
+                          external_data: Optional[ExternalData] = None,
+                          transport_settings: Optional[Dict[str, str]] = None):
         """
         Query method using the ClickHouse Arrow format to return a PyArrow table
         :param query: Query statement/format string
@@ -437,12 +457,14 @@ class AsyncClient:
         :param settings: Optional dictionary of ClickHouse settings (key/string values)
         :param use_strings:  Convert ClickHouse String type to Arrow string type (instead of binary)
         :param external_data ClickHouse "external data" to send with query
+        :param transport_settings: Optional dictionary of transport level settings (HTTP headers, etc.)
         :return: PyArrow.Table
         """
 
         def _query_arrow():
             return self.client.query_arrow(query=query, parameters=parameters, settings=settings,
-                                           use_strings=use_strings, external_data=external_data)
+                                           use_strings=use_strings, external_data=external_data,
+                                           transport_settings=transport_settings)
 
         loop = asyncio.get_running_loop()
         result = await loop.run_in_executor(self.executor, _query_arrow)
@@ -453,7 +475,8 @@ class AsyncClient:
                                  parameters: Optional[Union[Sequence, Dict[str, Any]]] = None,
                                  settings: Optional[Dict[str, Any]] = None,
                                  use_strings: Optional[bool] = None,
-                                 external_data: Optional[ExternalData] = None) -> StreamContext:
+                                 external_data: Optional[ExternalData] = None,
+                                 transport_settings: Optional[Dict[str, str]] = None) -> StreamContext:
         """
         Query method that returns the results as a stream of Arrow tables
         :param query: Query statement/format string
@@ -461,12 +484,14 @@ class AsyncClient:
         :param settings: Optional dictionary of ClickHouse settings (key/string values)
         :param use_strings:  Convert ClickHouse String type to Arrow string type (instead of binary)
         :param external_data ClickHouse "external data" to send with query
+        :param transport_settings: Optional dictionary of transport level settings (HTTP headers, etc.)
         :return: Generator that yields a PyArrow.Table for per block representing the result set
         """
 
         def _query_arrow_stream():
             return self.client.query_arrow_stream(query=query, parameters=parameters, settings=settings,
-                                                  use_strings=use_strings, external_data=external_data)
+                                                  use_strings=use_strings, external_data=external_data,
+                                                  transport_settings=transport_settings)
 
         loop = asyncio.get_running_loop()
         result = await loop.run_in_executor(self.executor, _query_arrow_stream)
@@ -478,7 +503,8 @@ class AsyncClient:
                       data: Union[str, bytes] = None,
                       settings: Dict[str, Any] = None,
                       use_database: bool = True,
-                      external_data: Optional[ExternalData] = None) -> Union[str, int, Sequence[str], QuerySummary]:
+                      external_data: Optional[ExternalData] = None,
+                      transport_settings: Optional[Dict[str, str]] = None) -> Union[str, int, Sequence[str], QuerySummary]:
         """
         Client method that returns a single value instead of a result set
         :param cmd: ClickHouse query/command as a python format string
@@ -489,13 +515,15 @@ class AsyncClient:
          database context.  Otherwise, no database will be specified with the command.  This is useful for determining
          the default user database
         :param external_data ClickHouse "external data" to send with command/query
+        :param transport_settings: Optional dictionary of transport level settings (HTTP headers, etc.)
         :return: Decoded response from ClickHouse as either a string, int, or sequence of strings, or QuerySummary
         if no data returned
         """
 
         def _command():
             return self.client.command(cmd=cmd, parameters=parameters, data=data, settings=settings,
-                                       use_database=use_database, external_data=external_data)
+                                       use_database=use_database, external_data=external_data,
+                                       transport_settings=transport_settings)
 
         loop = asyncio.get_running_loop()
         result = await loop.run_in_executor(self.executor, _command)
@@ -523,7 +551,8 @@ class AsyncClient:
                      column_type_names: Sequence[str] = None,
                      column_oriented: bool = False,
                      settings: Optional[Dict[str, Any]] = None,
-                     context: InsertContext = None) -> QuerySummary:
+                     context: InsertContext = None,
+                     transport_settings: Optional[Dict[str, str]] = None) -> QuerySummary:
         """
         Method to insert multiple rows/data matrix of native Python objects.  If context is specified arguments
         other than data are ignored
@@ -540,13 +569,15 @@ class AsyncClient:
         :param settings: Optional dictionary of ClickHouse settings (key/string values)
         :param context: Optional reusable insert context to allow repeated inserts into the same table with
             different data batches
+        :param transport_settings: Optional dictionary of transport level settings (HTTP headers, etc.)
         :return: QuerySummary with summary information, throws exception if insert fails
         """
 
         def _insert():
             return self.client.insert(table=table, data=data, column_names=column_names, database=database,
                                       column_types=column_types, column_type_names=column_type_names,
-                                      column_oriented=column_oriented, settings=settings, context=context)
+                                      column_oriented=column_oriented, settings=settings, context=context,
+                                      transport_settings=transport_settings)
 
         loop = asyncio.get_running_loop()
         result = await loop.run_in_executor(self.executor, _insert)
@@ -559,7 +590,8 @@ class AsyncClient:
                         column_names: Optional[Sequence[str]] = None,
                         column_types: Sequence[ClickHouseType] = None,
                         column_type_names: Sequence[str] = None,
-                        context: InsertContext = None) -> QuerySummary:
+                        context: InsertContext = None,
+                        transport_settings: Optional[Dict[str, str]] = None) -> QuerySummary:
         """
         Insert a pandas DataFrame into ClickHouse.  If context is specified arguments other than df are ignored
         :param table: ClickHouse table
@@ -574,6 +606,7 @@ class AsyncClient:
             retrieved from the server
         :param context: Optional reusable insert context to allow repeated inserts into the same table with
             different data batches
+        :param transport_settings: Optional dictionary of transport level settings (HTTP headers, etc.)
         :return: QuerySummary with summary information, throws exception if insert fails
         """
 
@@ -581,7 +614,7 @@ class AsyncClient:
             return self.client.insert_df(table=table, df=df, database=database, settings=settings,
                                          column_names=column_names,
                                          column_types=column_types, column_type_names=column_type_names,
-                                         context=context)
+                                         context=context, transport_settings=transport_settings)
 
         loop = asyncio.get_running_loop()
         result = await loop.run_in_executor(self.executor, _insert_df)
@@ -589,18 +622,21 @@ class AsyncClient:
 
     async def insert_arrow(self, table: str,
                            arrow_table, database: str = None,
-                           settings: Optional[Dict] = None) -> QuerySummary:
+                           settings: Optional[Dict] = None,
+                           transport_settings: Optional[Dict[str, str]] = None) -> QuerySummary:
         """
         Insert a PyArrow table DataFrame into ClickHouse using raw Arrow format
         :param table: ClickHouse table
         :param arrow_table: PyArrow Table object
         :param database: Optional ClickHouse database
         :param settings: Optional dictionary of ClickHouse settings (key/string values)
+        :param transport_settings: Optional dictionary of transport level settings (HTTP headers, etc.)
         :return: QuerySummary with summary information, throws exception if insert fails
         """
 
         def _insert_arrow():
-            return self.client.insert_arrow(table=table, arrow_table=arrow_table, database=database, settings=settings)
+            return self.client.insert_arrow(table=table, arrow_table=arrow_table, database=database,
+                                            settings=settings, transport_settings=transport_settings)
 
         loop = asyncio.get_running_loop()
         result = await loop.run_in_executor(self.executor, _insert_arrow)
@@ -614,7 +650,8 @@ class AsyncClient:
                                     column_type_names: Sequence[str] = None,
                                     column_oriented: bool = False,
                                     settings: Optional[Dict[str, Any]] = None,
-                                    data: Optional[Sequence[Sequence[Any]]] = None) -> InsertContext:
+                                    data: Optional[Sequence[Sequence[Any]]] = None,
+                                    transport_settings: Optional[Dict[str, str]] = None) -> InsertContext:
         """
         Builds a reusable insert context to hold state for a duration of an insert
         :param table: Target table
@@ -628,13 +665,15 @@ class AsyncClient:
         :param column_oriented: If true the data is already "pivoted" in column form
         :param settings: Optional dictionary of ClickHouse settings (key/string values)
         :param data: Initial dataset for insert
-        :return Reusable insert context
+        :param transport_settings: Optional dictionary of transport level settings (HTTP headers, etc.)
+        :return: Reusable insert context
         """
 
         def _create_insert_context():
             return self.client.create_insert_context(table=table, column_names=column_names, database=database,
                                                      column_types=column_types, column_type_names=column_type_names,
-                                                     column_oriented=column_oriented, settings=settings, data=data)
+                                                     column_oriented=column_oriented, settings=settings, data=data,
+                                                     transport_settings=transport_settings)
 
         loop = asyncio.get_running_loop()
         result = await loop.run_in_executor(self.executor, _create_insert_context)
@@ -659,7 +698,8 @@ class AsyncClient:
                          insert_block: Union[str, bytes, Generator[bytes, None, None], BinaryIO] = None,
                          settings: Optional[Dict] = None,
                          fmt: Optional[str] = None,
-                         compression: Optional[str] = None) -> QuerySummary:
+                         compression: Optional[str] = None,
+                         transport_settings: Optional[Dict[str, str]] = None) -> QuerySummary:
         """
         Insert data already formatted in a bytes object
         :param table: Table name (whether qualified with the database name or not)
@@ -667,12 +707,14 @@ class AsyncClient:
         :param insert_block: Binary or string data already in a recognized ClickHouse format
         :param settings:  Optional dictionary of ClickHouse settings (key/string values)
         :param compression:  Recognized ClickHouse `Accept-Encoding` header compression value
+        :param transport_settings: Optional dictionary of transport level settings (HTTP headers, etc.)
         :param fmt: Valid clickhouse format
         """
 
         def _raw_insert():
             return self.client.raw_insert(table=table, column_names=column_names, insert_block=insert_block,
-                                          settings=settings, fmt=fmt, compression=compression)
+                                          settings=settings, fmt=fmt, compression=compression,
+                                          transport_settings=transport_settings)
 
         loop = asyncio.get_running_loop()
         result = await loop.run_in_executor(self.executor, _raw_insert)

--- a/clickhouse_connect/driver/client.py
+++ b/clickhouse_connect/driver/client.py
@@ -213,7 +213,7 @@ class Client(ABC):
               query_tz: Optional[Union[str, tzinfo]] = None,
               column_tzs: Optional[Dict[str, Union[str, tzinfo]]] = None,
               external_data: Optional[ExternalData] = None,
-              extra_http_headers: Optional[Dict[str, str]] = None) -> QueryResult:
+              transport_settings: Optional[Dict[str, str]] = None) -> QueryResult:
         """
         Main query method for SELECT, DESCRIBE and other SQL statements that return a result matrix.  For
         parameters, see the create_query_context method
@@ -230,7 +230,7 @@ class Client(ABC):
                                     parameters=query_context.parameters,
                                     settings=query_context.settings,
                                     external_data=query_context.external_data,
-                                    extra_http_headers=query_context.extra_http_headers)
+                                    transport_settings=query_context.transport_settings)
             if isinstance(response, QuerySummary):
                 return response.as_query_result()
             return QueryResult([response] if isinstance(response, list) else [[response]])
@@ -248,7 +248,7 @@ class Client(ABC):
                                   query_tz: Optional[Union[str, tzinfo]] = None,
                                   column_tzs: Optional[Dict[str, Union[str, tzinfo]]] = None,
                                   external_data: Optional[ExternalData] = None,
-                                  extra_http_headers: Optional[Dict[str, str]] = None) -> StreamContext:
+                                  transport_settings: Optional[Dict[str, str]] = None) -> StreamContext:
         """
         Variation of main query method that returns a stream of column oriented blocks. For
         parameters, see the create_query_context method.
@@ -268,7 +268,7 @@ class Client(ABC):
                                query_tz: Optional[Union[str, tzinfo]] = None,
                                column_tzs: Optional[Dict[str, Union[str, tzinfo]]] = None,
                                external_data: Optional[ExternalData] = None,
-                               extra_http_headers: Optional[Dict[str, str]] = None) -> StreamContext:
+                               transport_settings: Optional[Dict[str, str]] = None) -> StreamContext:
         """
         Variation of main query method that returns a stream of row oriented blocks. For
         parameters, see the create_query_context method.
@@ -288,7 +288,7 @@ class Client(ABC):
                           query_tz: Optional[Union[str, tzinfo]] = None,
                           column_tzs: Optional[Dict[str, Union[str, tzinfo]]] = None,
                           external_data: Optional[ExternalData] = None,
-                          extra_http_headers: Optional[Dict[str, str]] = None) -> StreamContext:
+                          transport_settings: Optional[Dict[str, str]] = None) -> StreamContext:
         """
         Variation of main query method that returns a stream of row oriented blocks. For
         parameters, see the create_query_context method.
@@ -303,7 +303,7 @@ class Client(ABC):
                   fmt: str = None,
                   use_database: bool = True,
                   external_data: Optional[ExternalData] = None,
-                  extra_http_headers: Optional[Dict[str, str]] = None) -> bytes:
+                  transport_settings: Optional[Dict[str, str]] = None) -> bytes:
         """
         Query method that simply returns the raw ClickHouse format bytes
         :param query: Query statement/format string
@@ -313,8 +313,7 @@ class Client(ABC):
         :param use_database: Send the database parameter to ClickHouse so the command will be executed in the client
          database context.
         :param external_data: External data to send with the query
-        :param extra_http_headers: Optional dictionary of extra HTTP headers to pass to ClickHouse,
-          useful if using Proxy.
+        :param transport_settings: Optional dictionary of transport level settings (HTTP headers, etc.)
         :return: bytes representing raw ClickHouse return value based on format
         """
 
@@ -325,7 +324,7 @@ class Client(ABC):
                    fmt: str = None,
                    use_database: bool = True,
                    external_data: Optional[ExternalData] = None,
-                   extra_http_headers: Optional[Dict[str, str]] = None) -> io.IOBase:
+                   transport_settings: Optional[Dict[str, str]] = None) -> io.IOBase:
         """
        Query method that returns the result as an io.IOBase iterator
        :param query: Query statement/format string
@@ -335,8 +334,7 @@ class Client(ABC):
        :param use_database  Send the database parameter to ClickHouse so the command will be executed in the client
         database context.
        :param external_data: External data to send with the query.
-       :param extra_http_headers: Optional dictionary of extra HTTP headers to pass to ClickHouse,
-          useful if using Proxy.
+       :param transport_settings: Optional dictionary of transport level settings (HTTP headers, etc.)
        :return: io.IOBase stream/iterator for the result
        """
 
@@ -352,7 +350,7 @@ class Client(ABC):
                  max_str_len: Optional[int] = None,
                  context: QueryContext = None,
                  external_data: Optional[ExternalData] = None,
-                 extra_http_headers: Optional[Dict[str, str]] = None):
+                 transport_settings: Optional[Dict[str, str]] = None):
         """
         Query method that returns the results as a numpy array.  For parameter values, see the
         create_query_context method
@@ -373,7 +371,7 @@ class Client(ABC):
                         max_str_len: Optional[int] = None,
                         context: QueryContext = None,
                         external_data: Optional[ExternalData] = None,
-                        extra_http_headers: Optional[Dict[str, str]] = None) -> StreamContext:
+                        transport_settings: Optional[Dict[str, str]] = None) -> StreamContext:
         """
         Query method that returns the results as a stream of numpy arrays.  For parameter values, see the
         create_query_context method
@@ -398,7 +396,7 @@ class Client(ABC):
                  context: QueryContext = None,
                  external_data: Optional[ExternalData] = None,
                  use_extended_dtypes: Optional[bool] = None,
-                 extra_http_headers: Optional[Dict[str, str]] = None):
+                 transport_settings: Optional[Dict[str, str]] = None):
         """
         Query method that results the results as a pandas dataframe.  For parameter values, see the
         create_query_context method
@@ -423,7 +421,7 @@ class Client(ABC):
                         context: QueryContext = None,
                         external_data: Optional[ExternalData] = None,
                         use_extended_dtypes: Optional[bool] = None,
-                        extra_http_headers: Optional[Dict[str, str]] = None) -> StreamContext:
+                        transport_settings: Optional[Dict[str, str]] = None) -> StreamContext:
         """
         Query method that returns the results as a StreamContext.  For parameter values, see the
         create_query_context method
@@ -453,7 +451,7 @@ class Client(ABC):
                              as_pandas: bool = False,
                              external_data: Optional[ExternalData] = None,
                              use_extended_dtypes: Optional[bool] = None,
-                             extra_http_headers: Optional[Dict[str, str]] = None) -> QueryContext:
+                             transport_settings: Optional[Dict[str, str]] = None) -> QueryContext:
         """
         Creates or updates a reusable QueryContext object
         :param query: Query statement/format string
@@ -483,8 +481,7 @@ class Client(ABC):
         :param use_extended_dtypes:  Only relevant to Pandas Dataframe queries.  Use Pandas "missing types", such as
           pandas.NA and pandas.NaT for ClickHouse NULL values, as well as extended Pandas dtypes such as IntegerArray
           and StringArray.  Defaulted to True for query_df methods
-        :param extra_http_headers: Optional dictionary of extra HTTP headers to pass to ClickHouse,
-          useful if using Proxy.
+        :param transport_settings: Optional dictionary of transport level settings (HTTP headers, etc.)
         :return: Reusable QueryContext
         """
         if context:
@@ -504,7 +501,8 @@ class Client(ABC):
                                         as_pandas=as_pandas,
                                         use_extended_dtypes=use_extended_dtypes,
                                         streaming=streaming,
-                                        external_data=external_data)
+                                        external_data=external_data,
+                                        transport_settings=transport_settings)
         if use_numpy and max_str_len is None:
             max_str_len = 0
         if use_extended_dtypes is None:
@@ -529,7 +527,7 @@ class Client(ABC):
                             streaming=streaming,
                             apply_server_tz=self.apply_server_timezone,
                             external_data=external_data,
-                            extra_http_headers=extra_http_headers)
+                            transport_settings=transport_settings)
 
     def query_arrow(self,
                     query: str,
@@ -537,7 +535,7 @@ class Client(ABC):
                     settings: Optional[Dict[str, Any]] = None,
                     use_strings: Optional[bool] = None,
                     external_data: Optional[ExternalData] = None,
-                    extra_http_headers: Optional[Dict[str, str]] = None):
+                    transport_settings: Optional[Dict[str, str]] = None):
         """
         Query method using the ClickHouse Arrow format to return a PyArrow table
         :param query: Query statement/format string
@@ -545,8 +543,7 @@ class Client(ABC):
         :param settings: Optional dictionary of ClickHouse settings (key/string values)
         :param use_strings: Convert ClickHouse String type to Arrow string type (instead of binary)
         :param external_data: ClickHouse "external data" to send with query
-        :param extra_http_headers: Optional dictionary of extra HTTP headers to pass to ClickHouse,
-          useful if using Proxy.
+        :param transport_settings: Optional dictionary of transport level settings (HTTP headers, etc.)
         :return: PyArrow.Table
         """
         check_arrow()
@@ -556,7 +553,7 @@ class Client(ABC):
                                        settings,
                                        fmt='Arrow',
                                        external_data=external_data,
-                                       extra_http_headers=extra_http_headers))
+                                       transport_settings=transport_settings))
 
     def query_arrow_stream(self,
                            query: str,
@@ -564,7 +561,7 @@ class Client(ABC):
                            settings: Optional[Dict[str, Any]] = None,
                            use_strings: Optional[bool] = None,
                            external_data: Optional[ExternalData] = None,
-                           extra_http_headers: Optional[Dict[str, str]] = None) -> StreamContext:
+                           transport_settings: Optional[Dict[str, str]] = None) -> StreamContext:
         """
         Query method that returns the results as a stream of Arrow tables
         :param query: Query statement/format string
@@ -572,8 +569,7 @@ class Client(ABC):
         :param settings: Optional dictionary of ClickHouse settings (key/string values)
         :param use_strings: Convert ClickHouse String type to Arrow string type (instead of binary)
         :param external_data: ClickHouse "external data" to send with query
-        :param extra_http_headers: Optional dictionary of extra HTTP headers to pass to ClickHouse,
-          useful if using Proxy.
+        :param transport_settings: Optional dictionary of transport level settings (HTTP headers, etc.)
         :return: Generator that yields a PyArrow.Table for per block representing the result set
         """
         check_arrow()
@@ -583,7 +579,7 @@ class Client(ABC):
                                                 settings,
                                                 fmt='ArrowStream',
                                                 external_data=external_data,
-                                                extra_http_headers=extra_http_headers))
+                                                transport_settings=transport_settings))
 
     def _update_arrow_settings(self,
                                settings: Optional[Dict[str, Any]],
@@ -609,7 +605,7 @@ class Client(ABC):
                 settings: Dict[str, Any] = None,
                 use_database: bool = True,
                 external_data: Optional[ExternalData] = None,
-                extra_http_headers: Optional[Dict[str, str]] = None) -> Union[str, int, Sequence[str], QuerySummary]:
+                transport_settings: Optional[Dict[str, str]] = None) -> Union[str, int, Sequence[str], QuerySummary]:
         """
         Client method that returns a single value instead of a result set
         :param cmd: ClickHouse query/command as a python format string
@@ -620,8 +616,7 @@ class Client(ABC):
          database context. Otherwise, no database will be specified with the command.  This is useful for determining
          the default user database
         :param external_data: ClickHouse "external data" to send with command/query
-        :param extra_http_headers: Optional dictionary of extra HTTP headers to pass to ClickHouse,
-          useful if using Proxy.
+        :param transport_settings: Optional dictionary of transport level settings (HTTP headers, etc.)
         :return: Decoded response from ClickHouse as either a string, int, or sequence of strings, or QuerySummary
         if no data returned
         """
@@ -642,7 +637,8 @@ class Client(ABC):
                column_type_names: Sequence[str] = None,
                column_oriented: bool = False,
                settings: Optional[Dict[str, Any]] = None,
-               context: InsertContext = None) -> QuerySummary:
+               context: InsertContext = None,
+               transport_settings: Optional[Dict[str, str]] = None) -> QuerySummary:
         """
         Method to insert multiple rows/data matrix of native Python objects.  If context is specified arguments
         other than data are ignored
@@ -659,6 +655,7 @@ class Client(ABC):
         :param settings: Optional dictionary of ClickHouse settings (key/string values)
         :param context: Optional reusable insert context to allow repeated inserts into the same table with
             different data batches
+        :param transport_settings: Optional dictionary of transport level settings (HTTP headers, etc.)
         :return: QuerySummary with summary information, throws exception if insert fails
         """
         if (context is None or context.empty) and data is None:
@@ -670,7 +667,8 @@ class Client(ABC):
                                                  column_types,
                                                  column_type_names,
                                                  column_oriented,
-                                                 settings)
+                                                 settings,
+                                                 transport_settings=transport_settings)
         if data is not None:
             if not context.empty:
                 raise ProgrammingError('Attempting to insert new data with non-empty insert context') from None
@@ -684,7 +682,8 @@ class Client(ABC):
                   column_names: Optional[Sequence[str]] = None,
                   column_types: Sequence[ClickHouseType] = None,
                   column_type_names: Sequence[str] = None,
-                  context: InsertContext = None) -> QuerySummary:
+                  context: InsertContext = None,
+                  transport_settings: Optional[Dict[str, str]] = None) -> QuerySummary:
         """
         Insert a pandas DataFrame into ClickHouse.  If context is specified arguments other than df are ignored
         :param table: ClickHouse table
@@ -699,6 +698,7 @@ class Client(ABC):
             retrieved from the server
         :param context: Optional reusable insert context to allow repeated inserts into the same table with
             different data batches
+        :param transport_settings: Optional dictionary of transport level settings (HTTP headers, etc.)
         :return: QuerySummary with summary information, throws exception if insert fails
         """
         check_pandas()
@@ -713,25 +713,28 @@ class Client(ABC):
                            database,
                            column_types=column_types,
                            column_type_names=column_type_names,
-                           settings=settings, context=context)
+                           settings=settings,
+                           transport_settings=transport_settings,
+                           context=context)
 
     def insert_arrow(self, table: str,
                      arrow_table,
                      database: str = None,
-                     settings: Optional[Dict] = None) -> QuerySummary:
+                     settings: Optional[Dict] = None,
+                     transport_settings: Optional[Dict[str, str]] = None) -> QuerySummary:
         """
         Insert a PyArrow table DataFrame into ClickHouse using raw Arrow format
         :param table: ClickHouse table
         :param arrow_table: PyArrow Table object
         :param database: Optional ClickHouse database
         :param settings: Optional dictionary of ClickHouse settings (key/string values)
-        :return: QuerySummary with summary information, throws exception if insert fails
+        :param transport_settings: Optional dictionary of transport level settings (HTTP headers, etc.)
         """
         check_arrow()
         full_table = table if '.' in table or not database else f'{database}.{table}'
         compression = self.write_compression if self.write_compression in ('zstd', 'lz4') else None
         column_names, insert_block = arrow_buffer(arrow_table, compression)
-        return self.raw_insert(full_table, column_names, insert_block, settings, 'Arrow')
+        return self.raw_insert(full_table, column_names, insert_block, settings, 'Arrow', transport_settings)
 
     def create_insert_context(self,
                               table: str,
@@ -741,7 +744,8 @@ class Client(ABC):
                               column_type_names: Sequence[str] = None,
                               column_oriented: bool = False,
                               settings: Optional[Dict[str, Any]] = None,
-                              data: Optional[Sequence[Sequence[Any]]] = None) -> InsertContext:
+                              data: Optional[Sequence[Sequence[Any]]] = None,
+                              transport_settings: Optional[Dict[str, str]] = None) -> InsertContext:
         """
         Builds a reusable insert context to hold state for a duration of an insert
         :param table: Target table
@@ -755,7 +759,8 @@ class Client(ABC):
         :param column_oriented: If true the data is already "pivoted" in column form
         :param settings: Optional dictionary of ClickHouse settings (key/string values)
         :param data: Initial dataset for insert
-        :return Reusable insert context
+        :param transport_settings: Optional dictionary of transport level settings (HTTP headers, etc.)
+        :return: Reusable insert context
         """
         full_table = table
         if '.' not in table:
@@ -791,6 +796,7 @@ class Client(ABC):
                              column_types,
                              column_oriented=column_oriented,
                              settings=settings,
+                             transport_settings=transport_settings,
                              data=data)
 
     def min_version(self, version_str: str) -> bool:
@@ -831,15 +837,17 @@ class Client(ABC):
                    insert_block: Union[str, bytes, Generator[bytes, None, None], BinaryIO] = None,
                    settings: Optional[Dict] = None,
                    fmt: Optional[str] = None,
-                   compression: Optional[str] = None) -> QuerySummary:
+                   compression: Optional[str] = None,
+                   transport_settings: Optional[Dict[str, str]] = None) -> QuerySummary:
         """
         Insert data already formatted in a bytes object
         :param table: Table name (whether qualified with the database name or not)
         :param column_names: Sequence of column names
         :param insert_block: Binary or string data already in a recognized ClickHouse format
         :param settings:  Optional dictionary of ClickHouse settings (key/string values)
-        :param compression:  Recognized ClickHouse `Accept-Encoding` header compression value
         :param fmt: Valid clickhouse format
+        :param compression:  Recognized ClickHouse `Accept-Encoding` header compression value
+        :param transport_settings: Optional dictionary of transport level settings (HTTP headers, etc.)
         """
 
     @abstractmethod

--- a/clickhouse_connect/driver/context.py
+++ b/clickhouse_connect/driver/context.py
@@ -16,7 +16,8 @@ class BaseQueryContext:
                  column_formats: Optional[Dict[str, Union[str, Dict[str, str]]]] = None,
                  encoding: Optional[str] = None,
                  use_extended_dtypes: bool = False,
-                 use_numpy: bool = False):
+                 use_numpy: bool = False,
+                 transport_settings: Optional[Dict[str, str]] = None):
         self.settings = settings or {}
         if query_formats is None:
             self.type_formats = _empty_map
@@ -36,6 +37,7 @@ class BaseQueryContext:
                                                        for type_name, fmt in fmt.items()}
         self.query_formats = query_formats or {}
         self.column_formats = column_formats or {}
+        self.transport_settings = transport_settings
         self.column_name = None
         self.encoding = encoding
         self.use_numpy = use_numpy

--- a/clickhouse_connect/driver/httpclient.py
+++ b/clickhouse_connect/driver/httpclient.py
@@ -204,7 +204,7 @@ class HttpClient(Client):
         return final_query + fmt
 
     def _query_with_context(self, context: QueryContext) -> QueryResult:
-        headers = dict_copy(context.extra_http_headers)
+        headers = {}
         params = {}
         if self.database:
             params['database'] = self.database
@@ -242,7 +242,7 @@ class HttpClient(Client):
             headers['Content-Type'] = 'text/plain; charset=utf-8'
         response = self._raw_request(body,
                                      params,
-                                     headers,
+                                     dict_copy(headers, context.transport_settings),
                                      stream=True,
                                      retries=self.query_retries,
                                      fields=fields,
@@ -280,7 +280,7 @@ class HttpClient(Client):
         if self.database:
             params['database'] = self.database
         params.update(self._validate_settings(context.settings))
-
+        headers = dict_copy(headers, context.transport_settings)
         response = self._raw_request(block_gen, params, headers, error_handler=error_handler, server_wait=False)
         logger.debug('Context insert response code: %d, content: %s', response.status, response.data)
         context.data = None
@@ -291,7 +291,8 @@ class HttpClient(Client):
                    insert_block: Union[str, bytes, Generator[bytes, None, None], BinaryIO] = None,
                    settings: Optional[Dict] = None,
                    fmt: Optional[str] = None,
-                   compression: Optional[str] = None) -> QuerySummary:
+                   compression: Optional[str] = None,
+                   transport_settings: Optional[Dict[str, str]] = None) -> QuerySummary:
         """
         See BaseClient doc_string for this method
         """
@@ -311,6 +312,7 @@ class HttpClient(Client):
         if self.database:
             params['database'] = self.database
         params.update(self._validate_settings(settings or {}))
+        headers = dict_copy(headers, transport_settings)
         response = self._raw_request(insert_block, params, headers, server_wait=False)
         logger.debug('Raw insert response code: %d, content: %s', response.status, response.data)
         return QuerySummary(self._summary(response))
@@ -333,7 +335,7 @@ class HttpClient(Client):
                 settings: Optional[Dict] = None,
                 use_database: int = True,
                 external_data: Optional[ExternalData] = None,
-                extra_http_headers: Optional[Dict[str, str]] = None) -> Union[str, int, Sequence[str], QuerySummary]:
+                transport_settings: Optional[Dict[str, str]] = None) -> Union[str, int, Sequence[str], QuerySummary]:
         """
         See BaseClient doc_string for this method
         """
@@ -361,7 +363,7 @@ class HttpClient(Client):
         if use_database and self.database:
             params['database'] = self.database
         params.update(self._validate_settings(settings or {}))
-
+        headers = dict_copy(headers, transport_settings)
         method = 'POST' if payload or fields else 'GET'
         response = self._raw_request(payload, params, headers, method, fields=fields, server_wait=False)
         if response.data:
@@ -484,12 +486,12 @@ class HttpClient(Client):
                   fmt: str = None,
                   use_database: bool = True,
                   external_data: Optional[ExternalData] = None,
-                  extra_http_headers: Optional[Dict[str, str]] = None) -> bytes:
+                  transport_settings: Optional[Dict[str, str]] = None) -> bytes:
         """
         See BaseClient doc_string for this method
         """
         body, params, fields = self._prep_raw_query(query, parameters, settings, fmt, use_database, external_data)
-        return self._raw_request(body, params, fields=fields, headers=extra_http_headers).data
+        return self._raw_request(body, params, fields=fields, headers=transport_settings).data
 
     def raw_stream(self, query: str,
                    parameters: Optional[Union[Sequence, Dict[str, Any]]] = None,
@@ -497,13 +499,13 @@ class HttpClient(Client):
                    fmt: str = None,
                    use_database: bool = True,
                    external_data: Optional[ExternalData] = None,
-                   extra_http_headers: Optional[Dict[str, str]] = None) -> io.IOBase:
+                   transport_settings: Optional[Dict[str, str]] = None) -> io.IOBase:
         """
         See BaseClient doc_string for this method
         """
         body, params, fields = self._prep_raw_query(query, parameters, settings, fmt, use_database, external_data)
         return self._raw_request(body, params, fields=fields, stream=True, server_wait=False,
-                                 headers=extra_http_headers)
+                                 headers=transport_settings)
 
     def _prep_raw_query(self, query: str,
                         parameters: Optional[Union[Sequence, Dict[str, Any]]],

--- a/clickhouse_connect/driver/insert.py
+++ b/clickhouse_connect/driver/insert.py
@@ -42,8 +42,9 @@ class InsertContext(BaseQueryContext):
                  compression: Optional[Union[str, bool]] = None,
                  query_formats: Optional[Dict[str, str]] = None,
                  column_formats: Optional[Dict[str, Union[str, Dict[str, str]]]] = None,
-                 block_size: Optional[int] = None):
-        super().__init__(settings, query_formats, column_formats)
+                 block_size: Optional[int] = None,
+                 transport_settings: Optional[Dict[str, str]] = None):
+        super().__init__(settings, query_formats, column_formats, transport_settings=transport_settings)
         self.table = table
         self.column_names = column_names
         self.column_types = column_types

--- a/clickhouse_connect/driver/query.py
+++ b/clickhouse_connect/driver/query.py
@@ -53,7 +53,7 @@ class QueryContext(BaseQueryContext):
                  streaming: bool = False,
                  apply_server_tz: bool = False,
                  external_data: Optional[ExternalData] = None,
-                 extra_http_headers: Optional[Dict[str, str]] = None):
+                 transport_settings: Optional[Dict[str, str]] = None):
         """
         Initializes various configuration settings for the query context
 
@@ -86,7 +86,8 @@ class QueryContext(BaseQueryContext):
                          column_formats,
                          encoding,
                          use_extended_dtypes if use_extended_dtypes is not None else False,
-                         use_numpy if use_numpy is not None else False)
+                         use_numpy if use_numpy is not None else False,
+                         transport_settings=transport_settings)
         self.query = query
         self.parameters = parameters or {}
         self.use_none = True if use_none is None else use_none
@@ -117,7 +118,6 @@ class QueryContext(BaseQueryContext):
         self.as_pandas = as_pandas
         self.use_pandas_na = as_pandas and pd_extended_dtypes
         self.streaming = streaming
-        self.extra_http_headers = extra_http_headers
         self._update_query()
 
     @property
@@ -192,7 +192,7 @@ class QueryContext(BaseQueryContext):
                      as_pandas: bool = False,
                      streaming: bool = False,
                      external_data: Optional[ExternalData] = None,
-                     extra_http_headers: Optional[Dict[str, str]] = None) -> 'QueryContext':
+                     transport_settings: Optional[Dict[str, str]] = None) -> 'QueryContext':
         """
         Creates Query context copy with parameters overridden/updated as appropriate.
         """
@@ -214,7 +214,7 @@ class QueryContext(BaseQueryContext):
                             streaming,
                             self.apply_server_tz,
                             self.external_data if external_data is None else external_data,
-                            self.extra_http_headers if extra_http_headers is None else extra_http_headers)
+                            self.transport_settings if transport_settings is None else transport_settings)
 
     def _update_query(self):
         self.final_query, self.bind_params = bind_query(self.query, self.parameters, self.server_tz)

--- a/tests/integration_tests/test_client.py
+++ b/tests/integration_tests/test_client.py
@@ -40,9 +40,9 @@ def test_client_name(test_client: Client):
     assert 'py/' in user_agent
 
 
-def test_extra_http_headers(test_client: Client):
+def test_transport_settings(test_client: Client):
     result = test_client.query('SELECT name,database FROM system.tables',
-                               extra_http_headers={'X-Workload': 'ONLINE'})
+                               transport_settings={'X-Workload': 'ONLINE'})
     assert result.column_names == ('name', 'database')
     assert len(result.result_set) > 0
 


### PR DESCRIPTION
## Summary
Changes extra_http_headers to transport_settings for future compatibility (GRPC/Native eventually).  Added the new parameter to insert methods and the async client.

## Checklist
Delete items not relevant to your PR:
- [ ] Unit and integration tests covering the common scenarios were added
- [x] A human-readable description of the changes was provided to include in CHANGELOG
- [ ] For significant changes, documentation in https://github.com/ClickHouse/clickhouse-docs was updated with further explanations or tutorials
