### PR TITLE
Add GROUP BY alias rendering to ClickHouse SQLAlchemy compiler

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,7 @@ are now serialized using their native ClickHouse types client-side (e.g. inserti
 
 ### Bug Fixes
 - Recognize `UPDATE` as a command so lightweight updates work correctly via `client.query()` and SQLAlchemy.
+- SQLAlchemy: `GROUP BY` now renders label aliases instead of full expressions which avoids circular reference errors when an alias shadows a source column name in ClickHouse.
 
 ## 0.11.0, 2026-02-10
 

--- a/clickhouse_connect/cc_sqlalchemy/sql/compiler.py
+++ b/clickhouse_connect/cc_sqlalchemy/sql/compiler.py
@@ -1,4 +1,5 @@
 from sqlalchemy.exc import CompileError
+from sqlalchemy.sql import elements
 from sqlalchemy.sql.compiler import SQLCompiler
 
 from clickhouse_connect.cc_sqlalchemy import ArrayJoin
@@ -83,6 +84,33 @@ class ChStatementCompiler(SQLCompiler):
 
     def visit_sequence(self, sequence, **kw):
         raise NotImplementedError("ClickHouse doesn't support sequences")
+
+    def group_by_clause(self, select, **kw):
+        """Render GROUP BY using label aliases instead of full expressions."""
+        kw["_ch_group_by"] = True
+        return super().group_by_clause(select, **kw)
+
+    # pylint: disable=protected-access
+    def visit_label(
+        self,
+        label,
+        within_columns_clause=False,
+        render_label_as_label=None,
+        **kw,
+    ):
+        ch_group_by = kw.pop("_ch_group_by", False)
+        if ch_group_by and not within_columns_clause and render_label_as_label is None:
+            if isinstance(label.name, elements._truncated_label):
+                labelname = self._truncated_identifier("colident", label.name)
+            else:
+                labelname = label.name
+            return self.preparer.format_label(label, labelname)
+        return super().visit_label(
+            label,
+            within_columns_clause=within_columns_clause,
+            render_label_as_label=render_label_as_label,
+            **kw,
+        )
 
     def get_from_hint_text(self, table, text):
         if text == "FINAL":

--- a/tests/unit_tests/test_sqlalchemy/test_group_by_labels.py
+++ b/tests/unit_tests/test_sqlalchemy/test_group_by_labels.py
@@ -1,0 +1,71 @@
+import sqlalchemy as db
+from sqlalchemy import func
+
+from clickhouse_connect.cc_sqlalchemy.datatypes.sqltypes import String, UInt32, DateTime
+from clickhouse_connect.cc_sqlalchemy.dialect import ClickHouseDialect
+
+dialect = ClickHouseDialect()
+metadata = db.MetaData()
+
+commits = db.Table(
+    "commits",
+    metadata,
+    db.Column("time", DateTime),
+    db.Column("author", String),
+    db.Column("lines_added", UInt32),
+)
+
+
+def compile_query(stmt):
+    return str(stmt.compile(dialect=dialect, compile_kwargs={"literal_binds": True}))
+
+
+def test_group_by_renders_label_alias():
+    """Labeled expression in GROUP BY should render the alias, not the full expression."""
+    time_label = func.toStartOfDay(func.toDateTime(commits.c.time)).label("time")
+    stmt = db.select(time_label, func.sum(commits.c.lines_added)).group_by(time_label)
+    sql = compile_query(stmt)
+    assert "GROUP BY `time`" in sql
+    assert "GROUP BY toStartOfDay" not in sql
+
+
+def test_group_by_multiple_labels():
+    """Multiple labeled expressions in GROUP BY should all render as aliases."""
+    time_label = func.toStartOfDay(func.toDateTime(commits.c.time)).label("day")
+    author_label = func.lower(commits.c.author).label("author_lc")
+    stmt = (
+        db.select(time_label, author_label, func.sum(commits.c.lines_added))
+        .group_by(time_label, author_label)
+    )
+    sql = compile_query(stmt)
+    assert "GROUP BY `day`, `author_lc`" in sql
+
+
+def test_group_by_unlabeled_column():
+    """Unlabeled columns in GROUP BY should render normally (table-qualified)."""
+    stmt = (
+        db.select(commits.c.author, func.sum(commits.c.lines_added))
+        .group_by(commits.c.author)
+    )
+    sql = compile_query(stmt)
+    assert "GROUP BY `commits`.`author`" in sql
+
+
+def test_select_still_renders_full_expression():
+    """SELECT clause should still render the full expression AS alias (no regression)."""
+    time_label = func.toStartOfDay(func.toDateTime(commits.c.time)).label("time")
+    stmt = db.select(time_label, func.sum(commits.c.lines_added)).group_by(time_label)
+    sql = compile_query(stmt)
+    assert "toStartOfDay(toDateTime(`commits`.`time`)) AS `time`" in sql
+
+
+def test_order_by_still_renders_alias():
+    """ORDER BY should still render the alias (no regression)."""
+    time_label = func.toStartOfDay(func.toDateTime(commits.c.time)).label("time")
+    stmt = (
+        db.select(time_label, func.sum(commits.c.lines_added))
+        .group_by(time_label)
+        .order_by(time_label)
+    )
+    sql = compile_query(stmt)
+    assert "ORDER BY `time`" in sql


### PR DESCRIPTION
## Summary
ClickHouse resolves `SELECT` aliases inside `GROUP BY` expressions which causes circular reference errors when an alias shadows a source column name. For example

```sql
SELECT toStartOfDay(toDateTime(time)) AS time
...
GROUP BY toStartOfDay(toDateTime(time))
```

fails because `time` in the expression resolves to the alias, not the column.

This PR adds `group_by_clause` and `visit_label` overrides to `ChStatementCompiler` so that labeled expressions in `GROUP BY` render as their alias name instead of the full expression. Note that `SELECT` and `ORDER BY` rendering is unaffected.

This fixes the root cause and underlying issue behind https://github.com/apache/superset/issues/33551

Consequently, this should eliminate the need for Superset's [alias-mangling](https://github.com/apache/superset/pull/23185#issue-1598213991) workaround that appends hash suffixes to all ClickHouse column aliases to avoid these `GROUP BY` collisions.

To fully close the loop here I'll need to close https://github.com/apache/superset/pull/34091 and then open another PR that no-ops or removes the current [`_mutate_label`](https://github.com/apache/superset/blob/987b6a6f0419c9570f3429c78d2322b45a289fa5/superset/db_engine_specs/clickhouse.py#L522) behavior and then require a version of ciikchouse-connect in superset greater than or equal to whatever version we cut this release in.

## Checklist
Delete items not relevant to your PR:
- [X] Unit and integration tests covering the common scenarios were added
- [X] A human-readable description of the changes was provided to include in CHANGELOG