### PR TITLE
Add asyncclient settings Optional typing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ instead of being passed as ClickHouse server settings. This is in conjunction wi
 The supported method of passing ClickHouse server settings is to prefix such arguments/query parameters with`ch_`.
 
 ## UNRELEASED
+- Changed `AsyncClient.settings` typing to `Optional[Dict[str, Any]]` to accept None inputs.
 - Added more robust error handling and tests. Closes https://github.com/ClickHouse/clickhouse-connect/issues/508
 
 ## 0.8.18, 2025-06-24

--- a/clickhouse_connect/driver/asyncclient.py
+++ b/clickhouse_connect/driver/asyncclient.py
@@ -501,7 +501,7 @@ class AsyncClient:
                       cmd: str,
                       parameters: Optional[Union[Sequence, Dict[str, Any]]] = None,
                       data: Union[str, bytes] = None,
-                      settings: Dict[str, Any] = None,
+                      settings: Optional[Dict[str, Any]] = None,
                       use_database: bool = True,
                       external_data: Optional[ExternalData] = None,
                       transport_settings: Optional[Dict[str, str]] = None) -> Union[str, int, Sequence[str], QuerySummary]:


### PR DESCRIPTION
## Summary
Change `AsyncClient.settings` typing to `Optional[Dict[str, Any]]` to accept None inputs.

## Checklist
Delete items not relevant to your PR:
- [x] A human-readable description of the changes was provided to include in CHANGELOG
