### PR TITLE
Joe/519 code 117 dbexception cannot parse json object

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,7 @@ The supported method of passing ClickHouse server settings is to prefix such arg
 - Changed `AsyncClient.settings` typing to `Optional[Dict[str, Any]]` to accept None inputs.
 - Added more robust error handling and tests. Closes https://github.com/ClickHouse/clickhouse-connect/issues/508
 - Fixed an AttributeError on `http.client` when importing `clickhouse_connect` under certain circumstances
+- Added support for Nullable(JSON) types
 
 ## 0.8.18, 2025-06-24
 

--- a/tests/integration_tests/test_dynamic.py
+++ b/tests/integration_tests/test_dynamic.py
@@ -152,7 +152,8 @@ def test_typed_json(test_client: Client, table_context: Callable):
 
 
 def test_nullable_json(test_client: Client, table_context: Callable):
-    type_available(test_client, "json")
+    if not test_client.min_version('25.2'):
+        pytest.skip(f'Nullable(JSON) type not available in this version: {test_client.server_version}')
     with table_context("nullable_json", [
         "key Int32",
         "value_1 Nullable(JSON)",

--- a/tests/integration_tests/test_pandas.py
+++ b/tests/integration_tests/test_pandas.py
@@ -285,3 +285,50 @@ def test_pandas_small_blocks(test_config: TestConfig, test_client: Client):
     res = test_client.query_df('SELECT number, randomString(512) FROM numbers(1000000)',
                                settings={'max_block_size': 250})
     assert len(res) == 1000000
+
+
+def test_pandas_string_to_df_insert(test_client: Client, table_context: Callable):
+    with table_context(
+        "test_pandas_string_to_df_insert",
+        [
+            "id UInt32",
+            "timestamp Nullable(DateTime)",
+            "json_data Nullable(JSON)",
+        ],
+    ):
+
+        df = pd.DataFrame(
+            [[1, "simple"], [2, "with spaces"], [3, "特殊字符"], [4, ""]],
+            columns=["id", "s"],
+        )
+
+        json_data_dict = {"vm": "", "App Name": "MKT"}
+        json_data_dict2 = {"Room": "Leo"}
+
+        data = [
+            {
+                "id": 1,
+                "timestamp": datetime(year=2025, month=7, day=5, hour=12),
+                "json_data": json_data_dict,
+            },
+            {
+                "id": 2,
+                "timestamp": datetime(year=2025, month=7, day=6, hour=12),
+                "json_data": json_data_dict2,
+            },
+            {
+                "id": 3,
+                "timestamp": datetime(year=2025, month=7, day=7, hour=12),
+                "json_data": None,
+            },
+        ]
+
+        df = pd.DataFrame(data)
+        test_client.insert_df("test_pandas_string_to_df_insert", df)
+        result_df = test_client.query_df(
+            "SELECT * FROM test_pandas_string_to_df_insert ORDER BY id"
+        )
+
+        assert result_df.iloc[0]["json_data"] == json_data_dict
+        assert result_df.iloc[1]["json_data"] == json_data_dict2
+        assert result_df.iloc[2]["json_data"] is None

--- a/tests/integration_tests/test_pandas.py
+++ b/tests/integration_tests/test_pandas.py
@@ -288,6 +288,8 @@ def test_pandas_small_blocks(test_config: TestConfig, test_client: Client):
 
 
 def test_pandas_string_to_df_insert(test_client: Client, table_context: Callable):
+    if not test_client.min_version('25.2'):
+        pytest.skip(f'Nullable(JSON) type not available in this version: {test_client.server_version}')
     with table_context(
         "test_pandas_string_to_df_insert",
         [


### PR DESCRIPTION
## Summary
Adds support for `Nullable(JSON)` types.

Closes #519 

## Checklist
- [X] Unit and integration tests covering the common scenarios were added
- [X] A human-readable description of the changes was provided to include in CHANGELOG