### PR TITLE
fix ambiguous time bug

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@ The supported method of passing ClickHouse server settings is to prefix such arg
 ## UNRELEASED
 
 ### Bug Fixes
+- Fixed DST fallback bug in DateTime and DateTime64 types caused by passing potentially ambiguous times to pd.DateTimeIndex constructor.
 - Fixed issue with JSON key dot escaping. Closes [#571](https://github.com/ClickHouse/clickhouse-connect/issues/571)
 
 ### Improvements

--- a/clickhouse_connect/datatypes/temporal.py
+++ b/clickhouse_connect/datatypes/temporal.py
@@ -89,8 +89,8 @@ class Date(ClickHouseType):
                 if column.tz is None:
                     return column.astype(self.pandas_dtype)
 
-                naive = column.tz_localize(None).astype(self.pandas_dtype)
-                return pd.DatetimeIndex(naive, tz=column.tz)
+                naive = column.tz_convert("UTC").tz_localize(None).astype(self.pandas_dtype)
+                return naive.tz_localize("UTC").tz_convert(column.tz)
 
             if self.nullable and isinstance(column, list):
                 return np.array([None if pd.isna(s) else s for s in column]).astype(
@@ -159,8 +159,8 @@ class DateTimeBase(ClickHouseType, registered=False):
                     result = column.astype(self.pandas_dtype)
                     return pd.array(result) if self.nullable else result
 
-                naive_ns = column.tz_localize(None).astype(self.pandas_dtype)
-                tz_aware_result = pd.DatetimeIndex(naive_ns, tz=column.tz)
+                naive_ns = column.tz_convert("UTC").tz_localize(None).astype(self.pandas_dtype)
+                tz_aware_result = naive_ns.tz_localize("UTC").tz_convert(column.tz)
                 return (
                     pd.array(tz_aware_result) if self.nullable else tz_aware_result
                 )


### PR DESCRIPTION
## Summary
During DST fallback, the same time can occur twice. Without additional kwargs, `pd.DatetimeIndex` can't interpret ambiguous times. This is fixed by converting to UTC (which is never ambiguous) before removing the timezone, then re-localizing to UTC and converting back to the target timezone.

## Checklist
Delete items not relevant to your PR:
- [X] Unit and integration tests covering the common scenarios were added
- [X] A human-readable description of the changes was provided to include in CHANGELOG

Closes #585 