### PR TITLE
add pandas 1x and 2x testing to ci

### DIFF
--- a/.github/workflows/on_push.yml
+++ b/.github/workflows/on_push.yml
@@ -106,10 +106,10 @@ jobs:
           SQLALCHEMY_SILENCE_UBER_WARNING: 1
         run: pytest tests
 
-  pandas-2x-compat-test:
+  pandas-1x-compat-test:
     runs-on: ubuntu-latest
     needs: lint
-    name: Pandas 2.x Compatibility Tests
+    name: Pandas 1.x Compatibility Tests
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -128,8 +128,8 @@ jobs:
         run:  python -m pip install --upgrade pip
       - name: Install Test Dependencies
         run: pip install -r tests/test_requirements.txt
-      - name: Install Pandas 2.x
-        run: pip install "pandas>=2.0.0,<3.0" # Override pandas version
+      - name: Install pandas 1.x
+        run: pip install "pandas>=1.5,<2.0" # Override pandas version
       - name: Build cython extensions
         run: python setup.py build_ext --inplace
       - name: "Add distribution info"  #  This lets SQLAlchemy find entry points
@@ -146,7 +146,7 @@ jobs:
 
   check-secret:
     runs-on: ubuntu-latest
-    needs: [tests, pandas-2x-compat-test]
+    needs: [tests, pandas-1x-compat-test]
     outputs:
       has_secrets: ${{ steps.has_secrets.outputs.HAS_SECRETS }}
     steps:

--- a/.github/workflows/on_push.yml
+++ b/.github/workflows/on_push.yml
@@ -142,7 +142,7 @@ jobs:
           CLICKHOUSE_CONNECT_TEST_TLS: 1
           CLICKHOUSE_CONNECT_TEST_DOCKER: 'False'
           SQLALCHEMY_SILENCE_UBER_WARNING: 1
-        run: pytest tests/test_pandas_compat.py tests/test_pandas.py
+        run: pytest tests/integration_tests/test_pandas_compat.py tests/integration_tests/test_pandas.py
 
   check-secret:
     runs-on: ubuntu-latest

--- a/.github/workflows/on_push.yml
+++ b/.github/workflows/on_push.yml
@@ -106,9 +106,47 @@ jobs:
           SQLALCHEMY_SILENCE_UBER_WARNING: 1
         run: pytest tests
 
+  pandas-2x-compat-test:
+    runs-on: ubuntu-latest
+    needs: lint
+    name: Pandas 2.x Compatibility Tests
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+      - name: Start ClickHouse (version - latest) in Docker
+        uses: hoverkraft-tech/compose-action@v2.0.0
+        env:
+          CLICKHOUSE_CONNECT_TEST_CH_VERSION: latest
+        with:
+          compose-file: 'docker-compose.yml'
+          down-flags: '--volumes'
+      - name: Set up Python 3.11
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+      - name: Install pip
+        run:  python -m pip install --upgrade pip
+      - name: Install Test Dependencies
+        run: pip install -r tests/test_requirements.txt
+      - name: Install Pandas 2.x
+        run: pip install "pandas>=2.0.0,<3.0" # Override pandas version
+      - name: Build cython extensions
+        run: python setup.py build_ext --inplace
+      - name: "Add distribution info"  #  This lets SQLAlchemy find entry points
+        run: python setup.py develop
+      - name: Add ClickHouse TLS instance to /etc/hosts
+        run: |
+          sudo echo "127.0.0.1 server1.clickhouse.test" | sudo tee -a /etc/hosts
+      - name: Run tests
+        env:
+          CLICKHOUSE_CONNECT_TEST_TLS: 1
+          CLICKHOUSE_CONNECT_TEST_DOCKER: 'False'
+          SQLALCHEMY_SILENCE_UBER_WARNING: 1
+        run: pytest tests/test_pandas_compat.py tests/test_pandas.py
+
   check-secret:
     runs-on: ubuntu-latest
-    needs: tests
+    needs: [tests, pandas-2x-compat-test]
     outputs:
       has_secrets: ${{ steps.has_secrets.outputs.HAS_SECRETS }}
     steps:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ instead of being passed as ClickHouse server settings. This is in conjunction wi
 The supported method of passing ClickHouse server settings is to prefix such arguments/query parameters with`ch_`.
 
 ## UNRELEASED
+- Added pandas 1.x/2.x compatibility tests to CI
 - Begins effort toward Pandas 2.x support. Specifically:
     - Plumbs up a mechanism allowing date-like objects to leverage the additional Pandas 2.x datetime64/timedelta64 resolutions of "s", "ms", "us".
     - Introduces pandas compatibility tests that can be expanded and support for more 2.x features become available.

--- a/tests/test_requirements.txt
+++ b/tests/test_requirements.txt
@@ -13,7 +13,7 @@ pytest-cov
 numpy~=1.22.0; python_version >= '3.8' and python_version <= '3.10'
 numpy~=1.26.0; python_version >= '3.11' and python_version <= '3.12'
 numpy~=2.1.0; python_version >= '3.13'
-pandas>=1.5.0,<2.0
+pandas>=2.0,<3.0
 zstandard
 lz4
 pyjwt[crypto]==2.10.1

--- a/tests/test_requirements.txt
+++ b/tests/test_requirements.txt
@@ -13,7 +13,7 @@ pytest-cov
 numpy~=1.22.0; python_version >= '3.8' and python_version <= '3.10'
 numpy~=1.26.0; python_version >= '3.11' and python_version <= '3.12'
 numpy~=2.1.0; python_version >= '3.13'
-pandas
+pandas>=1.5.0,<2.0
 zstandard
 lz4
 pyjwt[crypto]==2.10.1


### PR DESCRIPTION
## Summary
The PR:
 - Pins pandas in test_requirements.py to `pandas>=2.0,<3.0`.
   - As this was not previously pinned we were getting whatever the latest version pip grabbed was, which was likely 2.x
 - Adds a compatibility test to CI that uses Python 3.11 (the latest version that pandas 1.x officially supports) and ClickHouse server `latest`.