### PR TITLE
Joe/111 polars support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ instead of being passed as ClickHouse server settings. This is in conjunction wi
 The supported method of passing ClickHouse server settings is to prefix such arguments/query parameters with`ch_`.
 
 ## UNRELEASED
+- Added Polars support for Arrow-based query and insert methods (query_df_arrow, query_df_arrow_stream, insert_df_arrow). This initial implementation provides basic dataframe conversion through the Arrow format, similar to how we support the pyarrow-backed pandas dataframes. Closes [#111](https://github.com/ClickHouse/clickhouse-connect/issues/111) and [#542](https://github.com/ClickHouse/clickhouse-connect/issues/542)
 - Added support for SQLAlchemy 2.x. The minimum required version is 1.4.40. Closes [#263](https://github.com/ClickHouse/clickhouse-connect/issues/263)
   - **WARNING: BREAKING CHANGE**: Removed support for sqlalchemy 1.3 which reached its EOL in 2021.
 - Added support for querying/inserting pyarrow-backed DataFrames:

--- a/clickhouse_connect/driver/asyncclient.py
+++ b/clickhouse_connect/driver/asyncclient.py
@@ -351,9 +351,10 @@ class AsyncClient:
         use_strings: Optional[bool] = None,
         external_data: Optional[ExternalData] = None,
         transport_settings: Optional[Dict[str, str]] = None,
-    ):
+        dataframe_library: str = "pandas",
+    ) -> Union["pd.DataFrame", "pl.DataFrame"]:
         """
-        Query method using the ClickHouse Arrow format to return a pandas DataFrame
+        Query method using the ClickHouse Arrow format to return a DataFrame
         with PyArrow dtype backend. This provides better performance and memory efficiency
         compared to the standard query_df method, though fewer output formatting options.
 
@@ -363,7 +364,8 @@ class AsyncClient:
         :param use_strings: Convert ClickHouse String type to Arrow string type (instead of binary)
         :param external_data: ClickHouse "external data" to send with query
         :param transport_settings: Optional dictionary of transport level settings (HTTP headers, etc.)
-        :return: Pandas DataFrame with PyArrow dtype backend
+        :param dataframe_library: Library to use for DataFrame creation ("pandas" or "polars")
+        :return: DataFrame (pandas or polars based on dataframe_library parameter)
         """
 
         def _query_df_arrow():
@@ -374,6 +376,7 @@ class AsyncClient:
                 use_strings=use_strings,
                 external_data=external_data,
                 transport_settings=transport_settings,
+                dataframe_library=dataframe_library
             )
 
         loop = asyncio.get_running_loop()
@@ -423,9 +426,10 @@ class AsyncClient:
         use_strings: Optional[bool] = None,
         external_data: Optional[ExternalData] = None,
         transport_settings: Optional[Dict[str, str]] = None,
-    ):
+        dataframe_library: str = "pandas"
+    ) -> StreamContext:
         """
-        Query method that returns the results as a stream of pandas DataFrames with PyArrow dtype backend.
+        Query method that returns the results as a stream of DataFrames with PyArrow dtype backend.
         Each DataFrame represents a block from the ClickHouse response.
 
         :param query: Query statement/format string
@@ -434,7 +438,8 @@ class AsyncClient:
         :param use_strings: Convert ClickHouse String type to Arrow string type (instead of binary)
         :param external_data: ClickHouse "external data" to send with query
         :param transport_settings: Optional dictionary of transport level settings (HTTP headers, etc.)
-        :return: Generator that yields pandas DataFrames with PyArrow dtype backend
+        :param dataframe_library: Library to use for DataFrame creation ("pandas" or "polars")
+        :return: StreamContext that yields DataFrames (pandas or polars based on dataframe_library parameter)
         """
 
         def _query_df_arrow_stream():
@@ -445,6 +450,7 @@ class AsyncClient:
                 use_strings=use_strings,
                 external_data=external_data,
                 transport_settings=transport_settings,
+                dataframe_library=dataframe_library
             )
 
         loop = asyncio.get_running_loop()
@@ -718,21 +724,22 @@ class AsyncClient:
     async def insert_df_arrow(
         self,
         table: str,
-        df: "pd.DataFrame",
+        df: Union["pd.DataFrame", "pl.DataFrame"],
         database: Optional[str] = None,
         settings: Optional[Dict] = None,
         transport_settings: Optional[Dict[str, str]] = None,
     ) -> QuerySummary:
         """
-        Insert a pandas DataFrame with PyArrow backend into ClickHouse using Arrow format.
-        This method is optimized for DataFrames that already use PyArrow dtypes, providing
+        Insert a pandas DataFrame with PyArrow backend or a polars DataFrame into ClickHouse using Arrow format.
+        This method is optimized for DataFrames that already use Arrow format, providing
         better performance than the standard insert_df method.
-
-        IMPORTANT: This method requires the DataFrame to have PyArrow-backed columns. 
-        Validation is performed and an exception will be raised if this requirement is not met.
-
+        
+        IMPORTANT: For pandas DataFrames, this method requires the DataFrame to have PyArrow-backed columns. 
+        Validation is performed and an exception will be raised if this requirement is not met.py
+        Polars DataFrames are natively Arrow-based and don't require additional validation.
+        
         :param table: ClickHouse table name
-        :param df: Pandas DataFrame with PyArrow dtype backend (from query_df_arrow or pd.read_* with dtype_backend='pyarrow')
+        :param df: Pandas DataFrame with PyArrow dtype backend or Polars DataFrame
         :param database: Optional ClickHouse database name
         :param settings: Optional dictionary of ClickHouse settings (key/string values)
         :param transport_settings: Optional dictionary of transport level settings (HTTP headers, etc.)

--- a/clickhouse_connect/driver/client.py
+++ b/clickhouse_connect/driver/client.py
@@ -19,7 +19,7 @@ from clickhouse_connect.driver.constants import CH_VERSION_WITH_PROTOCOL, PROTOC
 from clickhouse_connect.driver.exceptions import ProgrammingError, OperationalError, DataError
 from clickhouse_connect.driver.external import ExternalData
 from clickhouse_connect.driver.insert import InsertContext
-from clickhouse_connect.driver.options import check_arrow, check_pandas, check_numpy, pd, arrow, IS_PANDAS_2
+from clickhouse_connect.driver.options import check_arrow, check_pandas, check_numpy, check_polars, pd, arrow, pl, IS_PANDAS_2
 from clickhouse_connect.driver.summary import QuerySummary
 from clickhouse_connect.driver.models import ColumnDef, SettingDef, SettingStatus
 from clickhouse_connect.driver.query import QueryResult, to_arrow, to_arrow_batches, QueryContext, arrow_buffer
@@ -30,6 +30,7 @@ logger = logging.getLogger(__name__)
 arrow_str_setting = 'output_format_arrow_string_as_string'
 
 
+# pylint: disable=too-many-lines
 # pylint: disable=too-many-public-methods,too-many-arguments,too-many-positional-arguments,too-many-instance-attributes
 class Client(ABC):
     """
@@ -588,9 +589,10 @@ class Client(ABC):
                        use_strings: Optional[bool] = None,
                        external_data: Optional[ExternalData] = None,
                        transport_settings: Optional[Dict[str, str]] = None,
-                       ) -> pd.DataFrame:
+                       dataframe_library: str = "pandas"
+                       ) -> Union["pd.DataFrame", "pl.DataFrame"]:
         """
-        Query method using the ClickHouse Arrow format to return a pandas DataFrame
+        Query method using the ClickHouse Arrow format to return a DataFrame
         with PyArrow dtype backend. This provides better performance and memory efficiency
         compared to the standard query_df method, though fewer output formatting options.
 
@@ -600,11 +602,27 @@ class Client(ABC):
         :param use_strings: Convert ClickHouse String type to Arrow string type (instead of binary)
         :param external_data: ClickHouse "external data" to send with query
         :param transport_settings: Optional dictionary of transport level settings (HTTP headers, etc.)
-        :return: Pandas DataFrame with PyArrow dtype backend
+        :param dataframe_library: Library to use for DataFrame creation ("pandas" or "polars")
+        :return: DataFrame (pandas or polars based on dataframe_library parameter)
         """
-        check_pandas()
-        if not IS_PANDAS_2:
-            raise ProgrammingError("PyArrow-backed dtypes are only supported when using pandas 2.x.")
+        check_arrow()
+
+        if dataframe_library == "pandas":
+            check_pandas()
+            if not IS_PANDAS_2:
+                raise ProgrammingError("PyArrow-backed dtypes are only supported when using pandas 2.x.")
+
+            def converter(table: arrow.Table) -> pd.DataFrame:
+                return table.to_pandas(types_mapper=pd.ArrowDtype, safe=False)
+
+        elif dataframe_library == "polars":
+            check_polars()
+
+            def converter(table: arrow.Table) -> pl.DataFrame:
+                return pl.from_arrow(table)
+
+        else:
+            raise ValueError(f"dataframe_library must be 'pandas' or 'polars', got '{dataframe_library}'")
 
         arrow_table = self.query_arrow(
             query=query,
@@ -614,7 +632,8 @@ class Client(ABC):
             external_data=external_data,
             transport_settings=transport_settings,
         )
-        return arrow_table.to_pandas(types_mapper=pd.ArrowDtype, safe=False)
+
+        return converter(arrow_table)
 
     def query_df_arrow_stream(self,
                              query: str,
@@ -622,37 +641,47 @@ class Client(ABC):
                              settings: Optional[Dict[str, Any]] = None,
                              use_strings: Optional[bool] = None,
                              external_data: Optional[ExternalData] = None,
-                             transport_settings: Optional[Dict[str, str]] = None):
+                             transport_settings: Optional[Dict[str, str]] = None,
+                             dataframe_library: str = "pandas") -> StreamContext:
         """
-        Query method that returns the results as a stream of pandas DataFrames with PyArrow dtype backend.
+        Query method that returns the results as a stream of DataFrames with PyArrow dtype backend.
         Each DataFrame represents a block from the ClickHouse response.
-        
+
         :param query: Query statement/format string
         :param parameters: Optional dictionary used to format the query
         :param settings: Optional dictionary of ClickHouse settings (key/string values)
         :param use_strings: Convert ClickHouse String type to Arrow string type (instead of binary)
         :param external_data: ClickHouse "external data" to send with query
         :param transport_settings: Optional dictionary of transport level settings (HTTP headers, etc.)
-        :return: Generator that yields pandas DataFrames with PyArrow dtype backend
+        :param dataframe_library: Library to use for DataFrame creation ("pandas" or "polars")
+        :return: StreamContext that yields DataFrames (pandas or polars based on dataframe_library parameter)
         """
-        check_pandas()
+        check_arrow()
+        if dataframe_library == "pandas":
+            check_pandas()
+            if not IS_PANDAS_2:
+                raise ProgrammingError("PyArrow-backed dtypes are only supported when using pandas 2.x.")
 
-        stream_context = self.query_arrow_stream(
-            query=query,
-            parameters=parameters,
-            settings=settings,
-            use_strings=use_strings,
-            external_data=external_data,
-            transport_settings=transport_settings
+            def converter(table: "arrow.Table") -> "pd.DataFrame":
+                return table.to_pandas(types_mapper=pd.ArrowDtype, safe=False)
+        elif dataframe_library == "polars":
+            check_polars()
+
+            def converter(table: arrow.Table) -> pl.DataFrame:
+                return pl.from_arrow(table)
+        else:
+            raise ValueError(f"dataframe_library must be 'pandas' or 'polars', got '{dataframe_library}'")
+        settings = self._update_arrow_settings(settings, use_strings)
+        raw_stream = self.raw_stream(
+            query, parameters, settings, fmt="ArrowStream", external_data=external_data, transport_settings=transport_settings
         )
+        reader = arrow.ipc.open_stream(raw_stream)
 
-        with stream_context as ctx:
-            for arrow_table in ctx:
-                df = arrow_table.to_pandas(
-                        types_mapper=pd.ArrowDtype,
-                        safe=False
-                    )
-                yield df
+        def df_generator():
+            for batch in reader:
+                yield converter(batch)
+
+        return StreamContext(raw_stream, df_generator())
 
     def _update_arrow_settings(self,
                                settings: Optional[Dict[str, Any]],
@@ -811,39 +840,55 @@ class Client(ABC):
 
     def insert_df_arrow(self,
                         table: str,
-                        df: pd.DataFrame,
+                        df: Union["pd.DataFrame", "pl.DataFrame"],
                         database: Optional[str] = None,
                         settings: Optional[Dict] = None,
                         transport_settings: Optional[Dict[str, str]] = None) -> QuerySummary:
         """
-        Insert a pandas DataFrame with PyArrow backend into ClickHouse using Arrow format.
-        This method is optimized for DataFrames that already use PyArrow dtypes, providing
+        Insert a pandas DataFrame with PyArrow backend or a polars DataFrame into ClickHouse using Arrow format.
+        This method is optimized for DataFrames that already use Arrow format, providing
         better performance than the standard insert_df method.
         
-        IMPORTANT: This method requires the DataFrame to have PyArrow-backed columns. 
-        Validation is performed and an exception will be raised if this requirement is not met.
+        IMPORTANT: For pandas DataFrames, this method requires the DataFrame to have PyArrow-backed columns. 
+        Validation is performed and an exception will be raised if this requirement is not met.py
+        Polars DataFrames are natively Arrow-based and don't require additional validation.
         
         :param table: ClickHouse table name
-        :param df: Pandas DataFrame with PyArrow dtype backend (from query_df_arrow or pd.read_* with dtype_backend='pyarrow')
+        :param df: Pandas DataFrame with PyArrow dtype backend or Polars DataFrame
         :param database: Optional ClickHouse database name
         :param settings: Optional dictionary of ClickHouse settings (key/string values)
         :param transport_settings: Optional dictionary of transport level settings (HTTP headers, etc.)
         :return: QuerySummary with summary information, throws exception if insert fails
         """
-        check_pandas()
-        if not IS_PANDAS_2:
-            raise ProgrammingError("PyArrow-backed dtypes are only supported when using pandas 2.x.")
         check_arrow()
 
-        non_arrow_cols = [col for col, dtype in df.dtypes.items() if not isinstance(dtype, pd.ArrowDtype)]
-        if non_arrow_cols:
-            raise ProgrammingError(
-                f"insert_df_arrow requires all columns to use PyArrow dtypes. Non-Arrow columns found: [{', '.join(non_arrow_cols)}]. "
-            )
-        try:
-            arrow_table = arrow.Table.from_pandas(df, preserve_index=False)
-        except Exception as e:
-            raise DataError(f"Failed to convert DataFrame to Arrow table: {e}") from e
+        if pd is not None and isinstance(df, pd.DataFrame):
+            df_lib = "pandas"
+        elif pl is not None and isinstance(df, pl.DataFrame):
+            df_lib = "polars"
+        else:
+            if pd is None and pl is None:
+                raise ImportError("A DataFrame library (pandas or polars) must be installed to use insert_df_arrow.")
+            raise TypeError(f"df must be either a pandas DataFrame or polars DataFrame, got {type(df).__name__}")
+
+        if df_lib == "pandas":
+            if not IS_PANDAS_2:
+                raise ProgrammingError("PyArrow-backed dtypes are only supported when using pandas 2.x.")
+
+            non_arrow_cols = [col for col, dtype in df.dtypes.items() if not isinstance(dtype, pd.ArrowDtype)]
+            if non_arrow_cols:
+                raise ProgrammingError(
+                    f"insert_df_arrow requires all columns to use PyArrow dtypes. Non-Arrow columns found: [{', '.join(non_arrow_cols)}]. "
+                )
+            try:
+                arrow_table = arrow.Table.from_pandas(df, preserve_index=False)
+            except Exception as e:
+                raise DataError(f"Failed to convert pandas DataFrame to Arrow table: {e}") from e
+        else:
+            try:
+                arrow_table = df.to_arrow()
+            except Exception as e:
+                raise DataError(f"Failed to convert polars DataFrame to Arrow table: {e}") from e
 
         return self.insert_arrow(
             table=table,

--- a/clickhouse_connect/driver/options.py
+++ b/clickhouse_connect/driver/options.py
@@ -37,6 +37,10 @@ try:
 except ImportError:
     arrow = None
 
+try:
+    import polars as pl
+except ImportError:
+    pl = None
 
 def check_numpy():
     if np:
@@ -54,3 +58,9 @@ def check_arrow():
     if arrow:
         return arrow
     raise NotSupportedError('PyArrow package is not installed')
+
+
+def check_polars():
+    if pl:
+        return pl
+    raise NotSupportedError("Polars package is not installed")

--- a/setup.py
+++ b/setup.py
@@ -67,6 +67,7 @@ def run_setup(try_c: bool = True):
             'sqlalchemy': ['sqlalchemy>=1.4.40,<3.0'],
             'numpy': ['numpy'],
             'pandas': ['pandas'],
+            'polars': ['polars>=1.0'],
             'arrow': ['pyarrow'],
             'orjson': ['orjson'],
             'tzlocal': ['tzlocal>=4.0'],

--- a/tests/integration_tests/test_polars.py
+++ b/tests/integration_tests/test_polars.py
@@ -110,8 +110,6 @@ def test_polars_arrow_stream(test_client: Client, table_context: Callable):
             assert df["counter"].dtype == pl.Int64
             assert df["letter"].dtype == pl.String
             expected_letter = df["counter"].map_elements(lambda x: alphabet[x % 26], return_dtype=pl.String)
-            print(expected_letter)
-            print(df["letter"])
             assert df["letter"].equals(expected_letter)
             total_rows += len(df)
         assert total_rows == 1000000

--- a/tests/integration_tests/test_polars.py
+++ b/tests/integration_tests/test_polars.py
@@ -1,0 +1,117 @@
+from datetime import datetime, date
+import string
+from typing import Callable
+
+import pytest
+
+from clickhouse_connect.driver import Client
+from clickhouse_connect.driver.options import pl, arrow
+
+pytestmark = [
+    pytest.mark.skipif(pl is None, reason="polars package not installed"),
+    pytest.mark.skipif(arrow is None, reason="pyarrow package not installed"),
+]
+
+
+def test_polars_insert(test_client: Client, table_context: Callable):
+    with table_context(
+        "test_polars",
+        [
+            "key String",
+            "num Nullable(Int32)",
+            "flt Float32",
+            "str Nullable(String)",
+            "dt DateTime('America/Denver')",
+            "day_col Nullable(Date)",
+        ],
+    ) as ctx:
+        df = pl.DataFrame(
+            {
+                "key": ["a", "b", "c"],
+                "num": [1, None, 3],
+                "flt": [1.2, 3.4, 5.6],
+                "str": [None, "mystr", "another"],
+                "dt": [datetime(2025, 7, 1, 10, 30, 0, 0), datetime(2025, 8, 1, 10, 30, 0, 0), datetime(2025, 8, 12, 10, 30, 1, 0)],
+                "day_col": [date(2025, 7, 1), date(2025, 8, 1), date(2025, 8, 12)],
+            }
+        )
+        test_client.insert_df_arrow(ctx.table, df)
+        res = test_client.query(f"SELECT key FROM {ctx.table}")
+        assert [i[0] for i in res.result_rows] == df["key"].to_list()
+
+
+def test_bad_insert_fails(test_client: Client, table_context: Callable):
+    with table_context(
+        "test_polars",
+        [
+            "key String",
+            "num Nullable(Int32)",
+            "flt Float32",
+            "str Nullable(String)",
+            "dt DateTime('America/Denver')",
+            "day_col Nullable(Date)",
+        ],
+    ):
+        with pytest.raises(TypeError, match="got list"):
+            test_client.insert_df_arrow("test_polars", [[1, 2, 3]])
+
+
+def test_polars_query(test_client: Client, table_context: Callable):
+    with table_context(
+        "test_polars",
+        [
+            "key String",
+            "num Nullable(Int32)",
+            "flt Float32",
+            "str Nullable(String)",
+            "dt DateTime('America/Denver')",
+            "day_col Nullable(Date)",
+        ],
+    ) as ctx:
+        data = [
+            ["a", "b", "c"],
+            [1, None, 3],
+            [1.2, 3.4, 5.6],
+            [None, "mystr", "another"],
+            [datetime(2025, 7, 1, 10, 30, 0, 0), datetime(2025, 8, 1, 10, 30, 0, 0), datetime(2025, 8, 12, 10, 30, 1, 0)],
+            [date(2025, 7, 1), date(2025, 8, 1), date(2025, 8, 12)],
+        ]
+        test_client.insert(
+            ctx.table,
+            data,
+            column_names=["key", "num", "flt", "str", "dt", "day_col"],
+            column_oriented=True,
+        )
+        df = test_client.query_df_arrow(f"SELECT key FROM {ctx.table}", dataframe_library="polars")
+        assert isinstance(df, pl.DataFrame)
+        assert data[0] == df["key"].to_list()
+
+
+def test_polars_arrow_stream(test_client: Client, table_context: Callable):
+    if not arrow:
+        pytest.skip("PyArrow package not available")
+    if not test_client.min_version("21"):
+        pytest.skip(f"PyArrow is not supported in this server version {test_client.server_version}")
+    with table_context("test_arrow_insert", ["counter Int64", "letter String"]):
+        counter = arrow.array(range(1000000))
+        alphabet = string.ascii_lowercase
+        letter = arrow.array([alphabet[x % 26] for x in range(1000000)])
+        names = ["counter", "letter"]
+        insert_table = arrow.Table.from_arrays([counter, letter], names=names)
+        test_client.insert_arrow("test_arrow_insert", insert_table)
+        stream = test_client.query_df_arrow_stream("SELECT * FROM test_arrow_insert", dataframe_library="polars")
+        with stream:
+            result_dfs = list(stream)
+
+        assert len(result_dfs) > 1
+        total_rows = 0
+        for df in result_dfs:
+            assert df.shape[1] == 2
+            assert df["counter"].dtype == pl.Int64
+            assert df["letter"].dtype == pl.String
+            expected_letter = df["counter"].map_elements(lambda x: alphabet[x % 26], return_dtype=pl.String)
+            print(expected_letter)
+            print(df["letter"])
+            assert df["letter"].equals(expected_letter)
+            total_rows += len(df)
+        assert total_rows == 1000000

--- a/tests/test_requirements.txt
+++ b/tests/test_requirements.txt
@@ -14,6 +14,7 @@ numpy~=1.22.0; python_version >= '3.8' and python_version <= '3.10'
 numpy~=1.26.0; python_version >= '3.11' and python_version <= '3.12'
 numpy~=2.1.0; python_version >= '3.13'
 pandas>=2.0,<3.0
+polars>=1.0
 zstandard
 lz4
 pyjwt[crypto]==2.10.1


### PR DESCRIPTION
## Summary
Introduces [Polars](https://docs.pola.rs) support. The implementation simply leverages the arrow table methods to get the arrow table and then performs a mostly zero-copy conversion to a Polars dataframe. This is the same way the pyarrow dtype backed Pandas dataframes works. It does introduce a kwarg into the `df_arrow*` methods called `dataframe_library`. Valid strings for this argument are "pandas" (default) or "polars".

## Checklist
- [X] Unit and integration tests covering the common scenarios were added
- [X] A human-readable description of the changes was provided to include in CHANGELOG