### PR TITLE
fix: incorrect pagination in Cursor.fetchall and fetchmany

### DIFF
--- a/clickhouse_connect/dbapi/cursor.py
+++ b/clickhouse_connect/dbapi/cursor.py
@@ -108,7 +108,7 @@ class Cursor:
 
     def fetchall(self):
         self.check_valid()
-        ret = self.data
+        ret = self.data[self._ix :]
         self._ix = self._rowcount
         return ret
 
@@ -122,8 +122,10 @@ class Cursor:
 
     def fetchmany(self, size: int = -1):
         self.check_valid()
-        end = self._ix + max(size, self._rowcount - self._ix)
-        ret = self.data[self._ix: end]
+        if size == -1:
+            size = self._rowcount
+        end = min(self._rowcount, self._ix + size)
+        ret = self.data[self._ix : end]
         self._ix = end
         return ret
 


### PR DESCRIPTION
Two bugs fixed:
- `fetchall` returned rows that had already been consumed (pep-249 specifies all _remaining_)
- `fetchmany` returned all remaining rows, regardless of the `size` parameter

In my case, these bugs surfaced by causing duplication of all rows in query results when using a clickhouse connection in [jupysql](https://pypi.org/project/jupysql/), if that context is interesting.
