### PR TITLE
add special interval type support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ instead of being passed as ClickHouse server settings. This is in conjunction wi
 The supported method of passing ClickHouse server settings is to prefix such arguments/query parameters with`ch_`.
 
 ## UNRELEASED
+- Added support for special [interval types](https://clickhouse.com/docs/en/sql-reference/data-types/special-data-types/interval). Closes [#391](https://github.com/ClickHouse/clickhouse-connect/issues/391)
 - Added new common setting option "preserve_pandas_datetime_resolution" (default is `False`) allowing pandas 2.x users to opt into (when set to `True`) using the additional pandas 2.x datetime64/timedelta64 resolutions of "s", "ms", "us". If set to `False` or using  pandas 1.x, all datetime64/timedelta64 resolutions will be coerced to "ns". (See [here](https://pandas.pydata.org/docs/whatsnew/v2.0.0.html#construction-with-datetime64-or-timedelta64-dtype-with-unsupported-resolution) for more info). Closes [#165](https://github.com/ClickHouse/clickhouse-connect/issues/165) and [#531](https://github.com/ClickHouse/clickhouse-connect/issues/531)
 - Support for both pandas 1.x and 2.x
 - Added pandas 1.x/2.x compatibility tests to CI

--- a/clickhouse_connect/datatypes/numeric.py
+++ b/clickhouse_connect/datatypes/numeric.py
@@ -464,3 +464,47 @@ class Decimal128(BigDecimal):
 
 class Decimal256(BigDecimal):
     dec_size = 256
+
+
+class IntervalNanosecond(Int32):
+    pass
+
+
+class IntervalMicrosecond(Int32):
+    pass
+
+
+class IntervalMillisecond(Int32):
+    pass
+
+
+class IntervalSecond(Int32):
+    pass
+
+
+class IntervalMinute(Int32):
+    pass
+
+
+class IntervalHour(Int32):
+    pass
+
+
+class IntervalDay(Int32):
+    pass
+
+
+class IntervalWeek(Int32):
+    pass
+
+
+class IntervalMonth(Int32):
+    pass
+
+
+class IntervalQuarter(Int32):
+    pass
+
+
+class IntervalYear(Int32):
+    pass

--- a/tests/integration_tests/test_numeric.py
+++ b/tests/integration_tests/test_numeric.py
@@ -80,3 +80,17 @@ class TestBFloat16:
         assert result.row_count == len(input_data)
         for result_row, expected_row in zip(result.result_rows, expected):
             assert list(result_row) == expected_row
+
+
+class TestSpecialIntervalTypes:
+    """Integration tests for ClickHouse special interval type handling."""
+
+    client: Client
+
+    @pytest.fixture(autouse=True)
+    def setup_teardown(self, test_client: Client):
+        self.client = test_client
+
+    def test_interval_selects_work(self):
+        result = self.client.query("SELECT INTERVAL 30 DAY")
+        assert result.result_rows[0][0] == 30


### PR DESCRIPTION
## Summary
Adds support for [interval](https://clickhouse.com/docs/en/sql-reference/data-types/special-data-types/interval) types.

Closes #391

## Checklist
Delete items not relevant to your PR:
- [X] Unit and integration tests covering the common scenarios were added
- [X] A human-readable description of the changes was provided to include in CHANGELOG
