### PR TITLE
Joe/508 please propagate error messages from http 400 at least

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,9 @@ release (0.9.0), unrecognized arguments/keywords for these methods of creating a
 instead of being passed as ClickHouse server settings. This is in conjunction with some refactoring in Client construction.
 The supported method of passing ClickHouse server settings is to prefix such arguments/query parameters with`ch_`.
 
+## UNRELEASED
+- Added more robust error handling and tests. Closes https://github.com/ClickHouse/clickhouse-connect/issues/508
+
 ## 0.8.18, 2025-06-24
 
 ### Improvements

--- a/tests/integration_tests/test_error_handling.py
+++ b/tests/integration_tests/test_error_handling.py
@@ -1,0 +1,91 @@
+import logging
+import pytest
+
+from clickhouse_connect import create_client
+from clickhouse_connect.driver.exceptions import DatabaseError, OperationalError
+from tests.integration_tests.conftest import TestConfig
+
+# pylint: disable=attribute-defined-outside-init
+
+
+class TestErrorHandling:
+    """Tests for error handling in the ClickHouse Connect client"""
+
+    @pytest.fixture(autouse=True)
+    def setup(self, test_config: TestConfig):
+        self.config = test_config
+
+    def test_wrong_port_error_message(self):
+        """
+        Test that connecting to the wrong port properly propagates
+        the error message from ClickHouse.
+        """
+        wrong_port = 9000
+
+        with pytest.raises((DatabaseError, OperationalError)) as excinfo:
+            create_client(
+                host=self.config.host,
+                port=wrong_port,
+                username=self.config.username,
+                password=self.config.password,
+            )
+
+        error_message = str(excinfo.value)
+        assert (
+            f"Port {wrong_port} is for clickhouse-client program" in error_message
+            or "You must use port 8123 for HTTP" in error_message
+        )
+
+    def test_connection_refused_error(self, caplog):
+        """
+        Test that connecting to a port where nothing is listening
+        produces a clear error message.
+        """
+        # Suppress urllib3 connection pool warnings
+        urllib3_logger = logging.getLogger("urllib3.connectionpool")
+        original_level = urllib3_logger.level
+        urllib3_logger.setLevel(logging.CRITICAL)
+
+        # Swallow logging messages to prevent polluting pytest output
+        caplog.set_level(logging.CRITICAL)
+
+        try:
+            # Use a port that shouldn't have anything listening
+            unused_port = 45678
+
+            # Try connecting to an unused port - should fail with connection refused
+            with pytest.raises(OperationalError) as excinfo:
+                create_client(
+                    host=self.config.host,
+                    port=unused_port,
+                    username=self.config.username,
+                    password=self.config.password,
+                )
+
+            error_message = str(excinfo.value)
+            assert (
+                "Connection refused" in error_message
+                or "Failed to establish a new connection" in error_message
+            )
+        finally:
+            # Restore the original logging level
+            urllib3_logger.setLevel(original_level)
+
+    def test_successful_connection(self):
+        """
+        Verify that connecting to the correct port works properly.
+        This serves as a sanity check that the test environment is configured correctly.
+        """
+        # Connect to the correct HTTP port
+        client = create_client(
+            host=self.config.host,
+            port=self.config.port,  # Use the port from test config
+            username=self.config.username,
+            password=self.config.password,
+        )
+
+        # Simple query to verify connection works
+        result = client.command("SELECT 1")
+        assert result == 1
+
+        client.close()

--- a/tests/integration_tests/test_error_handling.py
+++ b/tests/integration_tests/test_error_handling.py
@@ -20,6 +20,8 @@ class TestErrorHandling:
         Test that connecting to the wrong port properly propagates
         the error message from ClickHouse.
         """
+        if self.config.cloud:
+            pytest.skip("Skipping wrong port test in cloud environ.")
         wrong_port = 9000
 
         with pytest.raises((DatabaseError, OperationalError)) as excinfo:
@@ -41,6 +43,8 @@ class TestErrorHandling:
         Test that connecting to a port where nothing is listening
         produces a clear error message.
         """
+        if self.config.cloud:
+            pytest.skip("Skipping connection refused test in cloud environ.")
         # Suppress urllib3 connection pool warnings
         urllib3_logger = logging.getLogger("urllib3.connectionpool")
         original_level = urllib3_logger.level

--- a/tests/unit_tests/test_driver/test_httpclient.py
+++ b/tests/unit_tests/test_driver/test_httpclient.py
@@ -1,0 +1,180 @@
+from unittest.mock import Mock, patch
+import logging
+import pytest
+
+from clickhouse_connect.driver.httpclient import HttpClient, ex_header
+from clickhouse_connect.driver.exceptions import DatabaseError, OperationalError
+
+# pylint: disable=protected-access
+# pylint: disable=attribute-defined-outside-init
+
+
+# Helper function to create mock response
+def create_mock_response(status=500, headers=None, data=None):
+    """Create a mock HTTP response with the specified attributes"""
+    response = Mock()
+    response.status = status
+    response.headers = headers or {}
+    response.data = data or b""
+    response.close = Mock()  # Mock the close method
+    return response
+
+
+class TestHttpClientErrorHandler:
+    """Test the error handling functionality of HttpClient"""
+
+    def setup_method(self):
+        """Set up common test fixtures"""
+        # Create a minimal HttpClient instance
+        self.client = HttpClient(
+            interface="http",
+            host="localhost",
+            port=8123,
+            username="default",
+            password="",
+            database="default",
+        )
+        self.client.url = "http://localhost:8123"
+
+        # Always turn on show_clickhouse_error. Will disable in tests as needed.
+        self.client.show_clickhouse_errors = True
+
+    def test_error_handler_with_exception_code(self):
+        """Test error handling when ClickHouse exception code is present"""
+
+        # Create mock response with exception code
+        response = create_mock_response(
+            status=500,
+            headers={ex_header: "99"},
+            data=b"Error executing query",
+        )
+
+        with pytest.raises(DatabaseError) as excinfo:
+            self.client._error_handler(response)
+
+        # Verify the error message contains all expected parts
+        error_msg = str(excinfo.value)
+        assert "Received ClickHouse exception, code: 99" in error_msg
+        assert "server response: Error executing query" in error_msg
+        assert self.client.url in error_msg
+        response.close.assert_called_once()
+
+    def test_error_handler_without_exception_code(self):
+        """Test error handling when only HTTP status is available"""
+
+        # Create mock response without exception code
+        response = create_mock_response(status=503, data=b"Service unavailable")
+
+        with pytest.raises(DatabaseError) as excinfo:
+            self.client._error_handler(response)
+
+        # Verify the error message contains all expected parts
+        error_msg = str(excinfo.value)
+        assert "HTTP driver received HTTP status 503" in error_msg
+        assert "server response: Service unavailable" in error_msg
+        assert self.client.url in error_msg
+        response.close.assert_called_once()
+
+    def test_error_handler_with_empty_body(self):
+        """Test error handling when response body is empty"""
+
+        # Create mock response with empty body
+        response = create_mock_response(status=400, headers={ex_header: "99"}, data=b"")
+
+        with pytest.raises(DatabaseError) as excinfo:
+            self.client._error_handler(response)
+
+        # Verify the error message contains expected parts but not empty body
+        error_msg = str(excinfo.value)
+        assert "Received ClickHouse exception, code: 99" in error_msg
+        assert (
+            "server response:" not in error_msg
+        )  # No body, so no server response part
+        assert self.client.url in error_msg
+        response.close.assert_called_once()
+
+    def test_error_handler_with_errors_disabled(self):
+        """Test error handling when show_clickhouse_errors is disabled"""
+        # Explicitly disable showing ClickHouse errors
+        self.client.show_clickhouse_errors = False
+
+        # Create mock response
+        response = create_mock_response(
+            status=400,
+            headers={ex_header: "99"},
+            data=b"Invalid query",
+        )
+
+        with pytest.raises(DatabaseError) as excinfo:
+            self.client._error_handler(response)
+
+        # Verify the error message is generic
+        error_msg = str(excinfo.value)
+        assert (
+            "The ClickHouse server returned an error (for url http://localhost:8123)"
+            in error_msg
+        )
+        assert "Invalid query" not in error_msg  # Should not include the body
+        assert "99" not in error_msg  # Should not include the exception code
+        response.close.assert_called_once()
+
+    def test_error_handler_with_unicode_decode_error(self):
+        """Test error handling when the response body has invalid Unicode"""
+
+        # Create response with invalid UTF-8 sequence
+        response = create_mock_response(
+            status=500, data=b"\xff\xfe Invalid UTF-8 sequence"
+        )
+
+        with pytest.raises(DatabaseError) as excinfo:
+            self.client._error_handler(response)
+
+        # Verify error message contains the backslash-escaped bytes
+        error_msg = str(excinfo.value)
+        assert "HTTP driver received HTTP status 500" in error_msg
+        assert "server response:" in error_msg  # Should have backslash-escaped data
+        response.close.assert_called_once()
+
+    def test_error_handler_with_retried_flag(self):
+        """Test error handling with retried flag set to True"""
+        # Create mock response
+        response = create_mock_response(status=500, data=b"Server error")
+
+        # Test the error handler with retried=True
+        with pytest.raises(OperationalError) as excinfo:
+            self.client._error_handler(response, retried=True)
+
+        # Verify that OperationalError is raised instead of DatabaseError
+        assert isinstance(excinfo.value, OperationalError)
+        response.close.assert_called_once()
+
+    @patch("clickhouse_connect.driver.httpclient.get_response_data")
+    def test_error_handler_with_body_reading_exception(
+        self, mock_get_response_data, caplog
+    ):
+        """Test error handling when reading the response body throws an exception"""
+        # Set up the mock to raise an exception when reading the response body
+        mock_get_response_data.side_effect = Exception("Error reading response data")
+
+        # Swallow logging messages to prevent polluting pytest output
+        caplog.set_level(logging.CRITICAL)
+
+        # Create mock response
+        response = create_mock_response(
+            status=500,
+            headers={"X-ClickHouse-Exception-Code": "99"},
+            data=b"Some data",  # This won't be read due to the mocked exception
+        )
+
+        with pytest.raises(DatabaseError) as excinfo:
+            self.client._error_handler(response)
+
+        # Verify the error message has the exception code but no body
+        error_msg = str(excinfo.value)
+        assert "Received ClickHouse exception, code: 99" in error_msg
+        assert "server response:" not in error_msg  # No body due to exception
+        assert self.client.url in error_msg
+
+        # Verify the mock was called
+        mock_get_response_data.assert_called_once_with(response)
+        response.close.assert_called_once()


### PR DESCRIPTION
## Summary
Improved error reporting and includes minor improvements to the httpclient's error handler. It now:

1. Always attempts body retrieval.
2. Always includes server's response when available.
3. Ensures response object is always closed.
4. Has added unit and integration tests.

Closes #508

## Checklist
Delete items not relevant to your PR:
- [X] Unit and integration tests covering the common scenarios were added
- [X] A human-readable description of the changes was provided to include in CHANGELOG