### PR TITLE
"role" is a valid transport setting

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,8 @@ The supported method of passing ClickHouse server settings is to prefix such arg
 
 ## UNRELEASED
 
+- Allow passing `role` as a field in the `settings` keyword argument to set a role for a specific query
+
 ## 0.9.1, 2025-09-16
 
 - Fix problem with typing that forced numpy to be installed.
@@ -61,7 +63,6 @@ The supported method of passing ClickHouse server settings is to prefix such arg
 - Changed `AsyncClient.settings` typing to `Optional[Dict[str, Any]]` to accept None inputs.
 - Added more robust error handling and tests. Closes [#508](https://github.com/ClickHouse/clickhouse-connect/issues/508)
 - Replace the use of deprecated `datetime.utcfromtimestamp`
-- Allow passing `role` as a field in the `settings` keyword argument to set a role for a specific query
 
 ### Bug Fixes
 - Fixed an AttributeError on `http.client` when importing `clickhouse_connect` under certain circumstances

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -61,6 +61,7 @@ The supported method of passing ClickHouse server settings is to prefix such arg
 - Changed `AsyncClient.settings` typing to `Optional[Dict[str, Any]]` to accept None inputs.
 - Added more robust error handling and tests. Closes [#508](https://github.com/ClickHouse/clickhouse-connect/issues/508)
 - Replace the use of deprecated `datetime.utcfromtimestamp`
+- Allow passing `role` as a field in the `settings` keyword argument to set a role for a specific query
 
 ### Bug Fixes
 - Fixed an AttributeError on `http.client` when importing `clickhouse_connect` under certain circumstances

--- a/clickhouse_connect/driver/httpclient.py
+++ b/clickhouse_connect/driver/httpclient.py
@@ -42,7 +42,8 @@ class HttpClient(Client):
     valid_transport_settings = {'database', 'buffer_size', 'session_id',
                                 'compress', 'decompress', 'session_timeout',
                                 'session_check', 'query_id', 'quota_key',
-                                'wait_end_of_query', 'client_protocol_version'}
+                                'wait_end_of_query', 'client_protocol_version',
+                                'role'}
     optional_transport_settings = {'send_progress_in_http_headers',
                                    'http_headers_progress_interval_ms',
                                    'enable_http_compression'}

--- a/tests/integration_tests/test_client.py
+++ b/tests/integration_tests/test_client.py
@@ -343,7 +343,7 @@ def test_column_rename_with_bad_option(test_config: TestConfig):
         )
 
 
-def test_role_setting_works(test_client: Client, test_config: TestConfig):
+def test_role_setting_works(test_client: Client):
     role_limited = 'limit_rows_role'
     user_limited = 'limit_rows_user'
 


### PR DESCRIPTION
## Summary
This makes it possible to set a role for a given query. It's still not possible to set *multiple* roles because the way this is expressed in the protocol is by *repeating* the `role=` query parameter, which this application doesn't know how to do. 

A better full-featured solution would be to add a `role=` kwarg that takes a set of roles and builds the query parameters correctly. That's a lot of work, though, so I wanted to offer this quick/hacky workaround to unblock myself for now.

#549

## Checklist
- [x] A human-readable description of the changes was provided to include in CHANGELOG