### PR TITLE
Remove deprecated Object('json') type

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,9 @@ The supported method of passing ClickHouse server settings is to prefix such arg
 
 ## UNRELEASED
 
+### Breaking Changes
+- Removed the deprecated `Object('json')` type. This was the legacy experimental JSON type that has been superseded by the new `JSON` type in ClickHouse. Closes [#556](https://github.com/ClickHouse/clickhouse-connect/issues/556)
+
 ### Improvements
 - Added support for the `SAMPLE` clause in SQLAlchemy statements. Note: Due to a SQLAlchemy limitation, only one hint (SAMPLE or FINAL) can be applied per table; chaining both will silently ignore one. For now, this change enables use of sample(), but chaining with final() is not yet supported.  Closes [#634](https://github.com/ClickHouse/clickhouse-connect/issues/634)
 - **Experimental:** Added Python 3.14 free-threading (cp314t) wheel builds for all platforms. The full test suite currently (as of 2 MAR, 2026) passes under free-threaded Python, but is not added to the CI test matrix at this time nor has it been otherwise tested to any degree. Free-threading support should be considered experimental with no guarantees of correctness at this time. Closes [#573](https://github.com/ClickHouse/clickhouse-connect/issues/573)

--- a/clickhouse_connect/cc_sqlalchemy/datatypes/sqltypes.py
+++ b/clickhouse_connect/cc_sqlalchemy/datatypes/sqltypes.py
@@ -445,17 +445,6 @@ class Nested(ChSqlaType, UserDefinedType):
     python_type = None
 
 
-class Object(ChSqlaType, UserDefinedType):
-    """
-    Note this isn't currently supported for insert/select, only table definitions
-    """
-    python_type = None
-
-    def __init__(self, fmt: str = None, type_def: TypeDef = None):
-        if not type_def:
-            type_def = TypeDef(values=(fmt,))
-        super().__init__(type_def)
-
 
 class SimpleAggregateFunction(ChSqlaType, UserDefinedType):
     python_type = None

--- a/clickhouse_connect/datatypes/dynamic.py
+++ b/clickhouse_connect/datatypes/dynamic.py
@@ -383,22 +383,3 @@ class JSON(ClickHouseType):
         if self.read_format(ctx) == 'string':
             return [any_to_json(v) for v in col]
         return col
-
-
-# Note that this type is deprecated and should not be used, it included for temporary backward compatibility only
-class Object(ClickHouseType):
-    python_type = dict
-    # Native is a Python type (primitive, dict, array), string is an actual JSON string
-    valid_formats = 'string', 'native'
-    _data_size = json_sample_size
-    write_column_data = write_json
-
-    def __init__(self, type_def):
-        data_type = type_def.values[0].lower().replace(' ', '')
-        if data_type not in ("'json'", "nullable('json')"):
-            raise NotImplementedError('Only json or Nullable(json) Object type is currently supported')
-        super().__init__(type_def)
-        self._name_suffix = type_def.arg_str
-
-    def write_column_prefix(self, dest: bytearray):
-        dest.append(0x01)

--- a/tests/integration_tests/test_native.py
+++ b/tests/integration_tests/test_native.py
@@ -1,16 +1,11 @@
 import decimal
-import os
 import uuid
 from datetime import datetime, date
 from ipaddress import IPv4Address, IPv6Address
 from typing import Callable
 
-import pytest
-
-from clickhouse_connect.datatypes.format import set_default_formats, clear_default_format, set_read_format, \
-    set_write_format
+from clickhouse_connect.datatypes.format import set_default_formats, clear_default_format, set_read_format
 from clickhouse_connect.driver import Client
-from clickhouse_connect.driver.common import coerce_bool
 
 
 def test_low_card(test_client: Client, table_context: Callable):
@@ -57,46 +52,6 @@ def test_nulls(test_client: Client, table_context: Callable):
         assert result[2] == (3, None, 5882374747732834)
         assert result[3] == (4, 'nonnull2', None)
 
-
-def test_old_json(test_client: Client, table_context: Callable):
-    if not coerce_bool(os.environ.get('CLICKHOUSE_CONNECT_TEST_OLD_JSON_TYPE')):
-        pytest.skip('Deprecated JSON type not tested')
-    with table_context('old_json_test', [
-        'key Int32',
-        'value JSON',
-        'e2 Int32',
-        "null_value Object(Nullable('json'))"
-    ]):
-        jv1 = {'key1': 337, 'value.2': 'vvvv', 'HKD@spéçiäl': 'Special K', 'blank': 'not_really_blank'}
-        jv3 = {'key3': 752, 'value.2': 'v2_rules', 'blank': None}
-        njv2 = {'nk1': -302, 'nk2': {'sub1': 372, 'sub2': 'a string'}}
-        njv3 = {'nk1': 5832.44, 'nk2': {'sub1': 47788382, 'sub2':'sub2val', 'sub3': 'sub3str', 'space key': 'spacey'}}
-        test_client.insert('old_json_test', [
-            [5, jv1, -44, None],
-            [20, None, 5200, njv2],
-            [25, jv3, 7302, njv3]])
-
-        result = test_client.query('SELECT * FROM old_json_test ORDER BY key')
-        json1 = result.result_set[0][1]
-        assert json1['HKD@spéçiäl'] == 'Special K'
-        assert json1['key3'] == 0
-        json2 = result.result_set[1][3]
-        assert json2['nk1'] == -302.0
-        assert json2['nk2']['sub2'] == 'a string'
-        assert json2['nk2']['sub3'] is None
-        json3 = result.result_set[2][1]
-        assert json3['value.2'] == 'v2_rules'
-        assert json3['blank'] == ''
-        assert json3['key1'] == 0
-        assert json3['key3'] == 752
-        null_json3 = result.result_set[2][3]
-        assert null_json3['nk2']['space key'] == 'spacey'
-
-        set_write_format('JSON', 'string')
-        test_client.insert('native_json_test', [[999, '{"key4": 283, "value.2": "str_value"}', 77, '{"nk1":53}']])
-        result = test_client.query('SELECT value.key4, null_value.nk1 FROM native_json_test ORDER BY key')
-        assert result.result_set[3][0] == 283
-        assert result.result_set[3][1] == 53
 
 
 def test_read_formats(test_client: Client, test_table_engine: str):


### PR DESCRIPTION
## Summary
- Removes the legacy experimental `Object('json')` ClickHouse type, which has been deprecated and removed entirely from the server code in 25.11 in favor of the new `JSON` type
- Removes the corresponding SQLAlchemy `Object` type wrapper
- Removes the `test_old_json` integration test