### PR TITLE
Joe/546 add library to user agent

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ instead of being passed as ClickHouse server settings. This is in conjunction wi
 The supported method of passing ClickHouse server settings is to prefix such arguments/query parameters with`ch_`.
 
 ## UNRELEASED
+- Add third-party library identifiers (name/version) in the User-Agent, e.g. pandas/2.2.5. Users can opt out by changing the common setting `send_integration_tags` to `False`.
 - Added support for form encoding query parameters when using HTTP interface. This addresses [#342](https://github.com/ClickHouse/clickhouse-connect/issues/342). Query parameters can now be sent as form-encoded data in the request body by setting `form_encode_query_params=True` when creating the client. This is particularly useful for queries with large parameter payloads that might exceed URL length limits.
 - Added Polars support for Arrow-based query and insert methods (query_df_arrow, query_df_arrow_stream, insert_df_arrow). This initial implementation provides basic dataframe conversion through the Arrow format, similar to how we support the pyarrow-backed pandas dataframes. Closes [#111](https://github.com/ClickHouse/clickhouse-connect/issues/111) and [#542](https://github.com/ClickHouse/clickhouse-connect/issues/542)
 - Added support for SQLAlchemy 2.x. The minimum required version is 1.4.40. Closes [#263](https://github.com/ClickHouse/clickhouse-connect/issues/263)
@@ -47,7 +48,7 @@ The supported method of passing ClickHouse server settings is to prefix such arg
 - Fixed an AttributeError on `http.client` when importing `clickhouse_connect` under certain circumstances
 - Added support for Nullable(JSON) types
 - Added support for BFloat16 types
--- Replace the use of deprecated datetime.utcfromtimestamp
+- Replace the use of deprecated `datetime.utcfromtimestamp`
 
 ## 0.8.18, 2025-06-24
 

--- a/clickhouse_connect/common.py
+++ b/clickhouse_connect/common.py
@@ -77,6 +77,11 @@ _init_common('product_name', (), '')  # Product name used as part of client iden
 _init_common('readonly', (0, 1), 0)  # Implied "read_only" ClickHouse settings for versions prior to 19.17
 _init_common('send_os_user', (True, False), True)
 
+# Include integration tags (library name/version) in the User-Agent, e.g.:
+# pandas/2.2.5; polars/0.20.x; sqlalchemy/2.0.x. These tags are only included
+# when using relevant API methods.
+_init_common('send_integration_tags', (True, False), True)
+
 # Use the client protocol version  This is needed for DateTime timezone columns but breaks with current version of
 # chproxy
 _init_common('use_protocol_version', (True, False), True)

--- a/clickhouse_connect/dbapi/connection.py
+++ b/clickhouse_connect/dbapi/connection.py
@@ -29,6 +29,10 @@ class Connection:
                                     secure=secure,
                                     dsn=dsn,
                                     generic_args=kwargs)
+        try:
+            self.client._add_integration_tag("sqlalchemy")
+        except Exception: # pylint: disable=broad-exception-caught
+            pass
         self.timezone = self.client.server_tz
 
     def close(self):

--- a/tests/integration_tests/test_sqlalchemy/test_inserts.py
+++ b/tests/integration_tests/test_sqlalchemy/test_inserts.py
@@ -42,6 +42,16 @@ def test_single_insert(test_engine: Engine, test_model):
         conn.execute(db.insert(test_model), {'test_name': 'another_single_insert'})
 
 
+def test_user_agent_integration_tags(test_engine: Engine):
+    with test_engine.begin():
+        client = test_engine.raw_connection().driver_connection.client
+        ua = client.headers["User-Agent"]
+        if db.__version__.startswith("1."):
+            assert "sqlalchemy/1." in ua
+        else:
+            assert "sqlalchemy/2." in ua
+
+
 def test_multiple_insert(test_engine: Engine, test_model):
     session = Session(test_engine)
     model_1 = test_model(test_name='multi_1',


### PR DESCRIPTION
## Summary
Adds 3rd party integration tags to the user agent. Prior to this the User-Agent would look like:

```clickhouse-connect/0.8.18 (lv:py/3.12.11; mode:sync; os:darwin)```

If the common setting `send_integration_tags` is set to `True` and the user uses the sqlalchemy integration capabilities, for example, the User-Agent would be updated to:

```clickhouse-connect/0.8.18 (sqlalchemy/2.0.43; lv:py/3.12.11; mode:sync; os:darwin)```

This will greatly help us to determine what kind of development effort should be spent supporting 3rd party integration libraries like pandas, polars, and SQLAlchemy and what versions of those libraries users have adopted.

Closes #546

## Checklist
- [X] Unit and integration tests covering the common scenarios were added
- [X] A human-readable description of the changes was provided to include in CHANGELOG
