### PR TITLE
support for sqalchemy 2.x

### DIFF
--- a/.github/workflows/on_push.yml
+++ b/.github/workflows/on_push.yml
@@ -144,9 +144,47 @@ jobs:
           SQLALCHEMY_SILENCE_UBER_WARNING: 1
         run: pytest tests/integration_tests/test_pandas_compat.py tests/integration_tests/test_pandas.py
 
+  sqlalchemy-2x-compat-test:
+    runs-on: ubuntu-latest
+    needs: lint
+    name: SQLAlchemy 2.x Compatibility Tests
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+      - name: Start ClickHouse (version - latest) in Docker
+        uses: hoverkraft-tech/compose-action@v2.0.0
+        env:
+          CLICKHOUSE_CONNECT_TEST_CH_VERSION: latest
+        with:
+          compose-file: 'docker-compose.yml'
+          down-flags: '--volumes'
+      - name: Set up Python 3.11
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+      - name: Install pip
+        run:  python -m pip install --upgrade pip
+      - name: Install Test Dependencies
+        run: pip install -r tests/test_requirements.txt
+      - name: Install sqlalchemy 2.x
+        run: pip install "sqlalchemy>=2.0,<3.0" # Override sqa version
+      - name: Build cython extensions
+        run: python setup.py build_ext --inplace
+      - name: "Add distribution info"  #  This lets SQLAlchemy find entry points
+        run: python setup.py develop
+      - name: Add ClickHouse TLS instance to /etc/hosts
+        run: |
+          sudo echo "127.0.0.1 server1.clickhouse.test" | sudo tee -a /etc/hosts
+      - name: Run tests
+        env:
+          CLICKHOUSE_CONNECT_TEST_TLS: 1
+          CLICKHOUSE_CONNECT_TEST_DOCKER: 'False'
+          SQLALCHEMY_SILENCE_UBER_WARNING: 1
+        run: pytest tests/integration_tests/test_sqlalchemy
+
   check-secret:
     runs-on: ubuntu-latest
-    needs: [tests, pandas-1x-compat-test]
+    needs: [tests, pandas-1x-compat-test, sqlalchemy-2x-compat-test]
     outputs:
       has_secrets: ${{ steps.has_secrets.outputs.HAS_SECRETS }}
     steps:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ instead of being passed as ClickHouse server settings. This is in conjunction wi
 The supported method of passing ClickHouse server settings is to prefix such arguments/query parameters with`ch_`.
 
 ## UNRELEASED
+- Added support for SQLAlchemy 2.x. Now supports >=1.4.40,<3.0. Closes [#263](https://github.com/ClickHouse/clickhouse-connect/issues/263)
 - Added support for querying/inserting pyarrow-backed DataFrames:
   - `query_df_arrow()`: returns a pandas DataFrame with PyArrow dtype backend. Note that Arrow data types are preserved without additional conversions.
   - `query_df_arrow_stream()`: Streaming version of `query_df_arrow()` for processing large result sets.

--- a/clickhouse_connect/cc_sqlalchemy/dialect.py
+++ b/clickhouse_connect/cc_sqlalchemy/dialect.py
@@ -1,4 +1,3 @@
-
 from sqlalchemy import text
 from sqlalchemy.engine.default import DefaultDialect
 
@@ -33,9 +32,16 @@ class ClickHouseDialect(DefaultDialect):
     ischema_names = ischema_names
     inspector = ChInspector
 
+    # SQA 1 compatibility
     # pylint: disable=method-hidden
     @classmethod
     def dbapi(cls):
+        return dbapi
+
+    # SQA 2 compatibility
+    # pylint: disable=method-hidden
+    @classmethod
+    def import_dbapi(cls):
         return dbapi
 
     def initialize(self, connection):

--- a/setup.py
+++ b/setup.py
@@ -64,7 +64,7 @@ def run_setup(try_c: bool = True):
             'lz4'
         ],
         extras_require={
-            'sqlalchemy': ['sqlalchemy>1.3.21,<2.0'],
+            'sqlalchemy': ['sqlalchemy>=1.4.40,<2.0'],
             'numpy': ['numpy'],
             'pandas': ['pandas'],
             'arrow': ['pyarrow'],
@@ -80,7 +80,6 @@ def run_setup(try_c: bool = True):
             'Development Status :: 4 - Beta',
             'Intended Audience :: Developers',
             'License :: OSI Approved :: Apache Software License',
-            'Programming Language :: Python :: 3.8',
             'Programming Language :: Python :: 3.9',
             'Programming Language :: Python :: 3.10',
             'Programming Language :: Python :: 3.11',

--- a/tests/integration_tests/test_sqlalchemy/test_ddl.py
+++ b/tests/integration_tests/test_sqlalchemy/test_ddl.py
@@ -1,10 +1,10 @@
 from enum import Enum as PyEnum
 
 import sqlalchemy as db
-from sqlalchemy import MetaData
+from sqlalchemy import MetaData, text
 
 from sqlalchemy.engine.base import Engine
-from sqlalchemy.ext.declarative import declarative_base
+from sqlalchemy.orm import declarative_base
 
 from tests.integration_tests.conftest import TestConfig
 from clickhouse_connect import common
@@ -18,14 +18,14 @@ from clickhouse_connect.cc_sqlalchemy.ddl.tableengine import engine_map
 def test_create_database(test_engine: Engine, test_config: TestConfig, test_db: str):
     if test_db:
         common.set_setting('invalid_setting_action', 'drop')
-        conn = test_engine.connect()
-        create_db = f'create_db_{test_db}'
-        if not test_engine.dialect.has_database(conn, create_db):
-            if test_config.host == 'localhost' and conn.connection.connection.client.min_version('20'):
-                conn.execute(CreateDatabase(create_db, 'Atomic'))
-            else:
-                conn.execute(CreateDatabase(create_db))
-        conn.execute(DropDatabase(create_db))
+        with test_engine.begin() as conn:
+            create_db = f'create_db_{test_db}'
+            if not test_engine.dialect.has_database(conn, create_db):
+                if test_config.host == 'localhost' and conn.connection.driver_connection.client.min_version('20'):
+                    conn.execute(CreateDatabase(create_db, 'Atomic'))
+                else:
+                    conn.execute(CreateDatabase(create_db))
+            conn.execute(DropDatabase(create_db))
 
 
 class ColorEnum(PyEnum):
@@ -37,57 +37,57 @@ class ColorEnum(PyEnum):
 
 def test_create_table(test_engine: Engine, test_db: str, test_table_engine: str):
     common.set_setting('invalid_setting_action', 'drop')
-    conn = test_engine.connect()
-    table_cls = engine_map[test_table_engine]
-    metadata = db.MetaData(bind=test_engine, schema=test_db)
-    conn.execute('DROP TABLE IF EXISTS simple_table_test')
-    bool_type = Boolean
-    date_tz64_type = DateTime64(3, 'Europe/Moscow')
-    if not conn.connection.connection.client.min_version('20'):
-        bool_type = Int8
-        date_tz64_type = DateTime('Europe/Moscow')
-    table = db.Table('simple_table_test', metadata,
-                     db.Column('key_col', Int8),
-                     db.Column('uint_col', UInt16),
-                     db.Column('dec_col', Decimal(38, 5)),  # Decimal128(5)
-                     db.Column('enum_col', Enum16(ColorEnum)),
-                     db.Column('float_col', Float64),
-                     db.Column('str_col', String),
-                     db.Column('fstr_col', FixedString(17)),
-                     db.Column('bool_col', bool_type),
-                     table_cls(('key_col', 'uint_col'), primary_key='key_col'))
-    table.create(conn)
-    conn.execute('DROP TABLE IF EXISTS advanced_table_test')
-    table = db.Table('advanced_table_test', metadata,
-                     db.Column('key_col', UInt64),
-                     db.Column('uuid_col', UUID),
-                     db.Column('dt_col', DateTime),
-                     db.Column('ip_col', IPv4),
-                     db.Column('dt64_col', date_tz64_type),
-                     db.Column('lc_col', LowCardinality(FixedString(16))),
-                     db.Column('lc_date_col', LowCardinality(Nullable(String))),
-                     db.Column('null_dt_col', Nullable(DateTime('America/Denver'))),
-                     db.Column('arr_col', Array(UUID)),
-                     db.Column('agg_col', AggregateFunction('uniq', LowCardinality(String))),
-                     table_cls('key_col'))
-    table.create(conn)
+    with test_engine.begin() as conn:
+        table_cls = engine_map[test_table_engine]
+        metadata = db.MetaData(schema=test_db)
+        conn.execute(text('DROP TABLE IF EXISTS simple_table_test'))
+        bool_type = Boolean
+        date_tz64_type = DateTime64(3, 'Europe/Moscow')
+        if not conn.connection.driver_connection.client.min_version('20'):
+            bool_type = Int8
+            date_tz64_type = DateTime('Europe/Moscow')
+        table = db.Table('simple_table_test', metadata,
+                        db.Column('key_col', Int8),
+                        db.Column('uint_col', UInt16),
+                        db.Column('dec_col', Decimal(38, 5)),  # Decimal128(5)
+                        db.Column('enum_col', Enum16(ColorEnum)),
+                        db.Column('float_col', Float64),
+                        db.Column('str_col', String),
+                        db.Column('fstr_col', FixedString(17)),
+                        db.Column('bool_col', bool_type),
+                        table_cls(('key_col', 'uint_col'), primary_key='key_col'))
+        table.create(conn)
+        conn.execute(text('DROP TABLE IF EXISTS advanced_table_test'))
+        table = db.Table('advanced_table_test', metadata,
+                        db.Column('key_col', UInt64),
+                        db.Column('uuid_col', UUID),
+                        db.Column('dt_col', DateTime),
+                        db.Column('ip_col', IPv4),
+                        db.Column('dt64_col', date_tz64_type),
+                        db.Column('lc_col', LowCardinality(FixedString(16))),
+                        db.Column('lc_date_col', LowCardinality(Nullable(String))),
+                        db.Column('null_dt_col', Nullable(DateTime('America/Denver'))),
+                        db.Column('arr_col', Array(UUID)),
+                        db.Column('agg_col', AggregateFunction('uniq', LowCardinality(String))),
+                        table_cls('key_col'))
+        table.create(conn)
 
 
 def test_declarative(test_engine: Engine, test_db: str, test_table_engine: str):
     common.set_setting('invalid_setting_action', 'drop')
-    conn = test_engine.connect()
-    conn.execute('DROP TABLE IF EXISTS users_test')
-    table_cls = engine_map[test_table_engine]
-    base_cls = declarative_base(metadata=MetaData(schema=test_db))
+    with test_engine.begin() as conn:
+        conn.execute(text('DROP TABLE IF EXISTS users_test'))
+        table_cls = engine_map[test_table_engine]
+        base_cls = declarative_base(metadata=MetaData(schema=test_db))
 
-    class User(base_cls):
-        __tablename__ = 'users_test'
-        __table_args__ = (table_cls(order_by=['id', 'name']),)
-        id = db.Column(UInt32, primary_key=True)
-        name = db.Column(String)
-        fullname = db.Column(String)
-        nickname = db.Column(String)
+        class User(base_cls):
+            __tablename__ = 'users_test'
+            __table_args__ = (table_cls(order_by=['id', 'name']),)
+            id = db.Column(UInt32, primary_key=True)
+            name = db.Column(String)
+            fullname = db.Column(String)
+            nickname = db.Column(String)
 
-    base_cls.metadata.create_all(test_engine)
-    user = User(name='Alice')
-    assert user.name == 'Alice'
+        base_cls.metadata.create_all(test_engine)
+        user = User(name='Alice')
+        assert user.name == 'Alice'

--- a/tests/integration_tests/test_sqlalchemy/test_reflect.py
+++ b/tests/integration_tests/test_sqlalchemy/test_reflect.py
@@ -1,6 +1,7 @@
 # pylint: disable=no-member
 import sqlalchemy as db
 from sqlalchemy.engine import Engine
+from sqlalchemy import text
 
 from clickhouse_connect import common
 from clickhouse_connect.cc_sqlalchemy.datatypes.sqltypes import UInt32, SimpleAggregateFunction, Point
@@ -8,46 +9,46 @@ from clickhouse_connect.cc_sqlalchemy.datatypes.sqltypes import UInt32, SimpleAg
 
 def test_basic_reflection(test_engine: Engine):
     common.set_setting('invalid_setting_action', 'drop')
-    conn = test_engine.connect()
-    metadata = db.MetaData(bind=test_engine, schema='system')
-    table = db.Table('tables', metadata, autoload_with=test_engine)
-    query = db.select([table.columns.create_table_query])
-    result = conn.execute(query)
-    rows = result.fetchmany(100)
-    assert rows
+    with test_engine.begin() as conn:
+        metadata = db.MetaData(schema='system')
+        table = db.Table('tables', metadata, autoload_with=test_engine)
+        query = db.select(table.columns.create_table_query)
+        result = conn.execute(query)
+        rows = result.fetchmany(100)
+        assert rows
 
 
 def test_full_table_reflection(test_engine: Engine, test_db: str):
     common.set_setting('invalid_setting_action', 'drop')
-    conn = test_engine.connect()
-    conn.execute(f'DROP TABLE IF EXISTS {test_db}.reflect_test')
-    conn.execute(
-        f'CREATE TABLE {test_db}.reflect_test (key UInt32, value FixedString(20),'+
-        'agg SimpleAggregateFunction(anyLast, String))' +
-        'ENGINE AggregatingMergeTree ORDER BY key')
-    metadata = db.MetaData(bind=test_engine, schema=test_db)
-    table = db.Table('reflect_test', metadata, autoload_with=test_engine)
-    assert table.columns.key.type.__class__ == UInt32
-    assert table.columns.agg.type.__class__ == SimpleAggregateFunction
-    assert 'MergeTree' in table.engine.name
+    with test_engine.begin() as conn:
+        conn.execute(text(f'DROP TABLE IF EXISTS {test_db}.reflect_test'))
+        conn.execute(text(
+            f'CREATE TABLE {test_db}.reflect_test (key UInt32, value FixedString(20),'+
+            'agg SimpleAggregateFunction(anyLast, String))' +
+            'ENGINE AggregatingMergeTree ORDER BY key'))
+        metadata = db.MetaData(schema=test_db)
+        table = db.Table('reflect_test', metadata, autoload_with=test_engine)
+        assert table.columns.key.type.__class__ == UInt32
+        assert table.columns.agg.type.__class__ == SimpleAggregateFunction
+        assert 'MergeTree' in table.engine.name
 
 
 def test_types_reflection(test_engine: Engine, test_db: str):
     common.set_setting('invalid_setting_action', 'drop')
-    conn = test_engine.connect()
-    conn.execute(f'DROP TABLE IF EXISTS {test_db}.sqlalchemy_types_test')
-    conn.execute(
-        f'CREATE TABLE {test_db}.sqlalchemy_types_test (key UInt32, pt Point) ' +
-        'ENGINE MergeTree ORDER BY key')
-    metadata = db.MetaData(bind=test_engine, schema=test_db)
-    table = db.Table('sqlalchemy_types_test', metadata, autoload_with=test_engine)
-    assert table.columns.key.type.__class__ == UInt32
-    assert table.columns.pt.type.__class__ == Point
-    assert 'MergeTree' in table.engine.name
+    with test_engine.begin() as conn:
+        conn.execute(text(f'DROP TABLE IF EXISTS {test_db}.sqlalchemy_types_test'))
+        conn.execute(text(
+            f'CREATE TABLE {test_db}.sqlalchemy_types_test (key UInt32, pt Point) ' +
+            'ENGINE MergeTree ORDER BY key'))
+        metadata = db.MetaData(schema=test_db)
+        table = db.Table('sqlalchemy_types_test', metadata, autoload_with=test_engine)
+        assert table.columns.key.type.__class__ == UInt32
+        assert table.columns.pt.type.__class__ == Point
+        assert 'MergeTree' in table.engine.name
 
 
 def test_table_exists(test_engine: Engine):
     common.set_setting('invalid_setting_action', 'drop')
-    conn = test_engine.connect()
-    assert test_engine.dialect.has_table(conn, 'columns', 'system')
-    assert not test_engine.dialect.has_table(conn, 'nope', 'fake_db')
+    with test_engine.begin() as conn:
+        assert test_engine.dialect.has_table(conn, 'columns', 'system')
+        assert not test_engine.dialect.has_table(conn, 'nope', 'fake_db')

--- a/tests/test_requirements.txt
+++ b/tests/test_requirements.txt
@@ -2,7 +2,7 @@ pytz
 urllib3>=1.26
 setuptools
 certifi
-sqlalchemy>1.3.21,<2.0
+sqlalchemy>=1.4.40,<2.0
 cython==3.0.11
 pyarrow
 pytest


### PR DESCRIPTION
## Summary
- Provides support for sqlalchemy 2. Supported version range is now sqlalchemy>=1.4.40,<3.0.
- Removes support for sqlalchemy 1.3 as it [has reached](https://www.sqlalchemy.org/download.html#status-desc-eol) EOL.
- Updates test requirements to pin sqa version to >=1.4.40,<2.0 and adds a new separate CI step to also run all sqalchemy tests against 2.x

Closes #263

## Checklist
- [X] A human-readable description of the changes was provided to include in CHANGELOG