### PR TITLE
Add pandas 1x deprecation warning

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,9 @@ The supported method of passing ClickHouse server settings is to prefix such arg
 ### Breaking Changes
 - Removed the deprecated `Object('json')` type. This was the legacy experimental JSON type that has been superseded by the new `JSON` type in ClickHouse. Closes [#556](https://github.com/ClickHouse/clickhouse-connect/issues/556)
 
+### Deprecations
+- Pandas 1.x support is now deprecated and will be removed in v1.0.0. A `DeprecationWarning` is emitted at import time for pandas 1.x users.
+
 ### Improvements
 - Added support for the `SAMPLE` clause in SQLAlchemy statements. Note: Due to a SQLAlchemy limitation, only one hint (SAMPLE or FINAL) can be applied per table; chaining both will silently ignore one. For now, this change enables use of sample(), but chaining with final() is not yet supported.  Closes [#634](https://github.com/ClickHouse/clickhouse-connect/issues/634)
 - **Experimental:** Added Python 3.14 free-threading (cp314t) wheel builds for all platforms. The full test suite currently (as of 2 MAR, 2026) passes under free-threaded Python, but is not added to the CI test matrix at this time nor has it been otherwise tested to any degree. Free-threading support should be considered experimental with no guarantees of correctness at this time. Closes [#573](https://github.com/ClickHouse/clickhouse-connect/issues/573)

--- a/clickhouse_connect/driver/options.py
+++ b/clickhouse_connect/driver/options.py
@@ -1,3 +1,5 @@
+import warnings
+
 from clickhouse_connect.driver.exceptions import NotSupportedError
 
 pd_time_test = None
@@ -15,6 +17,13 @@ try:
     PANDAS_VERSION = tuple(map(int, pd.__version__.split(".")[:2]))
     IS_PANDAS_2 = PANDAS_VERSION >= (2, 0)
     pd_extended_dtypes = not pd.__version__.startswith('0')
+    if not IS_PANDAS_2:
+        warnings.warn(
+            "clickhouse-connect support for pandas 1.x is deprecated and will be removed in v1.0.0. "
+            "Please upgrade to pandas 2.x or later.",
+            DeprecationWarning,
+            stacklevel=2,
+        )
     try:
         from pandas.core.dtypes.common import is_datetime64_dtype
         from pandas.core.dtypes.common import is_timedelta64_dtype


### PR DESCRIPTION
## Summary
Support for Pandas 1.x will be deprecated when we roll to 1.0.0. This will put in a deprecation warning until that happens to alert users.