### PR TITLE
Rename utc_tz_aware to tz_mode with deprecation bridge for 1.0 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,9 @@ The supported method of passing ClickHouse server settings is to prefix such arg
 
 ## UNRELEASED
 
+### Breaking Changes
+- Renamed `utc_tz_aware` parameter to `tz_mode` across Client, QueryContext, and all query methods. The new `tz_mode` parameter accepts string values: `"naive_utc"` (default, was `False`), `"aware"` (was `True`), and `"schema"` (unchanged). The old `utc_tz_aware` parameter is still accepted but emits a `DeprecationWarning` and will be removed in 1.0. Passing both `tz_mode` and `utc_tz_aware` raises `ProgrammingError`. Closes [#654](https://github.com/ClickHouse/clickhouse-connect/issues/654)
+
 ### Improvements
 - Added support for the `SAMPLE` clause in SQLAlchemy statements. Note: Due to a SQLAlchemy limitation, only one hint (SAMPLE or FINAL) can be applied per table; chaining both will silently ignore one. For now, this change enables use of sample(), but chaining with final() is not yet supported.  Closes [#634](https://github.com/ClickHouse/clickhouse-connect/issues/634)
 - **Experimental:** Added Python 3.14 free-threading (cp314t) wheel builds for all platforms. The full test suite currently (as of 2 MAR, 2026) passes under free-threaded Python, but is not added to the CI test matrix at this time nor has it been otherwise tested to any degree. Free-threading support should be considered experimental with no guarantees of correctness at this time. Closes [#573](https://github.com/ClickHouse/clickhouse-connect/issues/573)

--- a/clickhouse_connect/driver/__init__.py
+++ b/clickhouse_connect/driver/__init__.py
@@ -78,10 +78,11 @@ def create_client(*,
     :param server_host_name  This is the server host name that will be checked against a TLS certificate for
       validity.  This option can be used if using an ssh_tunnel or other indirect means to an ClickHouse server
       where the `host` argument refers to the tunnel or proxy and not the actual ClickHouse server
-    :param utc_tz_aware Controls timezone-aware behavior for UTC DateTime columns. False (default) returns
-      naive UTC timestamps. True forces timezone-aware UTC datetimes. "schema" returns datetimes that
+    :param tz_mode Controls timezone-aware behavior for UTC DateTime columns. "naive_utc" (default) returns
+      naive UTC timestamps. "aware" forces timezone-aware UTC datetimes. "schema" returns datetimes that
       match the server's column definition which means timezone-aware when the column defines a timezone and naive
       for bare DateTime columns.
+    :param utc_tz_aware Deprecated. Use tz_mode instead.
     :param autogenerate_session_id  If set, this will override the 'autogenerate_session_id' common setting.
     :param form_encode_query_params  If True, query parameters will be sent as form-encoded data in the request body
       instead of as URL parameters. This is useful for queries with large parameter sets that might exceed URL length
@@ -207,10 +208,11 @@ async def create_async_client(*,
     :param server_host_name  This is the server host name that will be checked against a TLS certificate for
       validity.  This option can be used if using an ssh_tunnel or other indirect means to an ClickHouse server
       where the `host` argument refers to the tunnel or proxy and not the actual ClickHouse server
-    :param utc_tz_aware Controls timezone-aware behavior for UTC DateTime columns. False (default) returns
-      naive UTC timestamps. True forces timezone-aware UTC datetimes. "schema" returns datetimes that
+    :param tz_mode Controls timezone-aware behavior for UTC DateTime columns. "naive_utc" (default) returns
+      naive UTC timestamps. "aware" forces timezone-aware UTC datetimes. "schema" returns datetimes that
       match the server's column definition which means timezone-aware when the column defines a timezone and naive
       for bare DateTime columns.
+    :param utc_tz_aware Deprecated. Use tz_mode instead.
     :param autogenerate_session_id  If set, this will override the 'autogenerate_session_id' common setting.
     :param form_encode_query_params  If True, query parameters will be sent as form-encoded data in the request body
       instead of as URL parameters. This is useful for queries with large parameter sets that might exceed URL length

--- a/clickhouse_connect/driver/asyncclient.py
+++ b/clickhouse_connect/driver/asyncclient.py
@@ -7,6 +7,7 @@ from datetime import tzinfo
 from typing import Literal, Optional, Union, Dict, Any, Sequence, Iterable, Generator, BinaryIO, TYPE_CHECKING
 
 from clickhouse_connect.driver.client import Client
+from clickhouse_connect.driver.query import TzMode
 from clickhouse_connect.driver.common import StreamContext
 from clickhouse_connect.driver.httpclient import HttpClient
 from clickhouse_connect.driver.external import ExternalData
@@ -117,7 +118,8 @@ class AsyncClient:
                     column_tzs: Optional[Dict[str, Union[str, tzinfo]]] = None,
                     utc_tz_aware: Optional[Union[bool, Literal["schema"]]] = None,
                     external_data: Optional[ExternalData] = None,
-                    transport_settings: Optional[Dict[str, str]] = None) -> QueryResult:
+                    transport_settings: Optional[Dict[str, str]] = None,
+                    tz_mode: Optional[TzMode] = None) -> QueryResult:
         """
         Main query method for SELECT, DESCRIBE and other SQL statements that return a result matrix.
         For parameters, see the create_query_context method.
@@ -129,7 +131,7 @@ class AsyncClient:
                                      column_formats=column_formats, encoding=encoding, use_none=use_none,
                                      column_oriented=column_oriented, use_numpy=use_numpy, max_str_len=max_str_len,
                                      context=context, query_tz=query_tz, column_tzs=column_tzs,
-                                     utc_tz_aware=utc_tz_aware,
+                                     tz_mode=tz_mode, utc_tz_aware=utc_tz_aware,
                                      external_data=external_data, transport_settings=transport_settings)
 
         loop = asyncio.get_running_loop()
@@ -150,6 +152,7 @@ class AsyncClient:
                                         utc_tz_aware: Optional[Union[bool, Literal["schema"]]] = None,
                                         external_data: Optional[ExternalData] = None,
                                         transport_settings: Optional[Dict[str, str]] = None,
+                                        tz_mode: Optional[TzMode] = None,
                                         ) -> StreamContext:
         """
         Variation of main query method that returns a stream of column oriented blocks.
@@ -162,7 +165,7 @@ class AsyncClient:
                                                          query_formats=query_formats, column_formats=column_formats,
                                                          encoding=encoding, use_none=use_none, context=context,
                                                          query_tz=query_tz, column_tzs=column_tzs,
-                                                         utc_tz_aware=utc_tz_aware,
+                                                         tz_mode=tz_mode, utc_tz_aware=utc_tz_aware,
                                                          external_data=external_data, transport_settings=transport_settings)
 
         loop = asyncio.get_running_loop()
@@ -182,7 +185,8 @@ class AsyncClient:
                                      column_tzs: Optional[Dict[str, Union[str, tzinfo]]] = None,
                                      utc_tz_aware: Optional[Union[bool, Literal["schema"]]] = None,
                                      external_data: Optional[ExternalData] = None,
-                                     transport_settings: Optional[Dict[str, str]] = None) -> StreamContext:
+                                     transport_settings: Optional[Dict[str, str]] = None,
+                                     tz_mode: Optional[TzMode] = None) -> StreamContext:
         """
         Variation of main query method that returns a stream of row oriented blocks.
         For parameters, see the create_query_context method.
@@ -194,7 +198,7 @@ class AsyncClient:
                                                       query_formats=query_formats, column_formats=column_formats,
                                                       encoding=encoding, use_none=use_none, context=context,
                                                       query_tz=query_tz, column_tzs=column_tzs,
-                                                      utc_tz_aware=utc_tz_aware,
+                                                      tz_mode=tz_mode, utc_tz_aware=utc_tz_aware,
                                                       external_data=external_data, transport_settings=transport_settings)
 
         loop = asyncio.get_running_loop()
@@ -214,7 +218,8 @@ class AsyncClient:
                                 column_tzs: Optional[Dict[str, Union[str, tzinfo]]] = None,
                                 utc_tz_aware: Optional[Union[bool, Literal["schema"]]] = None,
                                 external_data: Optional[ExternalData] = None,
-                                transport_settings: Optional[Dict[str, str]] = None) -> StreamContext:
+                                transport_settings: Optional[Dict[str, str]] = None,
+                                tz_mode: Optional[TzMode] = None) -> StreamContext:
         """
         Variation of main query method that returns a stream of row oriented blocks.
         For parameters, see the create_query_context method.
@@ -226,7 +231,7 @@ class AsyncClient:
                                                  query_formats=query_formats, column_formats=column_formats,
                                                  encoding=encoding, use_none=use_none, context=context,
                                                  query_tz=query_tz, column_tzs=column_tzs,
-                                                 utc_tz_aware=utc_tz_aware,
+                                                 tz_mode=tz_mode, utc_tz_aware=utc_tz_aware,
                                                  external_data=external_data, transport_settings=transport_settings)
 
         loop = asyncio.get_running_loop()
@@ -363,7 +368,8 @@ class AsyncClient:
                        context: QueryContext = None,
                        external_data: Optional[ExternalData] = None,
                        use_extended_dtypes: Optional[bool] = None,
-                       transport_settings: Optional[Dict[str, str]] = None) -> 'pandas.DataFrame':
+                       transport_settings: Optional[Dict[str, str]] = None,
+                       tz_mode: Optional[TzMode] = None) -> 'pandas.DataFrame':
         """
         Query method that results the results as a pandas dataframe.
         For parameter values, see the create_query_context method.
@@ -374,8 +380,8 @@ class AsyncClient:
             return self.client.query_df(query=query, parameters=parameters, settings=settings,
                                         query_formats=query_formats, column_formats=column_formats, encoding=encoding,
                                         use_none=use_none, max_str_len=max_str_len, use_na_values=use_na_values,
-                                        query_tz=query_tz, column_tzs=column_tzs, utc_tz_aware=utc_tz_aware,
-                                        context=context,
+                                        query_tz=query_tz, column_tzs=column_tzs, tz_mode=tz_mode,
+                                        utc_tz_aware=utc_tz_aware, context=context,
                                         external_data=external_data, use_extended_dtypes=use_extended_dtypes,
                                         transport_settings=transport_settings)
 
@@ -439,7 +445,8 @@ class AsyncClient:
                               context: QueryContext = None,
                               external_data: Optional[ExternalData] = None,
                               use_extended_dtypes: Optional[bool] = None,
-                              transport_settings: Optional[Dict[str, str]] = None) -> StreamContext:
+                              transport_settings: Optional[Dict[str, str]] = None,
+                              tz_mode: Optional[TzMode] = None) -> StreamContext:
         """
         Query method that returns the results as a StreamContext.
         For parameter values, see the create_query_context method.
@@ -452,7 +459,7 @@ class AsyncClient:
                                                encoding=encoding,
                                                use_none=use_none, max_str_len=max_str_len, use_na_values=use_na_values,
                                                query_tz=query_tz, column_tzs=column_tzs,
-                                               utc_tz_aware=utc_tz_aware, context=context,
+                                               tz_mode=tz_mode, utc_tz_aware=utc_tz_aware, context=context,
                                                external_data=external_data, use_extended_dtypes=use_extended_dtypes,
                                                transport_settings=transport_settings)
 
@@ -513,12 +520,14 @@ class AsyncClient:
                              context: Optional[QueryContext] = None,
                              query_tz: Optional[Union[str, tzinfo]] = None,
                              column_tzs: Optional[Dict[str, Union[str, tzinfo]]] = None,
+                             tz_mode: Optional[TzMode] = None,
                              use_na_values: Optional[bool] = None,
                              streaming: bool = False,
                              as_pandas: bool = False,
                              external_data: Optional[ExternalData] = None,
                              use_extended_dtypes: Optional[bool] = None,
-                             transport_settings: Optional[Dict[str, str]] = None) -> QueryContext:
+                             transport_settings: Optional[Dict[str, str]] = None,
+                             utc_tz_aware: Optional[Union[bool, Literal["schema"]]] = None) -> QueryContext:
         """
         Creates or updates a reusable QueryContext object
         :param query: Query statement/format string
@@ -558,6 +567,7 @@ class AsyncClient:
                                                 column_oriented=column_oriented,
                                                 use_numpy=use_numpy, max_str_len=max_str_len, context=context,
                                                 query_tz=query_tz, column_tzs=column_tzs,
+                                                tz_mode=tz_mode, utc_tz_aware=utc_tz_aware,
                                                 use_na_values=use_na_values,
                                                 streaming=streaming, as_pandas=as_pandas,
                                                 external_data=external_data,

--- a/clickhouse_connect/driver/client.py
+++ b/clickhouse_connect/driver/client.py
@@ -1,5 +1,6 @@
 import io
 import logging
+import warnings
 from datetime import tzinfo
 
 import pytz
@@ -22,7 +23,8 @@ from clickhouse_connect.driver.insert import InsertContext
 from clickhouse_connect.driver.options import check_arrow, check_pandas, check_numpy, check_polars, pd, arrow, pl, IS_PANDAS_2
 from clickhouse_connect.driver.summary import QuerySummary
 from clickhouse_connect.driver.models import ColumnDef, SettingDef, SettingStatus
-from clickhouse_connect.driver.query import QueryResult, to_arrow, to_arrow_batches, QueryContext, arrow_buffer
+from clickhouse_connect.driver.query import QueryResult, to_arrow, to_arrow_batches, QueryContext, arrow_buffer, \
+    TzMode, _resolve_tz_mode, _TZ_MODE_TO_UTC_TZ_AWARE
 from clickhouse_connect.driver.binding import quote_identifier
 
 if TYPE_CHECKING:
@@ -58,21 +60,21 @@ def _strip_utc_timezone_from_arrow(table: "arrow.Table") -> "arrow.Table":
     return table
 
 
-def _apply_arrow_tz_policy(table: "arrow.Table", utc_tz_aware: Union[bool, Literal["schema"]]) -> "arrow.Table":
-    """Apply the utc_tz_aware policy to an Arrow table before conversion.
+def _apply_arrow_tz_policy(table: "arrow.Table", tz_mode: str) -> "arrow.Table":
+    """Apply the tz_mode policy to an Arrow table before conversion.
 
-    Handles UTC stripping when utc_tz_aware is False and warns when
-    utc_tz_aware is "schema" since that mode is not yet implemented for
+    Handles UTC stripping when tz_mode is "naive_utc" and warns when
+    tz_mode is "schema" since that mode is not yet implemented for
     Arrow-based queries.
     """
-    if utc_tz_aware == "schema":
+    if tz_mode == "schema":
         logger.warning(
-            'utc_tz_aware="schema" is not yet supported for Arrow-based query methods. '
+            'tz_mode="schema" is not yet supported for Arrow-based query methods. '
             "It would require a separate schema lookup since ClickHouse attaches the server "
             "timezone to all DateTime columns in Arrow format. Use query/query_df for "
             "schema-matching behavior or open an issue if you need Arrow support."
         )
-    if not utc_tz_aware:
+    if tz_mode == "naive_utc":
         table = _strip_utc_timezone_from_arrow(table)
     return table
 
@@ -91,8 +93,19 @@ class Client(ABC):
     database = None
     max_error_message = 0
     apply_server_timezone = False
-    utc_tz_aware: Union[bool, Literal["schema"]] = False
+    tz_mode: TzMode = "naive_utc"
     show_clickhouse_errors = True
+
+    @property
+    def utc_tz_aware(self) -> Union[bool, Literal["schema"]]:
+        """Deprecated: use tz_mode instead."""
+        warnings.warn(
+            "utc_tz_aware is deprecated and will be removed in 1.0. "
+            "Use tz_mode instead.",
+            DeprecationWarning,
+            stacklevel=2,
+        )
+        return _TZ_MODE_TO_UTC_TZ_AWARE[self.tz_mode]
 
     def __init__(self,
                  database: str,
@@ -101,17 +114,19 @@ class Client(ABC):
                  query_retries: int,
                  server_host_name: Optional[str],
                  apply_server_timezone: Optional[Union[str, bool]],
-                 utc_tz_aware: Optional[Union[bool, Literal["schema"]]],
-                 show_clickhouse_errors: Optional[bool]):
+                 tz_mode: Optional[TzMode] = None,
+                 show_clickhouse_errors: Optional[bool] = None,
+                 utc_tz_aware: Optional[Union[bool, Literal["schema"]]] = None):
         """
         Shared initialization of ClickHouse Connect client
         :param database: database name
         :param query_limit: default LIMIT for queries
         :param uri: uri for error messages
-        :param utc_tz_aware: Controls timezone-aware behavior for UTC DateTime columns.  False (default) returns
-          naive UTC timestamps.  True forces timezone-aware UTC datetimes.  "schema" returns datetimes that
+        :param tz_mode: Controls timezone-aware behavior for UTC DateTime columns.  "naive_utc" (default) returns
+          naive UTC timestamps.  "aware" forces timezone-aware UTC datetimes.  "schema" returns datetimes that
           match the server's column definition which means timezone-aware when the column defines a timezone and naive
           for bare DateTime columns.
+        :param utc_tz_aware: Deprecated. Use tz_mode instead.
         """
         self.query_limit = coerce_int(query_limit)
         self.query_retries = coerce_int(query_retries)
@@ -121,12 +136,7 @@ class Client(ABC):
             self.show_clickhouse_errors = coerce_bool(show_clickhouse_errors)
         self.server_host_name = server_host_name
         self.uri = uri
-        if isinstance(utc_tz_aware, str):
-            if utc_tz_aware != "schema":
-                raise ProgrammingError(f'utc_tz_aware must be True, False, or "schema", got "{utc_tz_aware}"')
-            self.utc_tz_aware = utc_tz_aware
-        else:
-            self.utc_tz_aware = bool(utc_tz_aware)
+        self.tz_mode = _resolve_tz_mode(tz_mode, utc_tz_aware)
         self._init_common_settings(apply_server_timezone)
 
     def _init_common_settings(self, apply_server_timezone: Optional[Union[str, bool]]):
@@ -277,7 +287,8 @@ class Client(ABC):
               column_tzs: Optional[Dict[str, Union[str, tzinfo]]] = None,
               utc_tz_aware: Optional[Union[bool, Literal["schema"]]] = None,
               external_data: Optional[ExternalData] = None,
-              transport_settings: Optional[Dict[str, str]] = None) -> QueryResult:
+              transport_settings: Optional[Dict[str, str]] = None,
+              tz_mode: Optional[TzMode] = None) -> QueryResult:
         """
         Main query method for SELECT, DESCRIBE and other SQL statements that return a result matrix.  For
         parameters, see the create_query_context method
@@ -313,7 +324,8 @@ class Client(ABC):
                                   column_tzs: Optional[Dict[str, Union[str, tzinfo]]] = None,
                                   utc_tz_aware: Optional[Union[bool, Literal["schema"]]] = None,
                                   external_data: Optional[ExternalData] = None,
-                                  transport_settings: Optional[Dict[str, str]] = None) -> StreamContext:
+                                  transport_settings: Optional[Dict[str, str]] = None,
+                                  tz_mode: Optional[TzMode] = None) -> StreamContext:
         """
         Variation of main query method that returns a stream of column oriented blocks. For
         parameters, see the create_query_context method.
@@ -334,7 +346,8 @@ class Client(ABC):
                                column_tzs: Optional[Dict[str, Union[str, tzinfo]]] = None,
                                utc_tz_aware: Optional[Union[bool, Literal["schema"]]] = None,
                                external_data: Optional[ExternalData] = None,
-                               transport_settings: Optional[Dict[str, str]] = None) -> StreamContext:
+                               transport_settings: Optional[Dict[str, str]] = None,
+                               tz_mode: Optional[TzMode] = None) -> StreamContext:
         """
         Variation of main query method that returns a stream of row oriented blocks. For
         parameters, see the create_query_context method.
@@ -355,7 +368,8 @@ class Client(ABC):
                           column_tzs: Optional[Dict[str, Union[str, tzinfo]]] = None,
                           utc_tz_aware: Optional[Union[bool, Literal["schema"]]] = None,
                           external_data: Optional[ExternalData] = None,
-                          transport_settings: Optional[Dict[str, str]] = None) -> StreamContext:
+                          transport_settings: Optional[Dict[str, str]] = None,
+                          tz_mode: Optional[TzMode] = None) -> StreamContext:
         """
         Variation of main query method that returns a stream of row oriented blocks. For
         parameters, see the create_query_context method.
@@ -466,7 +480,8 @@ class Client(ABC):
                  context: QueryContext = None,
                  external_data: Optional[ExternalData] = None,
                  use_extended_dtypes: Optional[bool] = None,
-                 transport_settings: Optional[Dict[str, str]] = None) -> 'pandas.DataFrame':
+                 transport_settings: Optional[Dict[str, str]] = None,
+                 tz_mode: Optional[TzMode] = None) -> 'pandas.DataFrame':
         """
         Query method that results the results as a pandas dataframe.  For parameter values, see the
         create_query_context method
@@ -493,7 +508,8 @@ class Client(ABC):
                         context: QueryContext = None,
                         external_data: Optional[ExternalData] = None,
                         use_extended_dtypes: Optional[bool] = None,
-                        transport_settings: Optional[Dict[str, str]] = None) -> StreamContext:
+                        transport_settings: Optional[Dict[str, str]] = None,
+                        tz_mode: Optional[TzMode] = None) -> StreamContext:
         """
         Query method that returns the results as a StreamContext.  For parameter values, see the
         create_query_context method
@@ -525,7 +541,8 @@ class Client(ABC):
                              as_pandas: bool = False,
                              external_data: Optional[ExternalData] = None,
                              use_extended_dtypes: Optional[bool] = None,
-                             transport_settings: Optional[Dict[str, str]] = None) -> QueryContext:
+                             transport_settings: Optional[Dict[str, str]] = None,
+                             tz_mode: Optional[TzMode] = None) -> QueryContext:
         """
         Creates or updates a reusable QueryContext object
         :param query: Query statement/format string
@@ -548,9 +565,10 @@ class Client(ABC):
           objects with the selected timezone.
         :param column_tzs: A dictionary of column names to tzinfo objects (or strings that will be converted to
           tzinfo objects).  The timezone will be applied to datetime objects returned in the query
-        :param utc_tz_aware: Override the client default for handling UTC results.  True forces timezone-aware
-          UTC datetimes, False returns naive UTC datetimes, and "schema" returns datetimes matching the
+        :param tz_mode: Override the client default for handling UTC results.  "aware" forces timezone-aware
+          UTC datetimes, "naive_utc" returns naive UTC datetimes, and "schema" returns datetimes matching the
           server's column definition.
+        :param utc_tz_aware: Deprecated. Use tz_mode instead.
         :param use_na_values: Deprecated alias for use_advanced_dtypes
         :param as_pandas Return the result columns as pandas.Series objects
         :param streaming Marker used to correctly configure streaming queries
@@ -561,7 +579,10 @@ class Client(ABC):
         :param transport_settings: Optional dictionary of transport level settings (HTTP headers, etc.)
         :return: Reusable QueryContext
         """
-        resolved_utc_tz_aware = self.utc_tz_aware if utc_tz_aware is None else utc_tz_aware
+        if tz_mode is not None or utc_tz_aware is not None:
+            resolved_tz_mode = _resolve_tz_mode(tz_mode, utc_tz_aware)
+        else:
+            resolved_tz_mode = self.tz_mode
         if context:
             return context.updated_copy(query=query,
                                         parameters=parameters,
@@ -576,7 +597,7 @@ class Client(ABC):
                                         max_str_len=max_str_len,
                                         query_tz=query_tz,
                                         column_tzs=column_tzs,
-                                        utc_tz_aware=resolved_utc_tz_aware,
+                                        tz_mode=resolved_tz_mode,
                                         as_pandas=as_pandas,
                                         use_extended_dtypes=use_extended_dtypes,
                                         streaming=streaming,
@@ -601,7 +622,7 @@ class Client(ABC):
                             max_str_len=max_str_len,
                             query_tz=query_tz,
                             column_tzs=column_tzs,
-                            utc_tz_aware=resolved_utc_tz_aware,
+                            tz_mode=resolved_tz_mode,
                             use_extended_dtypes=use_extended_dtypes,
                             as_pandas=as_pandas,
                             streaming=streaming,
@@ -695,7 +716,7 @@ class Client(ABC):
                 raise ProgrammingError("PyArrow-backed dtypes are only supported when using pandas 2.x.")
 
             def converter(table: arrow.Table) -> pd.DataFrame:
-                table = _apply_arrow_tz_policy(table, self.utc_tz_aware)
+                table = _apply_arrow_tz_policy(table, self.tz_mode)
                 return table.to_pandas(types_mapper=pd.ArrowDtype, safe=False)
 
         elif dataframe_library == "polars":
@@ -703,7 +724,7 @@ class Client(ABC):
             self._add_integration_tag("polars")
 
             def converter(table: arrow.Table) -> pl.DataFrame:
-                table = _apply_arrow_tz_policy(table, self.utc_tz_aware)
+                table = _apply_arrow_tz_policy(table, self.tz_mode)
                 return pl.from_arrow(table)
 
         else:
@@ -749,14 +770,14 @@ class Client(ABC):
                 raise ProgrammingError("PyArrow-backed dtypes are only supported when using pandas 2.x.")
 
             def converter(table: "arrow.Table") -> "pd.DataFrame":
-                table = _apply_arrow_tz_policy(table, self.utc_tz_aware)
+                table = _apply_arrow_tz_policy(table, self.tz_mode)
                 return table.to_pandas(types_mapper=pd.ArrowDtype, safe=False)
         elif dataframe_library == "polars":
             check_polars()
             self._add_integration_tag("polars")
 
             def converter(table: arrow.Table) -> pl.DataFrame:
-                table = _apply_arrow_tz_policy(table, self.utc_tz_aware)
+                table = _apply_arrow_tz_policy(table, self.tz_mode)
                 return pl.from_arrow(table)
         else:
             raise ValueError(f"dataframe_library must be 'pandas' or 'polars', got '{dataframe_library}'")

--- a/clickhouse_connect/driver/httpclient.py
+++ b/clickhouse_connect/driver/httpclient.py
@@ -77,6 +77,7 @@ class HttpClient(Client):
                  https_proxy: Optional[str] = None,
                  server_host_name: Optional[str] = None,
                  apply_server_timezone: Optional[Union[str, bool]] = None,
+                 tz_mode: Optional[str] = None,
                  utc_tz_aware: Optional[Union[bool, Literal["schema"]]] = None,
                  show_clickhouse_errors: Optional[bool] = None,
                  autogenerate_session_id: Optional[bool] = None,
@@ -185,6 +186,7 @@ class HttpClient(Client):
                          query_retries=query_retries,
                          server_host_name=server_host_name,
                          apply_server_timezone=apply_server_timezone,
+                         tz_mode=tz_mode,
                          utc_tz_aware=utc_tz_aware,
                          show_clickhouse_errors=show_clickhouse_errors)
         self.params = dict_copy(self.params, self._validate_settings(ch_settings))

--- a/clickhouse_connect/driver/query.py
+++ b/clickhouse_connect/driver/query.py
@@ -1,5 +1,6 @@
 import logging
 import re
+import warnings
 import pytz
 
 from io import IOBase
@@ -21,6 +22,69 @@ if TYPE_CHECKING:
     from clickhouse_connect.datatypes.base import ClickHouseType
 
 logger = logging.getLogger(__name__)
+
+TzMode = Literal["naive_utc", "aware", "schema"]
+
+_UTC_TZ_AWARE_TO_TZ_MODE: Dict[Union[bool, str], TzMode] = {
+    False: "naive_utc",
+    True: "aware",
+    "schema": "schema",
+}
+
+_VALID_TZ_MODES = {"naive_utc", "aware", "schema"}
+
+_TZ_MODE_TO_UTC_TZ_AWARE: Dict[str, Union[bool, Literal["schema"]]] = {
+    "naive_utc": False,
+    "aware": True,
+    "schema": "schema",
+}
+
+# Mapping for string booleans that may arrive via URL params
+_STR_BOOL_MAP = {"true": True, "false": False, "1": True, "0": False}
+
+
+def _resolve_tz_mode(
+    tz_mode: Optional[TzMode] = None,
+    utc_tz_aware: Optional[Union[bool, Literal["schema"]]] = None,
+) -> TzMode:
+    """Resolve tz_mode from either the new ``tz_mode`` or deprecated ``utc_tz_aware`` parameter.
+
+    Returns the canonical TzMode string.  Raises ``ProgrammingError`` on conflicts or
+    invalid values.
+    """
+    if tz_mode is not None and utc_tz_aware is not None:
+        raise ProgrammingError(
+            "Cannot specify both 'tz_mode' and 'utc_tz_aware'. "
+            "Use 'tz_mode' only; 'utc_tz_aware' is deprecated."
+        )
+
+    if utc_tz_aware is not None:
+        # Coerce string booleans from URL params (e.g. "true" -> True)
+        if isinstance(utc_tz_aware, str) and utc_tz_aware.lower() in _STR_BOOL_MAP:
+            utc_tz_aware = _STR_BOOL_MAP[utc_tz_aware.lower()]
+
+        if utc_tz_aware not in _UTC_TZ_AWARE_TO_TZ_MODE:
+            raise ProgrammingError(
+                f'utc_tz_aware must be True, False, or "schema", got "{utc_tz_aware}"'
+            )
+        warnings.warn(
+            "utc_tz_aware is deprecated and will be removed in 1.0. "
+            "Use tz_mode='naive_utc' | 'aware' | 'schema' instead.",
+            DeprecationWarning,
+            stacklevel=3,
+        )
+        return _UTC_TZ_AWARE_TO_TZ_MODE[utc_tz_aware]
+
+    if tz_mode is not None:
+        if tz_mode not in _VALID_TZ_MODES:
+            raise ProgrammingError(
+                f'tz_mode must be "naive_utc", "aware", or "schema", got "{tz_mode}"'
+            )
+        return tz_mode
+
+    return "naive_utc"
+
+
 commands = 'CREATE|ALTER|SYSTEM|GRANT|REVOKE|CHECK|DETACH|ATTACH|DROP|DELETE|KILL|' + \
            'OPTIMIZE|SET|RENAME|TRUNCATE|USE|UPDATE'
 
@@ -51,14 +115,15 @@ class QueryContext(BaseQueryContext):
                  max_str_len: Optional[int] = 0,
                  query_tz: Optional[Union[str, tzinfo]] = None,
                  column_tzs: Optional[Dict[str, Union[str, tzinfo]]] = None,
-                 utc_tz_aware: Union[bool, Literal["schema"]] = False,
+                 utc_tz_aware: Optional[Union[bool, Literal["schema"]]] = None,
                  use_extended_dtypes: Optional[bool] = None,
                  as_pandas: bool = False,
                  streaming: bool = False,
                  apply_server_tz: bool = False,
                  external_data: Optional[ExternalData] = None,
                  transport_settings: Optional[Dict[str, str]] = None,
-                 rename_response_column: Optional[str] = None):
+                 rename_response_column: Optional[str] = None,
+                 tz_mode: Optional[TzMode] = None):
         """
         Initializes various configuration settings for the query context
 
@@ -85,10 +150,11 @@ class QueryContext(BaseQueryContext):
           objects with the selected timezone
         :param column_tzs A dictionary of column names to tzinfo objects (or strings that will be converted to
           tzinfo objects).  The timezone will be applied to datetime objects returned in the query
-        :param utc_tz_aware Controls timezone-aware behavior for UTC DateTime columns. False (default) returns
-          naive UTC timestamps. True forces timezone-aware UTC datetimes. "schema" returns datetimes that
+        :param tz_mode Controls timezone-aware behavior for UTC DateTime columns. "naive_utc" (default) returns
+          naive UTC timestamps. "aware" forces timezone-aware UTC datetimes. "schema" returns datetimes that
           match the server's column definition which means timezone-aware when the column schema defines a timezone
           (e.g. DateTime('UTC')) and naive for bare DateTime columns.
+        :param utc_tz_aware Deprecated. Use tz_mode instead.
         """
         super().__init__(settings,
                          query_formats,
@@ -106,9 +172,7 @@ class QueryContext(BaseQueryContext):
         self.server_tz = server_tz
         self.apply_server_tz = apply_server_tz
         self.external_data = external_data
-        if isinstance(utc_tz_aware, str) and utc_tz_aware != "schema":
-            raise ProgrammingError(f'utc_tz_aware must be True, False, or "schema", got "{utc_tz_aware}"')
-        self.utc_tz_aware = utc_tz_aware
+        self.tz_mode = _resolve_tz_mode(tz_mode, utc_tz_aware)
         if isinstance(query_tz, str):
             try:
                 query_tz = pytz.timezone(query_tz)
@@ -159,6 +223,17 @@ class QueryContext(BaseQueryContext):
     def is_command(self) -> bool:
         return command_re.search(self.uncommented_query) is not None
 
+    @property
+    def utc_tz_aware(self) -> Union[bool, Literal["schema"]]:
+        """Deprecated: use tz_mode instead."""
+        warnings.warn(
+            "utc_tz_aware is deprecated and will be removed in 1.0. "
+            "Use tz_mode instead.",
+            DeprecationWarning,
+            stacklevel=2,
+        )
+        return _TZ_MODE_TO_UTC_TZ_AWARE[self.tz_mode]
+
     def set_parameters(self, parameters: Dict[str, Any]):
         self.parameters = parameters
         self._update_query()
@@ -180,7 +255,7 @@ class QueryContext(BaseQueryContext):
             self.column_tz = None
 
     def active_tz(self, datatype_tz: Optional[tzinfo]):
-        if self.utc_tz_aware == "schema":
+        if self.tz_mode == "schema":
             return self.column_tz or datatype_tz
         if self.column_tz:
             active_tz = self.column_tz
@@ -194,7 +269,7 @@ class QueryContext(BaseQueryContext):
             active_tz = self.server_tz
         else:
             active_tz = tzutil.local_tz
-        if tzutil.is_utc_timezone(active_tz) and not self.utc_tz_aware:
+        if tzutil.is_utc_timezone(active_tz) and self.tz_mode == "naive_utc":
             return None
         return active_tz
 
@@ -219,31 +294,38 @@ class QueryContext(BaseQueryContext):
                      streaming: bool = False,
                      external_data: Optional[ExternalData] = None,
                      transport_settings: Optional[Dict[str, str]] = None,
-                     rename_response_column: Optional[str] = None) -> 'QueryContext':
+                     rename_response_column: Optional[str] = None,
+                     tz_mode: Optional[TzMode] = None) -> 'QueryContext':
         """
         Creates Query context copy with parameters overridden/updated as appropriate.
         """
-        return QueryContext(query or self.query,
-                            dict_copy(self.parameters, parameters),
-                            dict_copy(self.settings, settings),
-                            dict_copy(self.query_formats, query_formats),
-                            dict_copy(self.column_formats, column_formats),
-                            encoding if encoding else self.encoding,
-                            server_tz if server_tz else self.server_tz,
-                            self.use_none if use_none is None else use_none,
-                            self.column_oriented if column_oriented is None else column_oriented,
-                            self.use_numpy if use_numpy is None else use_numpy,
-                            self.max_str_len if max_str_len is None else max_str_len,
-                            self.query_tz if query_tz is None else query_tz,
-                            self.column_tzs if column_tzs is None else column_tzs,
-                            self.utc_tz_aware if utc_tz_aware is None else utc_tz_aware,
-                            self.use_extended_dtypes if use_extended_dtypes is None else use_extended_dtypes,
-                            as_pandas,
-                            streaming,
-                            self.apply_server_tz,
-                            self.external_data if external_data is None else external_data,
-                            self.transport_settings if transport_settings is None else transport_settings,
-                            self.rename_response_column if rename_response_column is None else rename_response_column)
+        if tz_mode is not None or utc_tz_aware is not None:
+            resolved_tz_mode = _resolve_tz_mode(tz_mode, utc_tz_aware)
+        else:
+            resolved_tz_mode = self.tz_mode
+        return QueryContext(
+            query=query or self.query,
+            parameters=dict_copy(self.parameters, parameters),
+            settings=dict_copy(self.settings, settings),
+            query_formats=dict_copy(self.query_formats, query_formats),
+            column_formats=dict_copy(self.column_formats, column_formats),
+            encoding=encoding if encoding else self.encoding,
+            server_tz=server_tz if server_tz else self.server_tz,
+            use_none=self.use_none if use_none is None else use_none,
+            column_oriented=self.column_oriented if column_oriented is None else column_oriented,
+            use_numpy=self.use_numpy if use_numpy is None else use_numpy,
+            max_str_len=self.max_str_len if max_str_len is None else max_str_len,
+            query_tz=self.query_tz if query_tz is None else query_tz,
+            column_tzs=self.column_tzs if column_tzs is None else column_tzs,
+            tz_mode=resolved_tz_mode,
+            use_extended_dtypes=self.use_extended_dtypes if use_extended_dtypes is None else use_extended_dtypes,
+            as_pandas=as_pandas,
+            streaming=streaming,
+            apply_server_tz=self.apply_server_tz,
+            external_data=self.external_data if external_data is None else external_data,
+            transport_settings=self.transport_settings if transport_settings is None else transport_settings,
+            rename_response_column=self.rename_response_column if rename_response_column is None else rename_response_column,
+        )
 
     def _update_query(self):
         self.final_query, self.bind_params = bind_query(self.query, self.parameters, self.server_tz)

--- a/tests/integration_tests/test_timezones.py
+++ b/tests/integration_tests/test_timezones.py
@@ -166,7 +166,7 @@ def test_timezone_binding_server(test_client: Client):
     assert server_time.astimezone(pytz.UTC) == utc_time
 
 
-def test_utc_tz_aware(test_client: Client):
+def test_tz_mode(test_client: Client):
     row = test_client.query("SELECT toDateTime('2023-07-05 15:10:40') as dt," +
                             "toDateTime('2023-07-05 15:10:40', 'UTC') as dt_utc",
                             query_tz='UTC').first_row
@@ -175,7 +175,7 @@ def test_utc_tz_aware(test_client: Client):
 
     row = test_client.query("SELECT toDateTime('2023-07-05 15:10:40') as dt," +
                             "toDateTime('2023-07-05 15:10:40', 'UTC') as dt_utc",
-                            query_tz='UTC', utc_tz_aware=True).first_row
+                            query_tz='UTC', tz_mode="aware").first_row
     assert row[0].tzinfo == pytz.UTC
     assert row[1].tzinfo == pytz.UTC
 
@@ -189,7 +189,7 @@ def test_utc_tz_aware(test_client: Client):
 
         row = test_client.query("SELECT toDateTime64('2023-07-05 15:10:40.123456', 6) as dt64," +
                                 "toDateTime64('2023-07-05 15:10:40.123456', 6, 'UTC') as dt64_utc",
-                                query_tz='UTC', utc_tz_aware=True).first_row
+                                query_tz='UTC', tz_mode="aware").first_row
         assert row[0].tzinfo == pytz.UTC
         assert row[1].tzinfo == pytz.UTC
         assert row[0].microsecond == 123456

--- a/tests/unit_tests/test_driver/test_query.py
+++ b/tests/unit_tests/test_driver/test_query.py
@@ -1,10 +1,12 @@
+import warnings
+
 import pytz
 import pytest
 
 import pyarrow as pa
 
 from clickhouse_connect.driver.exceptions import ProgrammingError
-from clickhouse_connect.driver.query import QueryContext
+from clickhouse_connect.driver.query import QueryContext, _resolve_tz_mode
 from clickhouse_connect.driver.client import _strip_utc_timezone_from_arrow
 from clickhouse_connect.driver import tzutil
 
@@ -36,13 +38,13 @@ def test_copy_context():
 
 def test_active_tz_utc_defaults_to_naive():
     ctx = QueryContext(query_tz=pytz.UTC)
-    assert ctx.utc_tz_aware is False
+    assert ctx.tz_mode == "naive_utc"
     assert ctx.active_tz(None) is None
 
 
 def test_active_tz_utc_opt_in_timezone():
-    ctx = QueryContext(query_tz=pytz.UTC, utc_tz_aware=True)
-    assert ctx.utc_tz_aware is True
+    ctx = QueryContext(query_tz=pytz.UTC, tz_mode="aware")
+    assert ctx.tz_mode == "aware"
     assert ctx.active_tz(None) == pytz.UTC
 
 
@@ -54,16 +56,16 @@ def test_active_tz_etc_utc_defaults_to_naive():
     """
     etc_utc = pytz.timezone('Etc/UTC')
     ctx = QueryContext(query_tz=etc_utc)
-    assert ctx.utc_tz_aware is False
+    assert ctx.tz_mode == "naive_utc"
     # BUG: Previously returned etc_utc instead of None
     assert ctx.active_tz(None) is None  # Should return None for naive datetime
 
 
 def test_active_tz_etc_utc_opt_in_timezone():
-    """Test that Etc/UTC with utc_tz_aware=True returns timezone."""
+    """Test that Etc/UTC with tz_mode='aware' returns timezone."""
     etc_utc = pytz.timezone('Etc/UTC')
-    ctx = QueryContext(query_tz=etc_utc, utc_tz_aware=True)
-    assert ctx.utc_tz_aware is True
+    ctx = QueryContext(query_tz=etc_utc, tz_mode="aware")
+    assert ctx.tz_mode == "aware"
     assert ctx.active_tz(None) is not None  # Should return the timezone
 
 
@@ -135,18 +137,18 @@ def test_utc_equivalent_timezones_normalize_to_naive():
 
     for tz_name in utc_equivalents:
         tz = pytz.timezone(tz_name)
-        ctx = QueryContext(utc_tz_aware=False)
+        ctx = QueryContext(tz_mode="naive_utc")
         result = ctx.active_tz(datatype_tz=tz)
         assert result is None
 
 
-def test_utc_equivalent_timezones_with_utc_tz_aware():
-    """Test that UTC-equivalent timezones return timezone-aware when utc_tz_aware=True"""
+def test_utc_equivalent_timezones_with_tz_mode_aware():
+    """Test that UTC-equivalent timezones return timezone-aware when tz_mode='aware'"""
     utc_equivalents = ['Etc/UCT', 'GMT', 'Etc/GMT']
 
     for tz_name in utc_equivalents:
         tz = pytz.timezone(tz_name)
-        ctx = QueryContext(utc_tz_aware=True)
+        ctx = QueryContext(tz_mode="aware")
         result = ctx.active_tz(datatype_tz=tz)
         assert result == tz
 
@@ -167,14 +169,14 @@ def test_tzutil_normalize_utc_equivalents():
         assert is_valid is True
 
 
-def test_etc_uct_returns_naive_when_utc_tz_aware_false():
+def test_etc_uct_returns_naive_when_tz_mode_naive_utc():
     """
     Regression test for the issue where DateTime('UTC') columns with Etc/UCT
     returned timezone-aware while DateTime columns returned naive
     """
     column_with_explicit_utc = pytz.timezone('Etc/UCT')
     server_tz = pytz.timezone('Etc/UCT')
-    ctx = QueryContext(utc_tz_aware=False, server_tz=server_tz, apply_server_tz=True)
+    ctx = QueryContext(tz_mode="naive_utc", server_tz=server_tz, apply_server_tz=True)
     result1 = ctx.active_tz(datatype_tz=column_with_explicit_utc)
 
     assert result1 is None
@@ -185,59 +187,139 @@ def test_etc_uct_returns_naive_when_utc_tz_aware_false():
 
 def test_schema_mode_with_schema_tz():
     """DateTime('UTC') should return tz-aware in schema mode."""
-    ctx = QueryContext(utc_tz_aware="schema")
+    ctx = QueryContext(tz_mode="schema")
     result = ctx.active_tz(datatype_tz=pytz.UTC)
     assert result == pytz.UTC
 
 
 def test_schema_mode_bare_datetime():
     """Bare DateTime (no schema tz) should return naive in schema mode."""
-    ctx = QueryContext(utc_tz_aware="schema", server_tz=pytz.UTC, apply_server_tz=True)
+    ctx = QueryContext(tz_mode="schema", server_tz=pytz.UTC, apply_server_tz=True)
     result = ctx.active_tz(datatype_tz=None)
     assert result is None
 
 
 def test_schema_mode_non_utc_tz():
     """DateTime('America/Denver') should return tz-aware in schema mode."""
-    denver = pytz.timezone("America/Denver")
-    ctx = QueryContext(utc_tz_aware="schema")
+    denver = pytz.timezone('America/Denver')
+    ctx = QueryContext(tz_mode="schema")
     result = ctx.active_tz(datatype_tz=denver)
     assert result == denver
 
 
 def test_schema_mode_with_column_tz_override():
     """Per-column tz override should still work in schema mode."""
-    denver = pytz.timezone("America/Denver")
-    ctx = QueryContext(utc_tz_aware="schema", column_tzs={"ts": denver})
-    ctx.start_column("ts")
+    denver = pytz.timezone('America/Denver')
+    ctx = QueryContext(tz_mode="schema", column_tzs={'ts': denver})
+    ctx.start_column('ts')
     result = ctx.active_tz(datatype_tz=None)
     assert result == denver
 
 
 def test_schema_mode_ignores_query_tz():
     """query_tz should not apply to bare DateTime in schema mode."""
-    ctx = QueryContext(utc_tz_aware="schema", query_tz=pytz.UTC)
+    ctx = QueryContext(tz_mode="schema", query_tz=pytz.UTC)
     result = ctx.active_tz(datatype_tz=None)
     assert result is None
 
 
 def test_schema_mode_ignores_server_tz():
     """Server tz should not apply to bare DateTime in schema mode."""
-    denver = pytz.timezone("America/Denver")
-    ctx = QueryContext(utc_tz_aware="schema", server_tz=denver, apply_server_tz=True)
+    denver = pytz.timezone('America/Denver')
+    ctx = QueryContext(tz_mode="schema", server_tz=denver, apply_server_tz=True)
     result = ctx.active_tz(datatype_tz=None)
     assert result is None
 
 
 def test_schema_mode_etc_utc_schema():
     """DateTime('Etc/UTC') should return tz-aware in schema mode."""
-    etc_utc = pytz.timezone("Etc/UTC")
-    ctx = QueryContext(utc_tz_aware="schema")
+    etc_utc = pytz.timezone('Etc/UTC')
+    ctx = QueryContext(tz_mode="schema")
     result = ctx.active_tz(datatype_tz=etc_utc)
     assert result == etc_utc
 
 
-def test_schema_mode_invalid_string_raises():
+def test_tz_mode_invalid_string_raises():
+    """Invalid string value for tz_mode should raise ProgrammingError."""
+    with pytest.raises(ProgrammingError, match='tz_mode must be'):
+        QueryContext(tz_mode="invalid")
+
+
+def test_utc_tz_aware_false_maps_to_naive_utc():
+    """utc_tz_aware=False should map to tz_mode='naive_utc' with a DeprecationWarning."""
+    with warnings.catch_warnings(record=True) as w:
+        warnings.simplefilter("always")
+        ctx = QueryContext(utc_tz_aware=False)
+        assert ctx.tz_mode == "naive_utc"
+        assert len(w) == 1
+        assert issubclass(w[0].category, DeprecationWarning)
+        assert "utc_tz_aware is deprecated" in str(w[0].message)
+
+
+def test_utc_tz_aware_true_maps_to_aware():
+    """utc_tz_aware=True should map to tz_mode='aware' with a DeprecationWarning."""
+    with warnings.catch_warnings(record=True) as w:
+        warnings.simplefilter("always")
+        ctx = QueryContext(utc_tz_aware=True)
+        assert ctx.tz_mode == "aware"
+        assert len(w) == 1
+        assert issubclass(w[0].category, DeprecationWarning)
+
+
+def test_utc_tz_aware_schema_maps_to_schema():
+    """utc_tz_aware='schema' should map to tz_mode='schema' with a DeprecationWarning."""
+    with warnings.catch_warnings(record=True) as w:
+        warnings.simplefilter("always")
+        ctx = QueryContext(utc_tz_aware="schema")
+        assert ctx.tz_mode == "schema"
+        assert len(w) == 1
+        assert issubclass(w[0].category, DeprecationWarning)
+
+
+def test_both_tz_mode_and_utc_tz_aware_raises():
+    """Providing both tz_mode and utc_tz_aware should raise ProgrammingError."""
+    with pytest.raises(ProgrammingError, match='Cannot specify both'):
+        QueryContext(tz_mode="aware", utc_tz_aware=True)
+
+
+def test_utc_tz_aware_invalid_string_raises():
     """Invalid string value for utc_tz_aware should raise ProgrammingError."""
-    with pytest.raises(ProgrammingError, match="utc_tz_aware must be"):
+    with pytest.raises(ProgrammingError, match='utc_tz_aware must be'):
         QueryContext(utc_tz_aware="invalid")
+
+
+def test_resolve_tz_mode_defaults():
+    """No arguments should return 'naive_utc'."""
+    assert _resolve_tz_mode() == "naive_utc"
+
+
+def test_resolve_tz_mode_string_bool_coercion():
+    """String booleans from URL params should be coerced correctly."""
+    with warnings.catch_warnings(record=True):
+        warnings.simplefilter("always")
+        assert _resolve_tz_mode(utc_tz_aware="true") == "aware"
+        assert _resolve_tz_mode(utc_tz_aware="false") == "naive_utc"
+        assert _resolve_tz_mode(utc_tz_aware="True") == "aware"
+        assert _resolve_tz_mode(utc_tz_aware="False") == "naive_utc"
+        assert _resolve_tz_mode(utc_tz_aware="1") == "aware"
+        assert _resolve_tz_mode(utc_tz_aware="0") == "naive_utc"
+
+
+def test_utc_tz_aware_property_returns_legacy_value():
+    """Accessing ctx.utc_tz_aware should return the legacy equivalent with a DeprecationWarning."""
+    ctx = QueryContext(tz_mode="naive_utc")
+    with warnings.catch_warnings(record=True) as w:
+        warnings.simplefilter("always")
+        assert ctx.utc_tz_aware is False
+        assert len(w) == 1
+        assert issubclass(w[0].category, DeprecationWarning)
+
+    ctx2 = QueryContext(tz_mode="aware")
+    with warnings.catch_warnings(record=True) as w:
+        warnings.simplefilter("always")
+        assert ctx2.utc_tz_aware is True
+
+    ctx3 = QueryContext(tz_mode="schema")
+    with warnings.catch_warnings(record=True) as w:
+        warnings.simplefilter("always")
+        assert ctx3.utc_tz_aware == "schema"


### PR DESCRIPTION
## Summary
- Introduces `tz_mode` parameter (options are (`"naive_utc"` | `"aware"` | `"schema"`)) as the primary API for controlling `DateTime` timezone behavior. Previously, this was a boolean parameter called `utc_tz_aware`. #653 introduced a temporary change that accepted a string of `"schema"` as well. The type hint changed to `Union[bool, Literal["schema"]]` which is not nice long term. Switching this to a type of `str` with the explicit options above, makes this easier to understand and maintain, and allows future flexibility if needed.
  - For reference:
    - `"naive_utc"` (formerly `False`) will return naive datetimes
    - `"aware"` (formerly `True`) will always attach a timezone to datetimes
    - `"schema"` returns datetimes that match the server's explicit column definition.
- `utc_tz_aware` remains fully functional in all signatures but emits `DeprecationWarning` and will be removed in 1.0.0.
- Passing both `tz_mode` and `utc_tz_aware` raises `ProgrammingError`.

## Value mapping
| `utc_tz_aware` (old) | `tz_mode` (new) |
|---|---|
| `False` | `"naive_utc"` |
| `True` | `"aware"` |
| `"schema"` | `"schema"` |

## Cleanup
All the deprecation scaffolding (`_resolve_tz_mode`, `_TZ_MODE_TO_UTC_TZ_AWARE`, `_STR_BOOL_MAP`, deprecated properties, and dual-param signatures) is intentionally temporary. It will be deleted entirely when `utc_tz_aware` is removed in 1.0.0.

Closes #654

## Checklist
Delete items not relevant to your PR:
- [X] Unit and integration tests covering the common scenarios were added
- [X] A human-readable description of the changes was provided to include in CHANGELOG