### PR TITLE
add if exists to drop

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,8 @@ The supported method of passing ClickHouse server settings is to prefix such arg
 
 ## UNRELEASED
 ### Bug Fixes
+- Fix issue with DROP table in client temp table test.
+
 ### Improvements
 
 ## 0.10.0, 2025-11-14

--- a/tests/integration_tests/test_client.py
+++ b/tests/integration_tests/test_client.py
@@ -234,7 +234,7 @@ def test_temporary_tables(test_client: Client):
     test_client.insert_df('temp_test_table', df, settings=session_settings)
     df = test_client.query_df('SELECT * FROM temp_test_table', settings=session_settings)
     assert len(df['field1']) == 4
-    test_client.command('DROP TABLE temp_test_table', settings=session_settings)
+    test_client.command('DROP TABLE IF EXISTS temp_test_table', settings=session_settings)
 
 
 def test_str_as_bytes(test_client: Client, table_context: Callable):


### PR DESCRIPTION
## Summary
This test would intermittently fail in cloud. Adding `IF EXISTS` should help.