### PR TITLE
run daily integration tests against head

### DIFF
--- a/.github/workflows/clickhouse_ci.yml
+++ b/.github/workflows/clickhouse_ci.yml
@@ -38,9 +38,9 @@ jobs:
           SQLALCHEMY_SILENCE_UBER_WARNING: 1
         run: pytest tests/integration_tests
 
-      - name: Run ClickHouse Container (LATEST)
-        run: CLICKHOUSE_CONNECT_TEST_CH_VERSION=latest docker compose up -d clickhouse
-      - name: Run LATEST tests
+      - name: Run ClickHouse Container (HEAD)
+        run: CLICKHOUSE_CONNECT_TEST_CH_VERSION=head docker compose up -d clickhouse
+      - name: Run HEAD tests
         run: pytest tests/integration_tests
-      - name: remove latest container
+      - name: remove HEAD container
         run: docker compose down -v


### PR DESCRIPTION
## Summary
Updates daily integration test suite to run again server head version instead of latest. This will give us much earlier visibility into breaking changes from the server's dev branch and will serve as a proper canary for upstream changes before they're released.

Closes #591