### PR TITLE
add bare import smoke test to CI

### DIFF
--- a/.github/workflows/on_push.yml
+++ b/.github/workflows/on_push.yml
@@ -49,6 +49,32 @@ jobs:
           pylint tests
           pylint examples
 
+  bare-import-test:
+    runs-on: ubuntu-latest
+    needs: lint
+    name: Bare Install Test (no extras)
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+      - name: Start ClickHouse (latest) in Docker
+        uses: hoverkraft-tech/compose-action@v2.0.0
+        env:
+          CLICKHOUSE_CONNECT_TEST_CH_VERSION: latest
+        with:
+          compose-file: 'docker-compose.yml'
+          down-flags: '--volumes'
+      - name: Set up Python 3.12
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+      - name: Install only core dependencies (no extras)
+        run: |
+          python -m pip install --upgrade pip
+          pip install -e . --no-deps
+          pip install certifi urllib3 pytz zstandard lz4
+      - name: Bare import test and basic query
+        run: python tests/test_bare_install.py
+
   tests:
     runs-on: ubuntu-latest
     needs: lint
@@ -63,9 +89,9 @@ jobs:
         clickhouse-version:
           - '25.3' # LTS
           - '25.8' # LTS
-          - '25.11' # Stable
           - '25.12' # Stable
           - '26.1' # Stable
+          - '26.2' # Stable
 
     name: Local Tests Py=${{ matrix.python-version }} CH=${{ matrix.clickhouse-version }}
     steps:
@@ -179,7 +205,7 @@ jobs:
 
   check-secret:
     runs-on: ubuntu-latest
-    needs: [tests, pandas-1x-compat-test, sqlalchemy-1x-compat-test]
+    needs: [bare-import-smoke-test, tests, pandas-1x-compat-test, sqlalchemy-1x-compat-test]
     outputs:
       has_secrets: ${{ steps.has_secrets.outputs.HAS_SECRETS }}
     steps:

--- a/.github/workflows/on_push.yml
+++ b/.github/workflows/on_push.yml
@@ -77,7 +77,7 @@ jobs:
 
   tests:
     runs-on: ubuntu-latest
-    needs: lint
+    needs: bare-import-test
     strategy:
       matrix:
         python-version:
@@ -129,7 +129,7 @@ jobs:
 
   pandas-1x-compat-test:
     runs-on: ubuntu-latest
-    needs: lint
+    needs: bare-import-test
     name: Pandas 1.x Compatibility Tests
     steps:
       - name: Checkout
@@ -167,7 +167,7 @@ jobs:
 
   sqlalchemy-1x-compat-test:
     runs-on: ubuntu-latest
-    needs: lint
+    needs: bare-import-test
     name: SQLAlchemy 1.x Compatibility Tests
     steps:
       - name: Checkout

--- a/.github/workflows/on_push.yml
+++ b/.github/workflows/on_push.yml
@@ -205,7 +205,7 @@ jobs:
 
   check-secret:
     runs-on: ubuntu-latest
-    needs: [bare-import-smoke-test, tests, pandas-1x-compat-test, sqlalchemy-1x-compat-test]
+    needs: [bare-import-test, tests, pandas-1x-compat-test, sqlalchemy-1x-compat-test]
     outputs:
       has_secrets: ${{ steps.has_secrets.outputs.HAS_SECRETS }}
     steps:

--- a/tests/test_bare_install.py
+++ b/tests/test_bare_install.py
@@ -1,0 +1,19 @@
+import clickhouse_connect
+
+
+def test_bare_install():
+    """Bare install test to validate the package works with only core dependencies"""
+    client = clickhouse_connect.get_client()
+
+    ver = client.command("SELECT version()")
+    assert isinstance(ver, str) and len(ver) > 0, f"unexpected version: {ver}"
+
+    result = client.query("SELECT 1 AS x, 2 AS y")
+    assert result.result_rows == [(1, 2)], f"unexpected result: {result.result_rows}"
+
+    client.command("DROP TABLE IF EXISTS _bare_install_test")
+    client.command("CREATE TABLE _bare_install_test (id UInt32, val String) ENGINE MergeTree ORDER BY id")
+    client.insert("_bare_install_test", [[1, "a"], [2, "b"]], column_names=["id", "val"])
+    res = client.query("SELECT * FROM _bare_install_test ORDER BY id")
+    assert res.result_rows == [(1, "a"), (2, "b")], f"unexpected: {res.result_rows}"
+    client.command("DROP TABLE _bare_install_test")


### PR DESCRIPTION
## Summary
- Add a simple CI job to import `clickhouse_connect` and make a simple query. This catches things like missed quoted type hints, etc. that'll break if you don't have all the extras installed.
- Updates test test matrix
