### PR TITLE
Add native write path for Variant data type

### DIFF
--- a/clickhouse_connect/datatypes/special.py
+++ b/clickhouse_connect/datatypes/special.py
@@ -13,6 +13,7 @@ empty_uuid_b = bytes(b'\x00' * 16)
 
 
 class UUID(ClickHouseType):
+    python_type = PYUUID
     valid_formats = 'string', 'native'
     np_type = 'U36'
     byte_size = 16

--- a/clickhouse_connect/datatypes/string.py
+++ b/clickhouse_connect/datatypes/string.py
@@ -12,6 +12,7 @@ from clickhouse_connect.driver.options import np, pd
 
 
 class String(ClickHouseType):
+    python_type = str
     valid_formats = 'bytes', 'native'
 
     def _active_encoding(self, ctx):
@@ -58,6 +59,7 @@ class String(ClickHouseType):
 
 
 class FixedString(ClickHouseType):
+    python_type = str
     valid_formats = 'string', 'native'
 
     def __init__(self, type_def: TypeDef):

--- a/tests/unit_tests/test_dynamic.py
+++ b/tests/unit_tests/test_dynamic.py
@@ -1,0 +1,18 @@
+import pytest
+from clickhouse_connect.datatypes.registry import get_from_name
+from clickhouse_connect.datatypes.dynamic import typed_variant
+from clickhouse_connect.driver.exceptions import DataError
+
+def test_variant_data_size():
+    v_type = get_from_name('Variant(UInt8, String)')
+
+    assert v_type.data_size([]) == 1
+    assert v_type.data_size([1, 2, 3]) == 2
+    assert v_type.data_size([1, "hello"]) == 4
+    assert v_type.data_size([typed_variant(1, 'UInt8'), typed_variant("a", 'String')]) == 2
+
+def test_variant_invalid_data_size():
+    v_type = get_from_name('Variant(UInt8, Int32)')
+
+    with pytest.raises(DataError):
+        v_type.data_size(["not an int"])


### PR DESCRIPTION
## Summary
Taking a stab at implementing this enhancement https://github.com/ClickHouse/clickhouse-connect/issues/534.

Implement native write path for Variant data type, replacing the previous approach that serialized all values as strings. 

Values are now written in native binary format with automatic type dispatch based on Python types. For ambiguous cases (e.g., `Variant(Array(UInt32), Array(String))` where both map to list), a `typed_variant()` helper allows explicit type tagging. 

When automatic dispatch is ambiguous and no explicit type tag is provided, an exception is raised. This is a backwards-incompatible change - previously the value would have been stored as a string if the Variant contained a String type.                                                                                                                                                                              

## Migration note

Previously, values inserted into `Variant` columns were stringified and sent to the server,
which stored them in the `String` member when available. With this change, values are
dispatched to their native ClickHouse types client-side.

**Before:**
```python
# Variant(Int64, String)
client.insert('t', [[100], ['hello']], column_names=['v'])
# SELECT variantType(v) → 'String', 'String'
```
**After:**
```python
# Variant(Int64, String)
client.insert('t', [[100], ['hello']], column_names=['v'])
# SELECT variantType(v) → 'Int64', 'String'
```

If your variant column contains members that share a Python type (e.g. `Array(UInt32)` and `Array(String)` are both list), use the new typed_variant helper to disambiguate:
```python
from clickhouse_connect.datatypes.dynamic import typed_variant

client.insert('t', [[typed_variant([1, 2], 'Array(UInt32)')],
                    [typed_variant(['a', 'b'], 'Array(String)')]], column_names=['v'])
```

Values that cannot be mapped to any variant member now raise DataError immediately,
rather than being stringified and sent to the server.

Closes #514

## Checklist
Delete items not relevant to your PR:
- [x] Unit and integration tests covering the common scenarios were added
- [x] A human-readable description of the changes was provided to include in CHANGELOG
- [ ] For significant changes, documentation in https://github.com/ClickHouse/clickhouse-docs was updated with further explanations or tutorials
