### PR TITLE
async native future warning

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,7 @@ The supported method of passing ClickHouse server settings is to prefix such arg
 
 ### Deprecations
 - Pandas 1.x support is now deprecated and will be removed in v1.0.0. A `DeprecationWarning` is emitted at import time for pandas 1.x users.
+- The current `AsyncClient` (a thread-pool wrapper around the sync client) now emits a `FutureWarning` on creation, pointing users to the fully native async client available as a prerelease: `pip install 'clickhouse-connect[async]==0.12.0rc1'`. This prerelease branch (based on 0.11.0) is gathering feedback ahead of 1.0.0, where it will become the default async implementation. It is a drop-in replacement with the same API surface.
 
 ### Improvements
 - Added support for the `SAMPLE` clause in SQLAlchemy statements. Note: Due to a SQLAlchemy limitation, only one hint (SAMPLE or FINAL) can be applied per table; chaining both will silently ignore one. For now, this change enables use of sample(), but chaining with final() is not yet supported.  Closes [#634](https://github.com/ClickHouse/clickhouse-connect/issues/634)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,7 +30,7 @@ The supported method of passing ClickHouse server settings is to prefix such arg
 
 ### Deprecations
 - Pandas 1.x support is now deprecated and will be removed in v1.0.0. A `DeprecationWarning` is emitted at import time for pandas 1.x users.
-- The current `AsyncClient` (a thread-pool wrapper around the sync client) now emits a `FutureWarning` on creation, pointing users to the fully native async client available as a prerelease: `pip install 'clickhouse-connect[async]==0.12.0rc1'`. This prerelease branch (based on 0.11.0) is gathering feedback ahead of 1.0.0, where it will become the default async implementation. It is a drop-in replacement with the same API surface.
+- The current `AsyncClient` is a thread-pool wrapper around the sync client and now emits a `FutureWarning` on creation, pointing users to the fully native async client available as a prerelease: `pip install 'clickhouse-connect[async]==0.12.0rc1'`. This prerelease branch is based on 0.11.0 and is gathering feedback ahead of 1.0.0, where it will become the default async implementation. It is a drop-in replacement with the same API surface.
 
 ### Improvements
 - Added support for the `SAMPLE` clause in SQLAlchemy statements. Note: Due to a SQLAlchemy limitation, only one hint (SAMPLE or FINAL) can be applied per table; chaining both will silently ignore one. For now, this change enables use of sample(), but chaining with final() is not yet supported.  Closes [#634](https://github.com/ClickHouse/clickhouse-connect/issues/634)

--- a/clickhouse_connect/driver/__init__.py
+++ b/clickhouse_connect/driver/__init__.py
@@ -1,4 +1,5 @@
 import asyncio
+import warnings
 from concurrent.futures import ThreadPoolExecutor
 from inspect import signature
 from typing import Optional, Union, Dict, Any
@@ -227,6 +228,18 @@ async def create_async_client(*,
       limits. Only available for query operations (not inserts). Default: False
     :return: ClickHouse Connect Client instance
     """
+
+    warnings.warn(
+        "The current async client is a thread-pool wrapper around the sync client. "
+        "A fully native async client is available for testing as a prerelease: "
+        "pip install 'clickhouse-connect[async]==0.12.0rc1'. "
+        "This prerelease branch (based on 0.11.0) is gathering feedback ahead of 1.0.0, "
+        "where it will become the default async implementation. It is a drop-in replacement "
+        "with the same API surface. The main line includes additional updates that the native "
+        "client will receive when merged into 1.0.0.",
+        FutureWarning,
+        stacklevel=2,
+    )
 
     def _create_client():
         if 'autogenerate_session_id' not in kwargs:

--- a/clickhouse_connect/driver/__init__.py
+++ b/clickhouse_connect/driver/__init__.py
@@ -233,7 +233,7 @@ async def create_async_client(*,
         "The current async client is a thread-pool wrapper around the sync client. "
         "A fully native async client is available for testing as a prerelease: "
         "pip install 'clickhouse-connect[async]==0.12.0rc1'. "
-        "This prerelease branch (based on 0.11.0) is gathering feedback ahead of 1.0.0, "
+        "This prerelease branch is based on 0.11.0 and is gathering feedback ahead of 1.0.0, "
         "where it will become the default async implementation. It is a drop-in replacement "
         "with the same API surface. The main line includes additional updates that the native "
         "client will receive when merged into 1.0.0.",


### PR DESCRIPTION
## Summary
This PR changes the current `AsyncClient` to emit a `FutureWarning` on creation, pointing users to the fully native async client available as a prerelease via `pip install 'clickhouse-connect[async]==0.12.0rc1'`. This prerelease branch is based on 0.11.0 and is gathering feedback ahead of 1.0.0, where it will become the default async implementation. It is a drop-in replacement with the same API surface.