### PR TITLE
Effort toward pandas 2.x support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,12 @@ instead of being passed as ClickHouse server settings. This is in conjunction wi
 The supported method of passing ClickHouse server settings is to prefix such arguments/query parameters with`ch_`.
 
 ## UNRELEASED
+- Begins effort toward Pandas 2.x support. Specifically:
+    - Plumbs up a mechanism allowing date-like objects to leverage the additional Pandas 2.x datetime64/timedelta64 resolutions of "s", "ms", "us".
+    - Introduces pandas compatibility tests that can be expanded and support for more 2.x features become available.
+- Tightens up type consistency of date-like objects when using `query_df` 
+- Enforces consistent resolution of ns for dataframe queries of datetime64/timedelta64 types when using Pandas 2.x (See [here](https://pandas.pydata.org/docs/whatsnew/v2.0.0.html#construction-with-datetime64-or-timedelta64-dtype-with-unsupported-resolution) for more info). Closes https://github.com/ClickHouse/clickhouse-connect/issues/165
+- Fixes problem with df inserts of Time and Time64 types. Closes https://github.com/ClickHouse/clickhouse-connect/issues/524
 - Added Time and Time64 type support and relevant tests. Closes https://github.com/ClickHouse/clickhouse-connect/issues/509
 - **WARNING: BREAKING CHANGE** — Behavior for reading from IPv6 columns has changed:
   - With `read_format='native'`, the client will **always** return [`ipaddress.IPv6Address`](https://docs.python.org/3/library/ipaddress.html#ipaddress.IPv6Address) objects, even for IPv4-mapped addresses (e.g., `"::ffff:192.168.1.1"`). Previously, the client returned [`ipaddress.IPv4Address`](https://docs.python.org/3/library/ipaddress.html#ipaddress.IPv4Address) objects for these cases. This change enforces type consistency and avoids surprising implicit conversions. If your application requires IPv4 objects, you can explicitly convert using the [`ipv4_mapped`](https://docs.python.org/3/library/ipaddress.html#ipaddress.IPv6Address.ipv4_mapped) attribute of `IPv6Address`.

--- a/clickhouse_connect/datatypes/base.py
+++ b/clickhouse_connect/datatypes/base.py
@@ -41,6 +41,7 @@ class ClickHouseType(ABC):
     encoding = 'utf8'
     np_type = 'O'  # Default to Numpy Object type
     nano_divisor = 0  # Only relevant for date like objects
+    pd_datetime_res = "ns"  # Default date-like resolution for pd
     byte_size = 0
     valid_formats = 'native'
 

--- a/tests/integration_tests/test_pandas_compat.py
+++ b/tests/integration_tests/test_pandas_compat.py
@@ -5,8 +5,8 @@ import pytest
 import pandas as pd
 
 from clickhouse_connect.driver import Client
-from tests.integration_tests.conftest import TestConfig
 from clickhouse_connect.driver.options import pd
+from tests.integration_tests.conftest import TestConfig
 
 PANDAS_VERSION = tuple(map(int, pd.__version__.split(".")[:2]))
 IS_PANDAS_2 = PANDAS_VERSION >= (2, 0)

--- a/tests/integration_tests/test_pandas_compat.py
+++ b/tests/integration_tests/test_pandas_compat.py
@@ -5,6 +5,7 @@ import pytest
 import pandas as pd
 
 from clickhouse_connect.driver import Client
+from tests.integration_tests.conftest import TestConfig
 from clickhouse_connect.driver.options import pd
 
 PANDAS_VERSION = tuple(map(int, pd.__version__.split(".")[:2]))
@@ -133,7 +134,19 @@ def test_pandas_datetime64_compat(test_client: Client, table_context: Callable):
             assert f"[{EXPECTED_RES}" in str(dt)
 
 
-def test_pandas_time_compat(test_client: Client, table_context: Callable):
+def test_pandas_time_compat(
+    test_config: TestConfig,
+    test_client: Client,
+    table_context: Callable,
+):
+    if not test_client.min_version("25.6"):
+        pytest.skip("Time types require ClickHouse 25.6+")
+
+    if test_config.cloud:
+        pytest.skip(
+            "Time types require settings change, but settings are locked in cloud, skipping tests."
+        )
+
     test_client.command("SET enable_time_time64_type = 1")
     table_name = "test_time"
     with table_context(
@@ -157,7 +170,19 @@ def test_pandas_time_compat(test_client: Client, table_context: Callable):
             assert f"[{EXPECTED_RES}" in str(dt)
 
 
-def test_pandas_time64_compat(test_client: Client, table_context: Callable):
+def test_pandas_time64_compat(
+    test_config: TestConfig,
+    test_client: Client,
+    table_context: Callable,
+):
+    if not test_client.min_version("25.6"):
+        pytest.skip("Time64 types require ClickHouse 25.6+")
+
+    if test_config.cloud:
+        pytest.skip(
+            "Time types require settings change, but settings are locked in cloud, skipping tests."
+        )
+
     test_client.command("SET enable_time_time64_type = 1")
     table_name = "test_time64"
     with table_context(

--- a/tests/integration_tests/test_pandas_compat.py
+++ b/tests/integration_tests/test_pandas_compat.py
@@ -1,0 +1,184 @@
+import datetime
+from typing import Callable
+
+import pytest
+import pandas as pd
+
+from clickhouse_connect.driver import Client
+from clickhouse_connect.driver.options import pd
+
+PANDAS_VERSION = tuple(map(int, pd.__version__.split(".")[:2]))
+IS_PANDAS_2 = PANDAS_VERSION >= (2, 0)
+EXPECTED_RES = "ns"
+
+pytestmark = pytest.mark.skipif(pd is None, reason="Pandas package not installed")
+
+
+def test_pandas_date_compat(test_client: Client, table_context: Callable):
+    table_name = "test_date"
+    with table_context(
+        table_name,
+        [
+            "key UInt8",
+            "dt Date",
+            "ndt Nullable(Date)",
+        ],
+    ):
+        df = pd.DataFrame(
+            [
+                [1, pd.Timestamp(1992, 10, 15), pd.Timestamp(2023, 5, 4)],
+                [2, pd.Timestamp(2088, 1, 31), pd.NaT],
+                [3, pd.Timestamp(1971, 4, 15), pd.Timestamp(2101, 12, 31)],
+            ],
+            columns=["key", "dt", "ndt"],
+        )
+        test_client.insert_df(table_name, df)
+        result_df = test_client.query_df(f"SELECT * FROM {table_name}")
+
+        for dt in list(result_df.dtypes)[1:]:
+            assert f"[{EXPECTED_RES}" in str(dt)
+
+
+def test_pandas_date32_compat(test_client: Client, table_context: Callable):
+    table_name = "test_date32"
+    with table_context(
+        table_name,
+        [
+            "key UInt8",
+            "dt Date32",
+            "ndt Nullable(Date32)",
+        ],
+    ):
+        df = pd.DataFrame(
+            [
+                [1, pd.Timestamp(1992, 10, 15), pd.Timestamp(2023, 5, 4)],
+                [2, pd.Timestamp(2088, 1, 31), pd.NaT],
+                [3, pd.Timestamp(1971, 4, 15), pd.Timestamp(2101, 12, 31)],
+            ],
+            columns=["key", "dt", "ndt"],
+        )
+        test_client.insert_df(table_name, df)
+        result_df = test_client.query_df(f"SELECT * FROM {table_name}")
+
+        for dt in list(result_df.dtypes)[1:]:
+            assert f"[{EXPECTED_RES}" in str(dt)
+
+
+def test_pandas_datetime_compat(test_client: Client, table_context: Callable):
+    table_name = "test_datetime"
+    with table_context(
+        table_name,
+        [
+            "key UInt8",
+            "dt DateTime",
+            "ndt Nullable(DateTime)",
+        ],
+    ):
+        df = pd.DataFrame(
+            [
+                [1, pd.Timestamp(1992, 10, 15), pd.Timestamp(2023, 5, 4)],
+                [2, pd.Timestamp(2088, 1, 31), pd.NaT],
+                [3, pd.Timestamp(1971, 4, 15), pd.Timestamp(2101, 12, 31)],
+            ],
+            columns=["key", "dt", "ndt"],
+        )
+        test_client.insert_df(table_name, df)
+        result_df = test_client.query_df(f"SELECT * FROM {table_name}")
+
+        for dt in list(result_df.dtypes)[1:]:
+            assert f"[{EXPECTED_RES}" in str(dt)
+
+
+def test_pandas_datetime64_compat(test_client: Client, table_context: Callable):
+    table_name = "test_datetime64"
+    with table_context(
+        table_name,
+        [
+            "key UInt8",
+            "dt3 DateTime64(3)",
+            "null_dt3 Nullable(DateTime64(3))",
+            "dt6 DateTime64(6)",
+            "null_dt6 Nullable(DateTime64(6))",
+            "dt9 DateTime64(9)",
+            "null_dt9 Nullable(DateTime64(9))",
+        ],
+    ):
+        df = pd.DataFrame(
+            [
+                [
+                    1,
+                    pd.Timestamp(1992, 10, 15),
+                    pd.Timestamp(2023, 5, 4),
+                    pd.Timestamp(1992, 10, 15),
+                    pd.Timestamp(2023, 5, 4),
+                    pd.Timestamp(1992, 10, 15),
+                    pd.Timestamp(2023, 5, 4),
+                ],
+                [
+                    2,
+                    pd.Timestamp(1992, 10, 15),
+                    pd.NaT,
+                    pd.Timestamp(1992, 10, 15),
+                    pd.NaT,
+                    pd.Timestamp(1992, 10, 15),
+                    pd.NaT,
+                ],
+            ],
+            columns=["key", "dt3", "null_dt3", "dt6", "null_dt6", "dt9", "null_dt9"],
+        )
+        test_client.insert_df(table_name, df)
+        result_df = test_client.query_df(f"SELECT * FROM {table_name}")
+
+        for dt in list(result_df.dtypes)[1:]:
+            assert f"[{EXPECTED_RES}" in str(dt)
+
+
+def test_pandas_time_compat(test_client: Client, table_context: Callable):
+    test_client.command("SET enable_time_time64_type = 1")
+    table_name = "test_time"
+    with table_context(
+        table_name,
+        [
+            "key UInt8",
+            "t Time",
+            "null_t Nullable(Time)",
+        ],
+    ):
+        data = (
+            [1, datetime.timedelta(hours=5), 500],
+            [2, datetime.timedelta(hours=1), None],
+            [3, -datetime.timedelta(minutes=45), 600],
+        )
+
+        test_client.insert(table_name, data)
+        result_df = test_client.query_df(f"SELECT * FROM {table_name}")
+
+        for dt in list(result_df.dtypes)[1:]:
+            assert f"[{EXPECTED_RES}" in str(dt)
+
+
+def test_pandas_time64_compat(test_client: Client, table_context: Callable):
+    test_client.command("SET enable_time_time64_type = 1")
+    table_name = "test_time64"
+    with table_context(
+        table_name,
+        [
+            "key UInt8",
+            "t3 Time64(3)",
+            "null_t3 Nullable(Time64(3))",
+            "t6 Time64(6)",
+            "null_t6 Nullable(Time64(6))",
+            "t9 Time64(9)",
+            "null_t9 Nullable(Time64(9))",
+        ],
+    ):
+        data = (
+            [1, 1, 2, 3, 4, 5, 6],
+            [2, 10, None, 30, None, 50, None],
+            [3, 100, 200, 300, 400, 500, 600],
+        )
+        test_client.insert(table_name, data)
+        result_df = test_client.query_df(f"SELECT * FROM {table_name}")
+
+        for dt in list(result_df.dtypes)[1:]:
+            assert f"[{EXPECTED_RES}" in str(dt)

--- a/tests/unit_tests/test_driver/test_temporal.py
+++ b/tests/unit_tests/test_driver/test_temporal.py
@@ -150,20 +150,22 @@ class TestTimeDataType(unittest.TestCase):
 
     def test_to_ticks_array_mixed_types_error(self):
         with patch.object(self.time_type, "write_format", return_value="native"):
-            with self.assertRaises(TypeError):
+            with self.assertRaises(ValueError):
                 self.time_type._to_ticks_array([1, "000:00:01"])
 
     # pylint: disable=c-extension-no-member
     def test_active_null_with_extended_dtypes(self):
         self.time_type.nullable = True
         ctx = SimpleNamespace(use_extended_dtypes=True, use_none=False)
-        null = self.time_type._active_null(ctx)
+        with patch.object(self.time_type, "read_format", return_value="native"):
+            null = self.time_type._active_null(ctx)
         self.assertTrue(isinstance(null, pd._libs.tslibs.nattype.NaTType))
 
     def test_active_null_with_use_none(self):
         self.time_type.nullable = True
         ctx = SimpleNamespace(use_extended_dtypes=False, use_none=True)
-        self.assertIsNone(self.time_type._active_null(ctx))
+        with patch.object(self.time_type, "read_format", return_value="native"):
+            self.assertIsNone(self.time_type._active_null(ctx))
 
     def test_build_lc_column_numpy(self):
         index = [timedelta(seconds=i) for i in range(5)]
@@ -346,13 +348,15 @@ class TestTime64DataType(unittest.TestCase):
     def test_active_null_with_extended_dtypes(self):
         t6 = self.make(6, nullable=True)
         ctx = SimpleNamespace(use_extended_dtypes=True, use_none=False)
-        null = t6._active_null(ctx)
+        with patch.object(t6, "read_format", return_value="native"):
+            null = t6._active_null(ctx)
         self.assertTrue(isinstance(null, pd._libs.tslibs.nattype.NaTType))
 
     def test_active_null_with_use_none(self):
         t6 = self.make(6, nullable=True)
         ctx = SimpleNamespace(use_extended_dtypes=False, use_none=True)
-        self.assertIsNone(t6._active_null(ctx))
+        with patch.object(t6, "read_format", return_value="native"):
+            self.assertIsNone(t6._active_null(ctx))
 
     # ------------------------------------------------------------------
     # Invalid constructor scale


### PR DESCRIPTION
## Summary

This PR:
- Fixes some errors when inserting dataframes of `Time` and `Time64` types.
- Enforce consistent resolution of `datetime64` and `timedelta64` dtypes when using `query_df` regardless of Pandas version
- Wires up a way to leverage additional Pandas 2.x resolutions of "s", "ms", "us" for `datetime64` and `timedelta64` dtypes. Note this PR does not expose that ability to the public API yet, but has put the wiring in place. Some additional work around Pandas version detection and setting the flag to use it will come in a future PR.
- Introduces a Pandas compatibility test file that can be expanded to ensure consistent behavior between 1.x and 2.x
- Improves null and nullable handling for time types, including tests to validate new behaviors

Closes #165 
Closes #524 

## Checklist
Delete items not relevant to your PR:
- [x] Unit and integration tests covering the common scenarios were added
- [x] A human-readable description of the changes was provided to include in CHANGELOG