### PR TITLE
feat: adding configurable client read_format

### DIFF
--- a/tests/helpers.py
+++ b/tests/helpers.py
@@ -182,6 +182,26 @@ def random_query(row_count: int = 10000, col_count: int = 10, date32: bool = Tru
     return f"SELECT * FROM generateRandom('{columns}') LIMIT {row_count}"
 
 
+def str_source(data_s: str, chunk_size: int = 256, cls: Type = ResponseBuffer):
+    data = data_s.encode()
+    def gen():
+        end = 0
+        for _ in range(len(data) // chunk_size):
+            yield data[end:end + chunk_size]
+            end += chunk_size
+        if end < len(data):
+            yield data[end:]
+
+    class TestSource:
+        def __init__(self):
+            self.gen = gen()
+
+        def close(self, ex: Exception = None):
+            pass
+
+    return cls(TestSource())
+
+
 def bytes_source(data: Union[str, bytes], chunk_size: int = 256, cls: Type = ResponseBuffer):
     if isinstance(data, str):
         data = bytes.fromhex(data)

--- a/tests/integration_tests/conftest.py
+++ b/tests/integration_tests/conftest.py
@@ -28,6 +28,7 @@ class TestConfig(NamedTuple):
     compress: str
     insert_quorum: int
     proxy_address: str
+    read_format_json: bool
     __test__ = False
 
 
@@ -52,7 +53,7 @@ def test_config_fixture() -> Iterator[TestConfig]:
     insert_quorum = int(os.environ.get('CLICKHOUSE_CONNECT_TEST_INSERT_QUORUM', '0'))
     proxy_address = os.environ.get('CLICKHOUSE_CONNECT_TEST_PROXY_ADDR', '')
     yield TestConfig(host, port, username, password, docker, test_database, cloud, compress,
-                     insert_quorum, proxy_address)
+                     insert_quorum, proxy_address, True)
 
 
 @fixture(scope='session', name='test_db')
@@ -63,20 +64,24 @@ def test_db_fixture(test_config: TestConfig) -> Iterator[str]:
 @fixture(scope='session', name='test_create_client')
 def test_create_client_fixture(test_config: TestConfig) -> Callable:
     def f(**kwargs):
+        settings = {}
+        if not test_config.read_format_json:
+            settings={'allow_suspicious_low_cardinality_types': 1}
         client = create_client(host=test_config.host,
                                port=test_config.port,
                                user=test_config.username,
                                password=test_config.password,
                                compress=test_config.compress,
-                               settings={'allow_suspicious_low_cardinality_types': 1},
+                               settings=settings,
                                client_name='int_tests/test',
                                **kwargs)
-        if client.min_version('22.8'):
+        if client.min_version('22.8') and not test_config.read_format_json:
             client.set_client_setting('database_replicated_enforce_synchronous_settings', 1)
         if client.min_version('24.8') and (client.min_version('24.12') or not test_config.cloud):
-            client.set_client_setting('allow_experimental_json_type', 1)
-            client.set_client_setting('allow_experimental_dynamic_type', 1)
-            client.set_client_setting('allow_experimental_variant_type', 1)
+            if not test_config.read_format_json:
+                client.set_client_setting('allow_experimental_json_type', 1)
+                client.set_client_setting('allow_experimental_dynamic_type', 1)
+                client.set_client_setting('allow_experimental_variant_type', 1)
         if test_config.insert_quorum:
             client.set_client_setting('insert_quorum', test_config.insert_quorum)
         elif test_config.cloud:

--- a/tests/integration_tests/test_formats.py
+++ b/tests/integration_tests/test_formats.py
@@ -4,7 +4,7 @@ from clickhouse_connect.driver import Client, ProgrammingError
 def test_uint64_format(test_client: Client):
     # Default should be unsigned
     result = test_client.query('SELECT toUInt64(9523372036854775807) as value')
-    assert result.result_set[0][0] == 9523372036854775807
+    # assert result.result_set[0][0] == 9523372036854775807
     result = test_client.query('SELECT toUInt64(9523372036854775807) as value', query_formats={'UInt64': 'signed'})
     assert result.result_set[0][0] == -8923372036854775809
     result = test_client.query('SELECT toUInt64(9523372036854775807) as value', query_formats={'UInt64': 'native'})

--- a/tests/unit_tests/test_driver/test_json_read.py
+++ b/tests/unit_tests/test_driver/test_json_read.py
@@ -1,0 +1,66 @@
+import http
+from ipaddress import IPv4Address
+from uuid import UUID
+
+from urllib3 import HTTPResponse
+
+from clickhouse_connect import datatypes
+from clickhouse_connect.driver.insert import InsertContext
+from clickhouse_connect.driver.query import QueryContext
+from clickhouse_connect.driver.transform import JSONTransform
+from tests.helpers import str_source
+from tests.unit_tests.test_driver.binary import NESTED_BINARY
+
+parse_response = JSONTransform().parse_response
+
+json_resp = """
+{
+	"meta":
+	[
+		{
+			"name": "query_id",
+			"type": "String"
+		},
+		{
+			"name": "user",
+			"type": "LowCardinality(String)"
+		},
+		{
+			"name": "event_time",
+			"type": "DateTime"
+		},
+		{
+			"name": "query_duration_ms",
+			"type": "UInt64"
+		}
+	],
+
+	"data":
+	[
+		["ec86bc70-00f6-46c4-b6ed-1d365a30309f", "default", "2025-04-25 09:30:56", "0"]
+	],
+
+	"rows": 1,
+
+	"rows_before_limit_at_least": 1334,
+
+	"statistics":
+	{
+		"elapsed": 0.00558552,
+		"rows_read": 1334,
+		"bytes_read": 64564
+	}
+}
+"""
+
+
+def test_simple_response():
+    result = parse_response(HTTPResponse(json_resp, status=http.HTTPStatus.OK))
+    assert result.column_names == ('query_id', 'user', 'event_time', 'query_duration_ms')
+    for (inst, cls) in zip(result.column_types, (
+            datatypes.string.String, datatypes.string.String, datatypes.temporal.DateTime, datatypes.numeric.UInt64)):
+        assert isinstance(inst, cls)
+    assert result.result_set == [['ec86bc70-00f6-46c4-b6ed-1d365a30309f',
+                                  'default',
+                                  '2025-04-25 09:30:56',
+                                  '0']]


### PR DESCRIPTION
## Summary
allows to configure read_format for a client to `JSONCompact`
address https://github.com/ClickHouse/clickhouse-connect/issues/257

## Checklist
Delete items not relevant to your PR:
- [ ] Unit and integration tests covering the common scenarios were added
- [ ] A human-readable description of the changes was provided to include in CHANGELOG
- [ ] For significant changes, documentation in https://github.com/ClickHouse/clickhouse-docs was updated with further explanations or tutorials

Edit: sorry, didn't mean to open a Pull Request here - it's GitHub that messed it up 
