### PR TITLE
rename apply_server_timezone to tz_source

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@ The supported method of passing ClickHouse server settings is to prefix such arg
 ## UNRELEASED
 
 ### Breaking Changes
+- Renamed `apply_server_timezone` parameter to `tz_source` across Client and HttpClient. The new `tz_source` parameter accepts string values: `"auto"` (default, was `None`), `"server"` (was `True` or `"always"`), and `"local"` (was `False`). The old `apply_server_timezone` parameter is still accepted but emits a `DeprecationWarning` and will be removed in 1.0. Passing both `tz_source` and `apply_server_timezone` raises `ProgrammingError`. The `"always"` value (which had no distinct runtime behavior from `True`) maps to `"server"`.
 - Renamed `utc_tz_aware` parameter to `tz_mode` across Client, QueryContext, and all query methods. The new `tz_mode` parameter accepts string values: `"naive_utc"` (default, was `False`), `"aware"` (was `True`), and `"schema"` (unchanged). The old `utc_tz_aware` parameter is still accepted but emits a `DeprecationWarning` and will be removed in 1.0. Passing both `tz_mode` and `utc_tz_aware` raises `ProgrammingError`. Closes [#654](https://github.com/ClickHouse/clickhouse-connect/issues/654)
 - Removed the deprecated `Object('json')` type. This was the legacy experimental JSON type that has been superseded by the new `JSON` type in ClickHouse. Closes [#556](https://github.com/ClickHouse/clickhouse-connect/issues/556)
 

--- a/clickhouse_connect/driver/__init__.py
+++ b/clickhouse_connect/driver/__init__.py
@@ -78,6 +78,10 @@ def create_client(*,
     :param server_host_name  This is the server host name that will be checked against a TLS certificate for
       validity.  This option can be used if using an ssh_tunnel or other indirect means to an ClickHouse server
       where the `host` argument refers to the tunnel or proxy and not the actual ClickHouse server
+    :param tz_source Controls how the client determines the fallback timezone for DateTime columns without an
+      explicit timezone. "auto" (default) auto-detects based on DST safety of server timezone. "server" always
+      uses the server timezone. "local" always uses the local timezone.
+    :param apply_server_timezone Deprecated. Use tz_source instead.
     :param tz_mode Controls timezone-aware behavior for UTC DateTime columns. "naive_utc" (default) returns
       naive UTC timestamps. "aware" forces timezone-aware UTC datetimes. "schema" returns datetimes that
       match the server's column definition which means timezone-aware when the column defines a timezone and naive
@@ -208,6 +212,10 @@ async def create_async_client(*,
     :param server_host_name  This is the server host name that will be checked against a TLS certificate for
       validity.  This option can be used if using an ssh_tunnel or other indirect means to an ClickHouse server
       where the `host` argument refers to the tunnel or proxy and not the actual ClickHouse server
+    :param tz_source Controls how the client determines the fallback timezone for DateTime columns without an
+      explicit timezone. "auto" (default) auto-detects based on DST safety of server timezone. "server" always
+      uses the server timezone. "local" always uses the local timezone.
+    :param apply_server_timezone Deprecated. Use tz_source instead.
     :param tz_mode Controls timezone-aware behavior for UTC DateTime columns. "naive_utc" (default) returns
       naive UTC timestamps. "aware" forces timezone-aware UTC datetimes. "schema" returns datetimes that
       match the server's column definition which means timezone-aware when the column defines a timezone and naive

--- a/clickhouse_connect/driver/client.py
+++ b/clickhouse_connect/driver/client.py
@@ -24,7 +24,8 @@ from clickhouse_connect.driver.options import check_arrow, check_pandas, check_n
 from clickhouse_connect.driver.summary import QuerySummary
 from clickhouse_connect.driver.models import ColumnDef, SettingDef, SettingStatus
 from clickhouse_connect.driver.query import QueryResult, to_arrow, to_arrow_batches, QueryContext, arrow_buffer, \
-    TzMode, _resolve_tz_mode, _TZ_MODE_TO_UTC_TZ_AWARE
+    TzMode, TzSource, _resolve_tz_mode, _resolve_tz_source, _TZ_MODE_TO_UTC_TZ_AWARE, \
+    _VALID_TZ_SOURCES, _APPLY_SERVER_TZ_TO_TZ_SOURCE
 from clickhouse_connect.driver.binding import quote_identifier
 
 if TYPE_CHECKING:
@@ -92,9 +93,52 @@ class Client(ABC):
     optional_transport_settings = set()
     database = None
     max_error_message = 0
-    apply_server_timezone = False
+    _tz_source: TzSource = "auto"
+    _apply_server_tz = False
     tz_mode: TzMode = "naive_utc"
     show_clickhouse_errors = True
+
+    @property
+    def tz_source(self) -> TzSource:
+        return self._tz_source
+
+    @tz_source.setter
+    def tz_source(self, value: TzSource):
+        if value not in _VALID_TZ_SOURCES:
+            raise ProgrammingError(
+                f'tz_source must be "auto", "server", or "local", got "{value}"'
+            )
+        self._tz_source = value
+        if value == "auto":
+            self._apply_server_tz = self._dst_safe
+        else:
+            self._apply_server_tz = value == "server"
+
+    @property
+    def apply_server_timezone(self) -> bool:
+        """Deprecated: use tz_source instead."""
+        warnings.warn(
+            "apply_server_timezone is deprecated and will be removed in 1.0. "
+            "Use tz_source instead.",
+            DeprecationWarning,
+            stacklevel=2,
+        )
+        return self._apply_server_tz
+
+    @apply_server_timezone.setter
+    def apply_server_timezone(self, value: Union[bool, str]):
+        """Deprecated: use tz_source instead."""
+        warnings.warn(
+            "apply_server_timezone is deprecated and will be removed in 1.0. "
+            "Use tz_source instead.",
+            DeprecationWarning,
+            stacklevel=2,
+        )
+        if value not in _APPLY_SERVER_TZ_TO_TZ_SOURCE:
+            raise ProgrammingError(
+                f"apply_server_timezone must be True, False, or 'always', got \"{value}\""
+            )
+        self.tz_source = _APPLY_SERVER_TZ_TO_TZ_SOURCE[value]
 
     @property
     def utc_tz_aware(self) -> Union[bool, Literal["schema"]]:
@@ -113,20 +157,25 @@ class Client(ABC):
                  uri: str,
                  query_retries: int,
                  server_host_name: Optional[str],
-                 apply_server_timezone: Optional[Union[str, bool]],
+                 tz_source: Optional[TzSource] = None,
                  tz_mode: Optional[TzMode] = None,
                  show_clickhouse_errors: Optional[bool] = None,
-                 utc_tz_aware: Optional[Union[bool, Literal["schema"]]] = None):
+                 utc_tz_aware: Optional[Union[bool, Literal["schema"]]] = None,
+                 apply_server_timezone: Optional[Union[str, bool]] = None):
         """
         Shared initialization of ClickHouse Connect client
         :param database: database name
         :param query_limit: default LIMIT for queries
         :param uri: uri for error messages
+        :param tz_source: Controls how the client determines the fallback timezone for DateTime columns without an
+          explicit timezone. "auto" (default) auto-detects based on DST safety of server timezone. "server" always
+          uses the server timezone. "local" always uses the local timezone.
         :param tz_mode: Controls timezone-aware behavior for UTC DateTime columns.  "naive_utc" (default) returns
           naive UTC timestamps.  "aware" forces timezone-aware UTC datetimes.  "schema" returns datetimes that
           match the server's column definition which means timezone-aware when the column defines a timezone and naive
           for bare DateTime columns.
         :param utc_tz_aware: Deprecated. Use tz_mode instead.
+        :param apply_server_timezone: Deprecated. Use tz_source instead.
         """
         self.query_limit = coerce_int(query_limit)
         self.query_retries = coerce_int(query_retries)
@@ -137,23 +186,26 @@ class Client(ABC):
         self.server_host_name = server_host_name
         self.uri = uri
         self.tz_mode = _resolve_tz_mode(tz_mode, utc_tz_aware)
-        self._init_common_settings(apply_server_timezone)
+        resolved_tz_source = _resolve_tz_source(tz_source, apply_server_timezone)
+        self._tz_source = resolved_tz_source
+        self._init_common_settings(resolved_tz_source)
 
-    def _init_common_settings(self, apply_server_timezone: Optional[Union[str, bool]]):
-        self.server_tz, dst_safe = pytz.UTC, True
+    def _init_common_settings(self, tz_source: TzSource):
+        self.server_tz, self._dst_safe = pytz.UTC, True
         self.server_version, server_tz = \
             tuple(self.command('SELECT version(), timezone()', use_database=False))
         try:
             server_tz = pytz.timezone(server_tz)
-            server_tz, dst_safe = tzutil.normalize_timezone(server_tz)
-            if apply_server_timezone is None:
-                apply_server_timezone = dst_safe
-            self.apply_server_timezone = apply_server_timezone == 'always' or coerce_bool(apply_server_timezone)
+            server_tz, self._dst_safe = tzutil.normalize_timezone(server_tz)
+            if tz_source == "auto":
+                self._apply_server_tz = self._dst_safe
+            else:
+                self._apply_server_tz = tz_source == "server"
             self.server_tz = server_tz
         except UnknownTimeZoneError:
             logger.warning('Warning, server is using an unrecognized timezone %s, will use UTC default', server_tz)
 
-        if not self.apply_server_timezone and not tzutil.local_tz_dst_safe:
+        if not self._apply_server_tz and not tzutil.local_tz_dst_safe:
             logger.warning('local timezone %s may return unexpected times due to Daylight Savings Time/' +
                            'Summer Time differences', tzutil.local_tz.tzname(None))
         readonly = 'readonly'
@@ -626,7 +678,7 @@ class Client(ABC):
                             use_extended_dtypes=use_extended_dtypes,
                             as_pandas=as_pandas,
                             streaming=streaming,
-                            apply_server_tz=self.apply_server_timezone,
+                            apply_server_tz=self._apply_server_tz,
                             external_data=external_data,
                             transport_settings=transport_settings)
 

--- a/clickhouse_connect/driver/httpclient.py
+++ b/clickhouse_connect/driver/httpclient.py
@@ -26,7 +26,7 @@ from clickhouse_connect.driver.external import ExternalData
 from clickhouse_connect.driver.httputil import ResponseSource, get_pool_manager, get_response_data, \
     default_pool_manager, get_proxy_manager, all_managers, check_env_proxy, check_conn_expiration
 from clickhouse_connect.driver.insert import InsertContext
-from clickhouse_connect.driver.query import QueryResult, QueryContext
+from clickhouse_connect.driver.query import QueryResult, QueryContext, TzSource
 from clickhouse_connect.driver.binding import quote_identifier, bind_query
 from clickhouse_connect.driver.summary import QuerySummary
 from clickhouse_connect.driver.transform import NativeTransform
@@ -76,9 +76,10 @@ class HttpClient(Client):
                  http_proxy: Optional[str] = None,
                  https_proxy: Optional[str] = None,
                  server_host_name: Optional[str] = None,
-                 apply_server_timezone: Optional[Union[str, bool]] = None,
+                 tz_source: Optional[TzSource] = None,
                  tz_mode: Optional[str] = None,
                  utc_tz_aware: Optional[Union[bool, Literal["schema"]]] = None,
+                 apply_server_timezone: Optional[Union[str, bool]] = None,
                  show_clickhouse_errors: Optional[bool] = None,
                  autogenerate_session_id: Optional[bool] = None,
                  autogenerate_query_id: Optional[bool] = None,
@@ -185,9 +186,10 @@ class HttpClient(Client):
                          query_limit=query_limit,
                          query_retries=query_retries,
                          server_host_name=server_host_name,
-                         apply_server_timezone=apply_server_timezone,
+                         tz_source=tz_source,
                          tz_mode=tz_mode,
                          utc_tz_aware=utc_tz_aware,
+                         apply_server_timezone=apply_server_timezone,
                          show_clickhouse_errors=show_clickhouse_errors)
         self.params = dict_copy(self.params, self._validate_settings(ch_settings))
         cancel_setting = self._setting_status("cancel_http_readonly_queries_on_client_close")

--- a/clickhouse_connect/driver/query.py
+++ b/clickhouse_connect/driver/query.py
@@ -24,6 +24,7 @@ if TYPE_CHECKING:
 logger = logging.getLogger(__name__)
 
 TzMode = Literal["naive_utc", "aware", "schema"]
+TzSource = Literal["auto", "server", "local"]
 
 _UTC_TZ_AWARE_TO_TZ_MODE: Dict[Union[bool, str], TzMode] = {
     False: "naive_utc",
@@ -38,6 +39,21 @@ _TZ_MODE_TO_UTC_TZ_AWARE: Dict[str, Union[bool, Literal["schema"]]] = {
     "aware": True,
     "schema": "schema",
 }
+
+_APPLY_SERVER_TZ_TO_TZ_SOURCE: Dict[Union[bool, str, None], TzSource] = {
+    None: "auto",
+    True: "server",
+    False: "local",
+    "always": "server",
+}
+
+_TZ_SOURCE_TO_APPLY_SERVER_TZ: Dict[str, Optional[Union[bool, str]]] = {
+    "auto": None,
+    "server": True,
+    "local": False,
+}
+
+_VALID_TZ_SOURCES = {"auto", "server", "local"}
 
 # Mapping for string booleans that may arrive via URL params
 _STR_BOOL_MAP = {"true": True, "false": False, "1": True, "0": False}
@@ -83,6 +99,49 @@ def _resolve_tz_mode(
         return tz_mode
 
     return "naive_utc"
+
+
+def _resolve_tz_source(
+    tz_source: Optional[TzSource] = None,
+    apply_server_timezone: Optional[Union[str, bool]] = None,
+) -> TzSource:
+    """Resolve tz_source from either the new ``tz_source`` or deprecated ``apply_server_timezone`` parameter.
+
+    Returns the canonical TzSource string.  Raises ``ProgrammingError`` on conflicts or
+    invalid values.
+    """
+    if tz_source is not None and apply_server_timezone is not None:
+        raise ProgrammingError(
+            "Cannot specify both 'tz_source' and 'apply_server_timezone'. "
+            "Use 'tz_source' only; 'apply_server_timezone' is deprecated."
+        )
+
+    if apply_server_timezone is not None:
+        # Coerce string booleans from URL params (e.g. "true" -> True)
+        if isinstance(apply_server_timezone, str) and apply_server_timezone.lower() in _STR_BOOL_MAP:
+            apply_server_timezone = _STR_BOOL_MAP[apply_server_timezone.lower()]
+
+        if apply_server_timezone not in _APPLY_SERVER_TZ_TO_TZ_SOURCE:
+            raise ProgrammingError(
+                f"apply_server_timezone must be None, True, False, or 'always', "
+                f'got "{apply_server_timezone}"'
+            )
+        warnings.warn(
+            "apply_server_timezone is deprecated and will be removed in 1.0. "
+            "Use tz_source='auto' | 'server' | 'local' instead.",
+            DeprecationWarning,
+            stacklevel=3,
+        )
+        return _APPLY_SERVER_TZ_TO_TZ_SOURCE[apply_server_timezone]
+
+    if tz_source is not None:
+        if tz_source not in _VALID_TZ_SOURCES:
+            raise ProgrammingError(
+                f'tz_source must be "auto", "server", or "local", got "{tz_source}"'
+            )
+        return tz_source
+
+    return "auto"
 
 
 commands = 'CREATE|ALTER|SYSTEM|GRANT|REVOKE|CHECK|DETACH|ATTACH|DROP|DELETE|KILL|' + \

--- a/tests/integration_tests/test_native_fuzz.py
+++ b/tests/integration_tests/test_native_fuzz.py
@@ -17,7 +17,7 @@ def test_query_fuzz(test_client: Client, test_table_engine: str):
     if not test_client.min_version('21'):
         pytest.skip(f'flatten_nested setting not supported in this server version {test_client.server_version}')
     test_runs = int(os.environ.get('CLICKHOUSE_CONNECT_TEST_FUZZ', '250'))
-    test_client.apply_server_timezone = True
+    test_client.tz_source = "server"
     try:
         for _ in range(test_runs):
             test_client.command('DROP TABLE IF EXISTS fuzz_test')
@@ -37,4 +37,4 @@ def test_query_fuzz(test_client: Client, test_table_engine: str):
                 assert data_result.column_names == col_names
                 assert data_result.result_set == data
     finally:
-        test_client.apply_server_timezone = False
+        test_client.tz_source = "auto"

--- a/tests/integration_tests/test_timezones.py
+++ b/tests/integration_tests/test_timezones.py
@@ -1,15 +1,19 @@
 import os
 import time
+import warnings
 from datetime import datetime
 
 import pytz
+import pytest
 
 from clickhouse_connect.driver import Client, tzutil
+from clickhouse_connect.driver.exceptions import ProgrammingError
 
 # We have to localize a datetime from a timezone to get a current, sensible timezone object for testing.  See
 # https://stackoverflow.com/questions/35462876/python-pytz-timezone-function-returns-a-timezone-that-is-off-by-9-minutes
 chicago_tz = pytz.timezone('America/Chicago').localize(datetime(2020, 8, 8, 10, 5, 5)).tzinfo
 
+# pylint:disable=protected-access
 
 def test_basic_timezones(test_client: Client):
     row = test_client.query("SELECT toDateTime('2022-10-25 10:55:22', 'America/Chicago') as chicago," +
@@ -36,7 +40,7 @@ def test_basic_timezones(test_client: Client):
 def test_server_timezone(test_client: Client):
     #  This test is really for manual testing since changing the timezone on the test ClickHouse server
     #  still requires a restart.  Other tests will depend on https://github.com/ClickHouse/ClickHouse/pull/44149
-    test_client.apply_server_timezone = True
+    test_client.tz_source = "server"
     test_datetime = datetime(2023, 3, 18, 16, 4, 25)
     try:
         date = test_client.query('SELECT toDateTime(%s) as st', parameters=[test_datetime]).first_row[0]
@@ -50,7 +54,7 @@ def test_server_timezone(test_client: Client):
             assert date.tzinfo == den_tz
             assert date.timestamp() == 1679177065
     finally:
-        test_client.apply_server_timezone = False
+        test_client.tz_source = "auto"
 
 
 def test_column_timezones(test_client: Client):
@@ -80,7 +84,7 @@ def test_column_timezones(test_client: Client):
 def test_local_timezones(test_client: Client):
     denver_tz = pytz.timezone('America/Denver')
     tzutil.local_tz = denver_tz
-    test_client.apply_server_timezone = False
+    test_client.tz_source = "local"
     try:
         row = test_client.query("SELECT toDateTime('2022-10-25 10:55:22'," +
                                 "'America/Chicago') as chicago," +
@@ -96,7 +100,7 @@ def test_local_timezones(test_client: Client):
         assert row[3].tzinfo.tzname(None) == denver_tz.tzname(None)
     finally:
         tzutil.local_tz = pytz.UTC
-        test_client.apply_server_timezone = True
+        test_client.tz_source = "auto"
 
 
 def test_naive_timezones(test_client: Client):
@@ -115,7 +119,7 @@ def test_timezone_binding_client(test_client: Client):
     time.tzset()
     denver_tz = pytz.timezone('America/Denver')
     tzutil.local_tz = denver_tz
-    test_client.apply_server_timezone = False
+    test_client.tz_source = "local"
     denver_time = datetime(2023, 3, 18, 16, 4, 25, tzinfo=denver_tz)
     try:
         server_time = test_client.query(
@@ -125,7 +129,7 @@ def test_timezone_binding_client(test_client: Client):
         os.environ['TZ'] = 'UTC'
         tzutil.local_tz = pytz.UTC
         time.tzset()
-        test_client.apply_server_timezone = True
+        test_client.tz_source = "auto"
 
     naive_time = datetime(2023, 3, 18, 16, 4, 25)
     server_time = test_client.query(
@@ -143,7 +147,7 @@ def test_timezone_binding_server(test_client: Client):
     time.tzset()
     denver_tz = pytz.timezone('America/Denver')
     tzutil.local_tz = denver_tz
-    test_client.apply_server_timezone = False
+    test_client.tz_source = "local"
     denver_time = datetime(2022, 3, 18, 16, 4, 25, tzinfo=denver_tz)
     try:
         server_time = test_client.query(
@@ -153,7 +157,7 @@ def test_timezone_binding_server(test_client: Client):
         os.environ['TZ'] = 'UTC'
         time.tzset()
         tzutil.local_tz = pytz.UTC
-        test_client.apply_server_timezone = True
+        test_client.tz_source = "auto"
 
     naive_time = datetime(2022, 3, 18, 16, 4, 25)
     server_time = test_client.query(
@@ -193,3 +197,53 @@ def test_tz_mode(test_client: Client):
         assert row[0].tzinfo == pytz.UTC
         assert row[1].tzinfo == pytz.UTC
         assert row[0].microsecond == 123456
+
+
+def test_apply_server_timezone_setter_deprecated(test_client: Client):
+    """Setting client.apply_server_timezone should emit a DeprecationWarning and update state."""
+    try:
+        with warnings.catch_warnings(record=True) as w:
+            warnings.simplefilter("always")
+            test_client.apply_server_timezone = True
+            assert len(w) == 1
+            assert issubclass(w[0].category, DeprecationWarning)
+            assert "apply_server_timezone is deprecated" in str(w[0].message)
+        assert test_client.tz_source == "server"
+        assert test_client._apply_server_tz is True
+
+        with warnings.catch_warnings(record=True) as w:
+            warnings.simplefilter("always")
+            test_client.apply_server_timezone = False
+            assert len(w) == 1
+            assert issubclass(w[0].category, DeprecationWarning)
+        assert test_client.tz_source == "local"
+        assert test_client._apply_server_tz is False
+    finally:
+        test_client.tz_source = "auto"
+
+
+def test_apply_server_timezone_getter_deprecated(test_client: Client):
+    """Reading client.apply_server_timezone should emit a DeprecationWarning."""
+    with warnings.catch_warnings(record=True) as w:
+        warnings.simplefilter("always")
+        _ = test_client.apply_server_timezone
+        assert len(w) == 1
+        assert issubclass(w[0].category, DeprecationWarning)
+
+
+def test_tz_source_setter_validates(test_client: Client):
+    """Setting client.tz_source to an invalid value should raise ProgrammingError."""
+    with pytest.raises(ProgrammingError, match='tz_source must be'):
+        test_client.tz_source = "serer"
+
+
+def test_tz_source_setter_auto_restores_dst_safe(test_client: Client):
+    """Setting tz_source back to 'auto' should re-resolve based on server DST safety."""
+    original = test_client._apply_server_tz
+    try:
+        test_client.tz_source = "local"
+        assert test_client._apply_server_tz is False
+        test_client.tz_source = "auto"
+        assert test_client._apply_server_tz == original
+    finally:
+        test_client.tz_source = "auto"

--- a/tests/unit_tests/test_driver/test_query.py
+++ b/tests/unit_tests/test_driver/test_query.py
@@ -6,7 +6,7 @@ import pytest
 import pyarrow as pa
 
 from clickhouse_connect.driver.exceptions import ProgrammingError
-from clickhouse_connect.driver.query import QueryContext, _resolve_tz_mode
+from clickhouse_connect.driver.query import QueryContext, _resolve_tz_mode, _resolve_tz_source
 from clickhouse_connect.driver.client import _strip_utc_timezone_from_arrow
 from clickhouse_connect.driver import tzutil
 
@@ -323,3 +323,75 @@ def test_utc_tz_aware_property_returns_legacy_value():
     with warnings.catch_warnings(record=True) as w:
         warnings.simplefilter("always")
         assert ctx3.utc_tz_aware == "schema"
+
+
+def test_resolve_tz_source_defaults():
+    """No arguments should return 'auto'."""
+    assert _resolve_tz_source() == "auto"
+
+
+def test_resolve_tz_source_valid_values():
+    """Each literal value should be accepted."""
+    assert _resolve_tz_source(tz_source="auto") == "auto"
+    assert _resolve_tz_source(tz_source="server") == "server"
+    assert _resolve_tz_source(tz_source="local") == "local"
+
+
+def test_resolve_tz_source_invalid_raises():
+    """Invalid string value should raise ProgrammingError."""
+    with pytest.raises(ProgrammingError, match='tz_source must be'):
+        _resolve_tz_source(tz_source="invalid")
+
+
+def test_apply_server_timezone_none_maps_to_auto():
+    """apply_server_timezone=None (default) should return 'auto' without a warning."""
+    with warnings.catch_warnings(record=True) as w:
+        warnings.simplefilter("always")
+        assert _resolve_tz_source(apply_server_timezone=None) == "auto"
+        # None means "not provided" so no deprecation warning
+        assert len(w) == 0
+
+
+def test_apply_server_timezone_true_maps_to_server():
+    """apply_server_timezone=True should map to 'server' with a DeprecationWarning."""
+    with warnings.catch_warnings(record=True) as w:
+        warnings.simplefilter("always")
+        assert _resolve_tz_source(apply_server_timezone=True) == "server"
+        assert len(w) == 1
+        assert issubclass(w[0].category, DeprecationWarning)
+
+
+def test_apply_server_timezone_false_maps_to_local():
+    """apply_server_timezone=False should map to 'local' with a DeprecationWarning."""
+    with warnings.catch_warnings(record=True) as w:
+        warnings.simplefilter("always")
+        assert _resolve_tz_source(apply_server_timezone=False) == "local"
+        assert len(w) == 1
+        assert issubclass(w[0].category, DeprecationWarning)
+
+
+def test_apply_server_timezone_always_maps_to_server():
+    """apply_server_timezone='always' should map to 'server' with a DeprecationWarning."""
+    with warnings.catch_warnings(record=True) as w:
+        warnings.simplefilter("always")
+        assert _resolve_tz_source(apply_server_timezone="always") == "server"
+        assert len(w) == 1
+        assert issubclass(w[0].category, DeprecationWarning)
+
+
+def test_both_tz_source_and_apply_server_timezone_raises():
+    """Providing both tz_source and apply_server_timezone should raise ProgrammingError."""
+    with pytest.raises(ProgrammingError, match="Cannot specify both"):
+        _resolve_tz_source(tz_source="server", apply_server_timezone=True)
+
+
+def test_apply_server_timezone_string_bool_coercion():
+    """String booleans from URL params should be coerced correctly."""
+    with warnings.catch_warnings(record=True):
+        warnings.simplefilter("always")
+        assert _resolve_tz_source(apply_server_timezone="true") == "server"
+        assert _resolve_tz_source(apply_server_timezone="false") == "local"
+        assert _resolve_tz_source(apply_server_timezone="True") == "server"
+        assert _resolve_tz_source(apply_server_timezone="False") == "local"
+        assert _resolve_tz_source(apply_server_timezone="1") == "server"
+        assert _resolve_tz_source(apply_server_timezone="0") == "local"


### PR DESCRIPTION
## Summary
- Renames `apply_server_timezone` parameter to `tz_source` across `Client`, `HttpClient`, and `create_client`/`create_async_client`, replacing magic `None`/`True`/`False`/`"always"` values with `"auto"` | `"server"` | `"local"`
- Old `apply_server_timezone` parameter still accepted at construction and via runtime assignment, emitting `DeprecationWarning` as it will be removed in 1.0.0
- Passing both `tz_source` and `apply_server_timezone` raises `ProgrammingError`
- "always" (which appeared to be dead code and was identical to `True` at runtime) maps to `"server"`
- There is zero default behavior change. `"auto"` resolves identically to the old `None` path
- This work follows the same deprecation pattern established by the `utc_tz_aware` -> `tz_mode` rename work

## Mapping
| Old (`apply_server_timezone`) | New (`tz_source`) | Behavior |
|---|---|---|
| `None` (default) | `"auto"` (default) | Use server tz if DST-safe, otherwise local tz |
| `True` | `"server"` | Always use server tz |
| `False` | `"local"` | Always use local tz |
| `"always"` | `"server"` | Same as `True` (was dead code) | 

## Checklist
Delete items not relevant to your PR:
- [X] Unit and integration tests covering the common scenarios were added
- [X] A human-readable description of the changes was provided to include in CHANGELOG