### PR TITLE
Add option to only use mTLS for cert

### DIFF
--- a/clickhouse_connect/driver/httpclient.py
+++ b/clickhouse_connect/driver/httpclient.py
@@ -75,7 +75,8 @@ class HttpClient(Client):
                  show_clickhouse_errors: Optional[bool] = None,
                  autogenerate_session_id: Optional[bool] = None,
                  tls_mode: Optional[str] = None,
-                 proxy_path: str = ''):
+                 proxy_path: str = '',
+                 ssl_certificate_auth: Union[bool, str] = False):
         """
         Create an HTTP ClickHouse Connect client
         See clickhouse_connect.get_client for parameters
@@ -99,7 +100,10 @@ class HttpClient(Client):
                 if not username:
                     raise ProgrammingError('username parameter is required for Mutual TLS authentication')
                 self.headers['X-ClickHouse-User'] = username
-                self.headers['X-ClickHouse-SSL-Certificate-Auth'] = 'on'
+                if ssl_certificate_auth == 'off' or ssl_certificate_auth is False:
+                    self.headers['X-ClickHouse-Key'] = password
+                else:
+                    self.headers['X-ClickHouse-SSL-Certificate-Auth'] = 'on'
             # pylint: disable=too-many-boolean-expressions
             if not self.http and (server_host_name or ca_cert or client_cert or not verify or https_proxy):
                 options = {'verify': verify}


### PR DESCRIPTION
Adds an option to turn on or off SSL Certificate Authentication. When set to off along with client certs, mTLS is only used for encryption and username/password is used for authentication.

Fixes #515

## Summary
<!-- A short description of the changes with a link to an open issue. -->

## Checklist
Delete items not relevant to your PR:
- [ ] Unit and integration tests covering the common scenarios were added
- [ ] A human-readable description of the changes was provided to include in CHANGELOG
- [ ] For significant changes, documentation in https://github.com/ClickHouse/clickhouse-docs was updated with further explanations or tutorials
