### PR TITLE
fix python_requires def

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@ The supported method of passing ClickHouse server settings is to prefix such arg
 
 ## UNRELEASED
 
+- Updated `python_requires` to drop Python 3.8 and advertise support for 3.9–3.13
 - Allow passing `role` as a field in the `settings` keyword argument to set a role for a specific query
 
 ## 0.9.1, 2025-09-16

--- a/setup.py
+++ b/setup.py
@@ -54,7 +54,7 @@ def run_setup(try_c: bool = True):
         package_data={'clickhouse_connect': ['VERSION', 'py.typed']},
         url='https://github.com/ClickHouse/clickhouse-connect',
         packages=find_packages(exclude=['tests*']),
-        python_requires='~=3.8',
+        python_requires='>=3.9,<3.14',
         license='Apache License 2.0',
         install_requires=[
             'certifi',


### PR DESCRIPTION
## Summary
Correctly advertise valid Python versions via `python_requires` in the setup.py.