### PR TITLE
Add Python 3.14 free-threading (cp314t) wheel builds

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -17,8 +17,8 @@ jobs:
     name: Build x86 manylinux wheels on Linux
     runs-on: ubuntu-latest
     env:
-      CIBW_SKIP: '*-musllinux* pp38-* pp311-* cp38-* cp314t-*'
-      CIBW_ENABLE: 'pypy pypy-eol'
+      CIBW_SKIP: '*-musllinux* pp38-* pp311-* cp38-*'
+      CIBW_ENABLE: 'pypy pypy-eol cpython-freethreading'
     steps:
       - uses: actions/checkout@v4
       - name: Build wheels
@@ -32,8 +32,8 @@ jobs:
     name: Build x86 musllinux wheels on Linux
     runs-on: ubuntu-latest
     env:
-      CIBW_SKIP: '*-manylinux* pp38-* pp311-* cp38-* cp314t-*'
-      CIBW_ENABLE: 'pypy pypy-eol'
+      CIBW_SKIP: '*-manylinux* pp38-* pp311-* cp38-*'
+      CIBW_ENABLE: 'pypy pypy-eol cpython-freethreading'
     steps:
       - uses: actions/checkout@v4
       - name: Build wheels
@@ -48,7 +48,8 @@ jobs:
     runs-on: ubuntu-latest
     env:
       CIBW_ARCHS_LINUX: aarch64
-      CIBW_SKIP: '*-musllinux* cp38-* cp314t-*'
+      CIBW_SKIP: '*-musllinux* cp38-*'
+      CIBW_ENABLE: 'cpython-freethreading'
     steps:
       - uses: actions/checkout@v4
       - name: Set up QEMU
@@ -67,7 +68,8 @@ jobs:
     runs-on: ubuntu-latest
     env:
       CIBW_ARCHS_LINUX: aarch64
-      CIBW_SKIP: '*-manylinux* cp38-* cp314t-*'
+      CIBW_SKIP: '*-manylinux* cp38-*'
+      CIBW_ENABLE: 'cpython-freethreading'
     steps:
       - uses: actions/checkout@v4
       - name: Set up QEMU
@@ -106,8 +108,8 @@ jobs:
     runs-on: macos-14
     env:
       CIBW_ARCHS_MACOS: x86_64 arm64
-      CIBW_ENABLE: 'pypy pypy-eol'
-      CIBW_SKIP: 'pp38-* pp311-* cp38-* cp314t-*'
+      CIBW_ENABLE: 'pypy pypy-eol cpython-freethreading'
+      CIBW_SKIP: 'pp38-* pp311-* cp38-*'
     steps:
       - uses: actions/checkout@v4
       - name: Build wheels
@@ -124,8 +126,8 @@ jobs:
     runs-on: windows-latest
     env:
       CIBW_BUILD_VERBOSITY: 2
-      CIBW_ENABLE: 'pypy pypy-eol'
-      CIBW_SKIP: 'pp38-* pp311-* cp38-* cp314t-*'
+      CIBW_ENABLE: 'pypy pypy-eol cpython-freethreading'
+      CIBW_SKIP: 'pp38-* pp311-* cp38-*'
     steps:
       - uses: actions/checkout@v4
       - name: Build wheels

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -17,7 +17,7 @@ jobs:
     name: Build x86 manylinux wheels on Linux
     runs-on: ubuntu-latest
     env:
-      CIBW_SKIP: '*-musllinux* pp38-* pp311-* cp38-*'
+      CIBW_SKIP: '*-musllinux* pp38-* pp311-* cp38-* cp313t-*'
       CIBW_ENABLE: 'pypy pypy-eol cpython-freethreading'
     steps:
       - uses: actions/checkout@v4
@@ -32,7 +32,7 @@ jobs:
     name: Build x86 musllinux wheels on Linux
     runs-on: ubuntu-latest
     env:
-      CIBW_SKIP: '*-manylinux* pp38-* pp311-* cp38-*'
+      CIBW_SKIP: '*-manylinux* pp38-* pp311-* cp38-* cp313t-*'
       CIBW_ENABLE: 'pypy pypy-eol cpython-freethreading'
     steps:
       - uses: actions/checkout@v4
@@ -48,7 +48,7 @@ jobs:
     runs-on: ubuntu-latest
     env:
       CIBW_ARCHS_LINUX: aarch64
-      CIBW_SKIP: '*-musllinux* cp38-*'
+      CIBW_SKIP: '*-musllinux* cp38-* cp313t-*'
       CIBW_ENABLE: 'cpython-freethreading'
     steps:
       - uses: actions/checkout@v4
@@ -68,7 +68,7 @@ jobs:
     runs-on: ubuntu-latest
     env:
       CIBW_ARCHS_LINUX: aarch64
-      CIBW_SKIP: '*-manylinux* cp38-*'
+      CIBW_SKIP: '*-manylinux* cp38-* cp313t-*'
       CIBW_ENABLE: 'cpython-freethreading'
     steps:
       - uses: actions/checkout@v4
@@ -109,7 +109,7 @@ jobs:
     env:
       CIBW_ARCHS_MACOS: x86_64 arm64
       CIBW_ENABLE: 'pypy pypy-eol cpython-freethreading'
-      CIBW_SKIP: 'pp38-* pp311-* cp38-*'
+      CIBW_SKIP: 'pp38-* pp311-* cp38-* cp313t-*'
     steps:
       - uses: actions/checkout@v4
       - name: Build wheels
@@ -127,7 +127,7 @@ jobs:
     env:
       CIBW_BUILD_VERBOSITY: 2
       CIBW_ENABLE: 'pypy pypy-eol cpython-freethreading'
-      CIBW_SKIP: 'pp38-* pp311-* cp38-*'
+      CIBW_SKIP: 'pp38-* pp311-* cp38-* cp313t-*'
     steps:
       - uses: actions/checkout@v4
       - name: Build wheels

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@ The supported method of passing ClickHouse server settings is to prefix such arg
 
 ### Improvements
 - Added support for the `SAMPLE` clause in SQLAlchemy statements. Note: Due to a SQLAlchemy limitation, only one hint (SAMPLE or FINAL) can be applied per table; chaining both will silently ignore one. For now, this change enables use of sample(), but chaining with final() is not yet supported.  Closes [#634](https://github.com/ClickHouse/clickhouse-connect/issues/634)
+- **Experimental:** Added Python 3.14 free-threading (cp314t) wheel builds for all platforms. The full test suite currently (as of 2 MAR, 2026) passes under free-threaded Python, but is not added to the CI test matrix at this time nor has it been otherwise tested to any degree. Free-threading support should be considered experimental with no guarantees of correctness at this time. Closes [#573](https://github.com/ClickHouse/clickhouse-connect/issues/573)
 
 ## 0.13.0, 2026-02-26
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ requires = ["setuptools", "cython==3.0.11"]
 build-backend = "setuptools.build_meta"
 
 [tool.cibuildwheel]
-skip = "cp38-* pp38-* cp314t-*"
+skip = "cp38-* pp38-*"
 
 [tool.pytest.ini_options]
 log_cli = true

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ requires = ["setuptools", "cython>=3.0.11,<4"]
 build-backend = "setuptools.build_meta"
 
 [tool.cibuildwheel]
-skip = "cp38-* pp38-* cp313t-*"
+skip = "cp38-* pp38-*"
 
 [tool.pytest.ini_options]
 log_cli = true

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,10 +1,10 @@
 [build-system]
-requires = ["setuptools", "cython==3.0.11"]
+requires = ["setuptools", "cython>=3.0.11,<4"]
 
 build-backend = "setuptools.build_meta"
 
 [tool.cibuildwheel]
-skip = "cp38-* pp38-*"
+skip = "cp38-* pp38-* cp313t-*"
 
 [tool.pytest.ini_options]
 log_cli = true


### PR DESCRIPTION
## Summary
This PR does the following:
- Build and publish Python 3.14 free-threading wheels for all platforms
- Bump Cython build requirement from `==3.0.11 to >=3.0.11,<4` which is needed for free-threading ABI compilation

**NOTE**: Free-threading support is **EXPERIMENTAL**. The full test suite passes under 3.14t but it is not in the CI test matrix and has not been stress-tested under concurrent workloads.

Closes #573