### PR TITLE
Fix shared variant decoding for JSON and Dynamic columns

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,9 @@ The supported method of passing ClickHouse server settings is to prefix such arg
 
 ## UNRELEASED
 
+### Bug Fixes
+- Fix JSON column read path when shared data is present i.e. when paths exceed `max_dynamic_paths`. Shared data values are decoded from ClickHouse's binary type encoding which is the type discriminator byte followed by type-specific binary payload. Scalar types (like integers, floats, strings, booleans, and nulls) and nested objects are fully decoded. Compound types (Array, Tuple, Map, DateTime, Date, Decimal, UUID) are not yet decoded and will be returned as raw bytes. Fixes [#599](https://github.com/ClickHouse/clickhouse-connect/issues/599) and [#615](https://github.com/ClickHouse/clickhouse-connect/issues/615)
+
 ## 0.14.0, 2026-03-09
 
 ### Breaking Changes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,7 +24,7 @@ The supported method of passing ClickHouse server settings is to prefix such arg
 ## UNRELEASED
 
 ### Bug Fixes
-- Fix JSON column read path when shared data is present i.e. when paths exceed `max_dynamic_paths`. Shared data values are decoded from ClickHouse's binary type encoding which is the type discriminator byte followed by type-specific binary payload. Scalar types (like integers, floats, strings, booleans, and nulls) and nested objects are fully decoded. Compound types (Array, Tuple, Map, DateTime, Date, Decimal, UUID) are not yet decoded and will be returned as raw bytes. Fixes [#599](https://github.com/ClickHouse/clickhouse-connect/issues/599) and [#615](https://github.com/ClickHouse/clickhouse-connect/issues/615)
+- Fix JSON and Dynamic column read paths to properly decode shared variant data instead of returning raw binary with discriminator byte prefixes. Shared data values, used when paths exceed `max_dynamic_paths` or types exceed `max_dynamic_types` are now decoded from ClickHouse's binary variant encoding. Scalar types like integers, floats, strings, booleans, and nulls as well as nested objects are now fully decoded. Compound types like Array, Tuple, Map, DateTime, Date, Decimal, and UUID are not yet decoded and will be returned as raw bytes. Fixes [#599](https://github.com/ClickHouse/clickhouse-connect/issues/599), [#615](https://github.com/ClickHouse/clickhouse-connect/issues/615), and [#674](https://github.com/ClickHouse/clickhouse-connect/issues/674)
 
 ## 0.14.0, 2026-03-09
 

--- a/clickhouse_connect/datatypes/dynamic.py
+++ b/clickhouse_connect/datatypes/dynamic.py
@@ -1,9 +1,12 @@
+import logging
 from collections import namedtuple
 from typing import List, Tuple, Sequence, Collection, Any
 from urllib.parse import unquote
 
 from clickhouse_connect.datatypes.base import ClickHouseType, TypeDef
 from clickhouse_connect.datatypes.registry import get_from_name
+from clickhouse_connect.datatypes.string import String
+from clickhouse_connect.driver.bytesource import ByteArraySource
 from clickhouse_connect.driver.common import unescape_identifier, first_value, write_uint64
 from clickhouse_connect.driver.ctypes import data_conv
 from clickhouse_connect.driver.errors import handle_error
@@ -15,8 +18,11 @@ from clickhouse_connect.json_impl import any_to_json
 
 SHARED_DATA_TYPE: ClickHouseType
 STRING_DATA_TYPE: ClickHouseType
+SHARED_VARIANT_TYPE: ClickHouseType
 _JSON_NULL = b'null'
 _JSON_NULL_STR = 'null'
+
+logger = logging.getLogger(__name__)
 
 json_serialization_format = 0x1
 
@@ -28,6 +34,24 @@ def _json_path_segments(path: str) -> List[str]:
     if '%' in path:
         return [unquote(segment) for segment in segments]
     return segments
+
+
+def _nest_value(target: dict, path: str, value) -> None:
+    """Insert a value into a nested dict structure using a dot-separated path."""
+    chain = _json_path_segments(path)
+    item = target
+    for key in chain[:-1]:
+        child = item.get(key)
+        if child is None:
+            child = {}
+            item[key] = child
+        item = child
+    item[chain[-1]] = value
+
+
+class SharedDataString(String):
+    def _read_column_binary(self, source: ByteSource, num_rows: int, ctx: QueryContext, _read_state: Any):
+        return source.read_str_col(num_rows, None)
 
 
 TypedVariant = namedtuple('TypedVariant', 'value type_name')
@@ -193,7 +217,7 @@ def read_dynamic_prefix(_, source: ByteSource, ctx: QueryContext) -> DynamicStat
         raise DataError('Unrecognized dynamic structure version')
     num_variants = source.read_leb128()
     variant_types = [get_from_name(source.read_leb128_str()) for _ in range(num_variants)]
-    variant_types.append(STRING_DATA_TYPE)
+    variant_types.append(SHARED_VARIANT_TYPE)
     if source.read_uint64() != 0:  # discriminator format, currently only 0 is recognized
         raise DataError('Unexpected discriminator format in Variant column prefix')
     variant_states = [e_type.read_column_prefix(source, ctx) for e_type in variant_types]
@@ -264,11 +288,201 @@ def write_str_values(ch_type: ClickHouseType, column: Sequence, dest: bytearray,
     handle_error(data_conv.write_str_col(col, False, encoding, dest), ctx)
 
 
-JSONState = namedtuple('JSONState', 'serialize_version dynamic_paths typed_states dynamic_states')
+JSONState = namedtuple("JSONState", "serialize_version dynamic_paths typed_states dynamic_states shared_state")
+
+# Discriminator byte to ClickHouse type name for types we can decode.
+# From ClickHouse src/DataTypes/DataTypesBinaryEncoding.cpp BinaryTypeIndex enum.
+STANDARD_DISCRIMINATOR_TYPES = {
+    0x00: "Nothing",
+    0x01: "UInt8",
+    0x02: "UInt16",
+    0x03: "UInt32",
+    0x04: "UInt64",
+    0x05: "UInt128",
+    0x06: "UInt256",
+    0x07: "Int8",
+    0x08: "Int16",
+    0x09: "Int32",
+    0x0A: "Int64",
+    0x0B: "Int128",
+    0x0C: "Int256",
+    0x0D: "Float32",
+    0x0E: "Float64",
+    0x15: "String",
+    0x2D: "Bool",
+}
+
+# Known fixed payload sizes for BinaryTypeIndex values outside STANDARD_DISCRIMINATOR_TYPES.
+# Used to validate variant-encoded data in the printable ASCII overlap range (0x20+).
+_EXTENDED_PAYLOAD_SIZE = {
+    0x0F: 2,   # Date (UInt16)
+    0x10: 4,   # Date32 (Int32)
+    0x11: 4,   # DateTimeUTC (UInt32)
+    0x13: 8,   # DateTime64UTC (Int64)
+    0x1D: 16,  # UUID
+    0x28: 4,   # IPv4
+    0x29: 16,  # IPv6
+    0x31: 2,   # BFloat16
+}
+
+# Expected payload sizes for fixed-size discriminator types.
+# Used to validate that binary data is actually variant-encoded vs a plain string
+# whose first byte happens to collide with a discriminator value.
+_DISCRIMINATOR_PAYLOAD_SIZE = {
+    0x00: 0,   # Nothing
+    0x01: 1,   # UInt8
+    0x02: 2,   # UInt16
+    0x03: 4,   # UInt32
+    0x04: 8,   # UInt64
+    0x05: 16,  # UInt128
+    0x06: 32,  # UInt256
+    0x07: 1,   # Int8
+    0x08: 2,   # Int16
+    0x09: 4,   # Int32
+    0x0A: 8,   # Int64
+    0x0B: 16,  # Int128
+    0x0C: 32,  # Int256
+    0x0D: 4,   # Float32
+    0x0E: 8,   # Float64
+    0x2D: 1,   # Bool
+    # String (0x15) is variable-length and validated separately
+}
+
+
+def _validate_variant_length(binary_data: bytes, discriminator: int) -> bool:
+    """Check whether binary_data has the correct length for a variant-encoded value."""
+    payload = binary_data[1:]
+    expected = _DISCRIMINATOR_PAYLOAD_SIZE.get(discriminator)
+    if expected is not None:
+        return len(payload) == expected
+    if discriminator == 0x15:  # String: LEB128 length prefix + that many bytes
+        if len(payload) == 0:
+            return False
+        length = 0
+        shift = 0
+        for i, b in enumerate(payload):
+            length |= (b & 0x7F) << shift
+            shift += 7
+            if (b & 0x80) == 0:
+                return len(payload) == i + 1 + length
+        return False
+    return True  # Unknown discriminator, skip validation
+
+
+def _decode_variant(binary_data: bytes, ctx: QueryContext, validate_length: bool = True):
+    """Try to decode variant-encoded binary data.
+
+    Returns the decoded value on success, or the original bytes on failure
+    (unknown discriminator, unsupported type, decode error).
+    """
+    if len(binary_data) == 0:
+        return b""
+
+    discriminator = binary_data[0]
+    if discriminator == 255:
+        return None
+
+    type_name = STANDARD_DISCRIMINATOR_TYPES.get(discriminator)
+    if type_name is None:
+        # If unsupported discriminator like Date, DateTime, Array, etc. just return raw bytes
+        return binary_data
+
+    if validate_length and not _validate_variant_length(binary_data, discriminator):
+        # Length doesn't match expected payload, it's not actually variant-encoded
+        return None
+
+    value_type = get_from_name(type_name)
+    try:
+        byte_source = ByteArraySource(binary_data[1:])
+        read_state = value_type.read_column_prefix(byte_source, ctx)
+        result = value_type.read_column_data(byte_source, 1, ctx, read_state)
+        return result[0] if result else None
+
+    # pylint: disable=broad-exception-caught
+    except Exception as e:
+        logger.debug("Variant decode failed: %s", e)
+        return binary_data
+
+
+def decode_shared_data_value(binary_data: bytes, ctx: QueryContext):
+    """Decode a variant-encoded value from JSON shared data."""
+    if binary_data is None:
+        return None
+    if not isinstance(binary_data, bytes):
+        if isinstance(binary_data, memoryview):
+            binary_data = bytes(binary_data)
+        elif isinstance(binary_data, str):
+            return binary_data  # already decoded
+        else:
+            binary_data = bytes(binary_data)
+    return _decode_variant(binary_data, ctx)
+
+
+# pylint: disable=too-many-return-statements, too-many-branches
+def decode_shared_variant_value(binary_data: bytes, ctx: QueryContext):
+    """Decode a value from a Dynamic column's shared variant.
+
+    The shared variant can contain either:
+    - Variant-encoded binary data i.e. from paths promoted from shared data after merge
+    - Plain string bytes i.e. from paths that were already dynamic
+
+    Heuristics for distinguishing the two:
+    1. Supported types (STANDARD_DISCRIMINATOR_TYPES): length-validate then decode.
+    2. Control characters (< 0x20): no real string starts with these, so it's
+       variant-encoded with an unsupported type — return raw bytes.
+    3. Printable range (>= 0x20) with known fixed payload size: length-validate,
+       return raw bytes if it matches.
+    4. Everything else: treat as a plain UTF-8 string.
+    """
+    if binary_data is None:
+        return None
+    if not isinstance(binary_data, bytes):
+        if isinstance(binary_data, memoryview):
+            binary_data = bytes(binary_data)
+        elif isinstance(binary_data, str):
+            return binary_data
+        else:
+            binary_data = bytes(binary_data)
+    if len(binary_data) == 0:
+        return ""
+
+    discriminator = binary_data[0]
+    if discriminator == 255:
+        return None
+
+    # 1. Supported type we can fully decode —> validate length and decode
+    if discriminator in STANDARD_DISCRIMINATOR_TYPES:
+        if _validate_variant_length(binary_data, discriminator):
+            return _decode_variant(binary_data, ctx, validate_length=False)
+        # Length mismatch —> not variant-encoded -> fall through to string
+
+    # 2. Control character range -> almost certainly variant-encoded
+    elif discriminator < 0x20:
+        return _decode_variant(binary_data, ctx)
+
+    # 3. Printable range with known fixed payload size —> validate length
+    else:
+        expected = _EXTENDED_PAYLOAD_SIZE.get(discriminator)
+        if expected is not None and len(binary_data) == 1 + expected:
+            return binary_data  # variant-encoded but unsupported fixed-size type
+
+    # 4. Plain UTF-8 string
+    try:
+        return binary_data.decode("utf-8")
+    except UnicodeDecodeError:
+        return binary_data
+
+
+class SharedVariant(String):
+    """Reads the shared variant sub-column in Dynamic columns."""
+
+    def _read_column_binary(self, source: ByteSource, num_rows: int, ctx: QueryContext, _read_state: Any):
+        raw_values = source.read_str_col(num_rows, None)
+        return [decode_shared_variant_value(v, ctx) for v in raw_values]
 
 
 class JSON(ClickHouseType):
-    _slots = 'typed_paths', 'typed_types'
+    __slots__ = 'typed_paths', 'typed_types'
     python_type = dict
     valid_formats = 'string', 'native'
     _data_size = json_sample_size
@@ -342,7 +556,8 @@ class JSON(ClickHouseType):
         dynamic_paths = [source.read_leb128_str() for _ in range(dynamic_path_cnt)]
         typed_states = [typed.read_column_prefix(source, ctx) for typed in self.typed_types]
         dynamic_states = [read_dynamic_prefix(self, source, ctx) for _ in range(dynamic_path_cnt)]
-        return JSONState(serialize_version, dynamic_paths, typed_states, dynamic_states)
+        shared_state = SHARED_DATA_TYPE.read_column_prefix(source, ctx)
+        return JSONState(serialize_version, dynamic_paths, typed_states, dynamic_states, shared_state)
 
     # pylint: disable=too-many-locals
     def _read_column_binary(self, source: ByteSource, num_rows: int, ctx: QueryContext, read_state: JSONState):
@@ -351,34 +566,23 @@ class JSON(ClickHouseType):
         dynamic_columns = [
             read_variant_column(source, num_rows, ctx, dynamic_state.variant_types, dynamic_state.variant_states)
             for dynamic_state in read_state.dynamic_states]
-        SHARED_DATA_TYPE.read_column_data(source, num_rows, ctx, None)
+        shared_columns = SHARED_DATA_TYPE.read_column_data(source, num_rows, ctx, read_state.shared_state)
         col = []
         for row_num in range(num_rows):
             top = {}
             for ix, field in enumerate(self.typed_paths):
-                value = typed_columns[ix][row_num]
-                item = top
-                chain = _json_path_segments(field)
-                for key in chain[:-1]:
-                    child = item.get(key)
-                    if child is None:
-                        child = {}
-                        item[key] = child
-                    item = child
-                item[chain[-1]] = value
+                _nest_value(top, field, typed_columns[ix][row_num])
             for ix, field in enumerate(read_state.dynamic_paths):
                 value = dynamic_columns[ix][row_num]
-                if value is None:
-                    continue
-                item = top
-                chain = _json_path_segments(field)
-                for key in chain[:-1]:
-                    child = item.get(key)
-                    if child is None:
-                        child = {}
-                        item[key] = child
-                    item = child
-                item[chain[-1]] = value
+                if value is not None:
+                    _nest_value(top, field, value)
+            if shared_columns and row_num < len(shared_columns):
+                shared_data = shared_columns[row_num]
+                if shared_data:
+                    for key, raw_value in shared_data.items():
+                        value = decode_shared_data_value(raw_value, ctx)
+                        if value is not None:
+                            _nest_value(top, key, value)
             col.append(top)
         if self.read_format(ctx) == 'string':
             return [any_to_json(v) for v in col]

--- a/clickhouse_connect/datatypes/dynamic.py
+++ b/clickhouse_connect/datatypes/dynamic.py
@@ -384,11 +384,9 @@ def _decode_variant(binary_data: bytes, ctx: QueryContext, validate_length: bool
 
     type_name = STANDARD_DISCRIMINATOR_TYPES.get(discriminator)
     if type_name is None:
-        # If unsupported discriminator like Date, DateTime, Array, etc. just return raw bytes
         return binary_data
 
     if validate_length and not _validate_variant_length(binary_data, discriminator):
-        # Length doesn't match expected payload, it's not actually variant-encoded
         return None
 
     value_type = get_from_name(type_name)
@@ -482,7 +480,7 @@ class SharedVariant(String):
 
 
 class JSON(ClickHouseType):
-    __slots__ = 'typed_paths', 'typed_types'
+    __slots__ = "typed_paths", "typed_types", "skips"
     python_type = dict
     valid_formats = 'string', 'native'
     _data_size = json_sample_size
@@ -490,12 +488,12 @@ class JSON(ClickHouseType):
     shared_data_type: ClickHouseType
     max_dynamic_paths = 0
     max_dynamic_types = 0
-    typed_paths = []
-    typed_types = []
-    skips = []
 
     def __init__(self, type_def: TypeDef):
         super().__init__(type_def)
+        self.typed_paths = []
+        self.typed_types = []
+        self.skips = []
         typed_paths = []
         typed_types = []
         skips = []

--- a/clickhouse_connect/datatypes/format.py
+++ b/clickhouse_connect/datatypes/format.py
@@ -5,9 +5,6 @@ from typing import Dict, Type, Sequence, Optional
 from clickhouse_connect.datatypes.base import ClickHouseType, type_map, ch_read_formats, ch_write_formats
 from clickhouse_connect.driver.exceptions import ProgrammingError
 
-json_re = re.compile('json', re.IGNORECASE)
-
-
 def set_default_formats(*args, **kwargs):
     fmt_map = format_map(_convert_arguments(*args, **kwargs))
     ch_read_formats.update(fmt_map)
@@ -26,7 +23,6 @@ def clear_default_format(pattern: str):
 
 
 def set_write_format(pattern: str, fmt: str):
-    pattern = json_re.sub('object', pattern)
     for ch_type in _matching_types(pattern):
         ch_write_formats[ch_type] = fmt
 

--- a/clickhouse_connect/datatypes/postinit.py
+++ b/clickhouse_connect/datatypes/postinit.py
@@ -1,7 +1,18 @@
 from clickhouse_connect.datatypes import registry, dynamic, geometric
+from clickhouse_connect.datatypes.base import TypeDef
+from clickhouse_connect.datatypes.container import Map
 
-dynamic.SHARED_DATA_TYPE = registry.get_from_name('Array(String, String)')
 dynamic.STRING_DATA_TYPE = registry.get_from_name('String')
+
+# Build a private Map(String, String) for JSON shared data decoding.
+# We must NOT reuse the cached registry instance because we replace
+# value_type with SharedDataString (reads raw bytes, encoding=None).
+# Mutating the cached instance would break all normal Map(String, String) columns.
+_shared_map = Map(TypeDef((), (), ('String', 'String')))
+_shared_map.value_type = dynamic.SharedDataString(dynamic.STRING_DATA_TYPE.type_def)
+dynamic.SHARED_DATA_TYPE = _shared_map
+
+dynamic.SHARED_VARIANT_TYPE = dynamic.SharedVariant(dynamic.STRING_DATA_TYPE.type_def)
 
 point = 'Tuple(Float64, Float64)'
 ring = f'Array({point})'

--- a/clickhouse_connect/driver/bytesource.py
+++ b/clickhouse_connect/driver/bytesource.py
@@ -16,18 +16,11 @@ class ByteArraySource(ByteSource):
     """
 
     def __init__(self, data: bytes, encoding: str = "utf-8"):
-        """
-        Initialize ByteArraySource with byte array data.
-
-        :param data: The byte array to read from
-        :param encoding: Character encoding for string operations (default: utf-8)
-        """
         self.data = data
         self.pos = 0
         self.encoding = encoding
 
     def read_byte(self) -> int:
-        """Read a single byte and advance position."""
         if self.pos >= len(self.data):
             raise EOFError("Attempted to read past end of byte array")
         b = self.data[self.pos]
@@ -35,7 +28,6 @@ class ByteArraySource(ByteSource):
         return b
 
     def read_bytes(self, sz: int) -> bytes:
-        """Read specified number of bytes and advance position."""
         if self.pos + sz > len(self.data):
             raise EOFError(f"Attempted to read {sz} bytes, only {len(self.data) - self.pos} available")
         result = self.data[self.pos : self.pos + sz]
@@ -43,7 +35,6 @@ class ByteArraySource(ByteSource):
         return result
 
     def read_leb128(self) -> int:
-        """Read a LEB128 (variable-length) encoded integer."""
         sz = 0
         shift = 0
         while self.pos < len(self.data):
@@ -55,57 +46,35 @@ class ByteArraySource(ByteSource):
         raise EOFError("Unexpected end while reading LEB128")
 
     def read_leb128_str(self) -> str:
-        """Read a LEB128 length-prefixed string."""
         sz = self.read_leb128()
         return self.read_bytes(sz).decode(self.encoding)
 
     def read_uint64(self) -> int:
-        """Read an unsigned 64-bit integer (little-endian)."""
         return int.from_bytes(self.read_bytes(8), "little", signed=False)
 
     def read_int64(self) -> int:
-        """Read a signed 64-bit integer (little-endian)."""
         return int.from_bytes(self.read_bytes(8), "little", signed=True)
 
     def read_uint32(self) -> int:
-        """Read an unsigned 32-bit integer (little-endian)."""
         return int.from_bytes(self.read_bytes(4), "little", signed=False)
 
     def read_int32(self) -> int:
-        """Read a signed 32-bit integer (little-endian)."""
         return int.from_bytes(self.read_bytes(4), "little", signed=True)
 
     def read_uint16(self) -> int:
-        """Read an unsigned 16-bit integer (little-endian)."""
         return int.from_bytes(self.read_bytes(2), "little", signed=False)
 
     def read_int16(self) -> int:
-        """Read a signed 16-bit integer (little-endian)."""
         return int.from_bytes(self.read_bytes(2), "little", signed=True)
 
     def read_float32(self) -> float:
-        """Read a 32-bit float (little-endian)."""
         return struct.unpack("<f", self.read_bytes(4))[0]
 
     def read_float64(self) -> float:
-        """Read a 64-bit float (double, little-endian)."""
         return struct.unpack("<d", self.read_bytes(8))[0]
 
     # pylint: disable=too-many-return-statements
     def read_array(self, array_type: str, num_rows: int):  # type: ignore
-        """
-        Limited implementation of array reading for basic types.
-
-        Args:
-            array_type: Python struct format character
-                'B' = UInt8, 'H' = UInt16, 'I' = UInt32, 'Q' = UInt64
-                'b' = Int8, 'h' = Int16, 'i' = Int32, 'q' = Int64
-                'f' = Float32, 'd' = Float64
-            num_rows: Number of elements to read
-
-        Returns:
-            List of values
-        """
         if array_type == "B":
             return [self.read_byte() for _ in range(num_rows)]
         if array_type == "H":
@@ -129,10 +98,6 @@ class ByteArraySource(ByteSource):
         raise NotImplementedError(f"Array type {array_type} not implemented for ByteArraySource")
 
     def read_str_col(self, num_rows, encoding, nullable=False, null_obj=None):  # type: ignore
-        """
-        Read a column of strings.
-        For single-value decoding (num_rows=1), read one LEB128 length-prefixed string.
-        """
         if num_rows != 1:
             raise NotImplementedError("read_str_col only supports num_rows=1 for single-value decoding")
 
@@ -145,11 +110,9 @@ class ByteArraySource(ByteSource):
         return [string_bytes.decode(encoding)]
 
     def read_bytes_col(self, sz, num_rows):
-        """Not used for single-value decoding."""
         raise NotImplementedError("read_bytes_col not needed for single-value decoding")
 
     def read_fixed_str_col(self, sz, num_rows, encoding):
-        """Not used for single-value decoding."""
         raise NotImplementedError("read_fixed_str_col not needed for single-value decoding")
 
     def close(self):

--- a/clickhouse_connect/driver/bytesource.py
+++ b/clickhouse_connect/driver/bytesource.py
@@ -1,0 +1,156 @@
+import struct
+
+from clickhouse_connect.driver.types import ByteSource
+
+
+class ByteArraySource(ByteSource):
+    """
+    ByteSource implementation for in-memory byte arrays.
+
+    This class wraps a byte array and provides the ByteSource interface,
+    allowing ClickHouse type decoders to read from in-memory data instead
+    of a network stream.
+
+    Used primarily for decoding variant-encoded values from JSON shared data
+    where each value is a complete serialized type instance.
+    """
+
+    def __init__(self, data: bytes, encoding: str = "utf-8"):
+        """
+        Initialize ByteArraySource with byte array data.
+
+        :param data: The byte array to read from
+        :param encoding: Character encoding for string operations (default: utf-8)
+        """
+        self.data = data
+        self.pos = 0
+        self.encoding = encoding
+
+    def read_byte(self) -> int:
+        """Read a single byte and advance position."""
+        if self.pos >= len(self.data):
+            raise EOFError("Attempted to read past end of byte array")
+        b = self.data[self.pos]
+        self.pos += 1
+        return b
+
+    def read_bytes(self, sz: int) -> bytes:
+        """Read specified number of bytes and advance position."""
+        if self.pos + sz > len(self.data):
+            raise EOFError(f"Attempted to read {sz} bytes, only {len(self.data) - self.pos} available")
+        result = self.data[self.pos : self.pos + sz]
+        self.pos += sz
+        return result
+
+    def read_leb128(self) -> int:
+        """Read a LEB128 (variable-length) encoded integer."""
+        sz = 0
+        shift = 0
+        while self.pos < len(self.data):
+            b = self.read_byte()
+            sz += (b & 0x7F) << shift
+            if (b & 0x80) == 0:
+                return sz
+            shift += 7
+        raise EOFError("Unexpected end while reading LEB128")
+
+    def read_leb128_str(self) -> str:
+        """Read a LEB128 length-prefixed string."""
+        sz = self.read_leb128()
+        return self.read_bytes(sz).decode(self.encoding)
+
+    def read_uint64(self) -> int:
+        """Read an unsigned 64-bit integer (little-endian)."""
+        return int.from_bytes(self.read_bytes(8), "little", signed=False)
+
+    def read_int64(self) -> int:
+        """Read a signed 64-bit integer (little-endian)."""
+        return int.from_bytes(self.read_bytes(8), "little", signed=True)
+
+    def read_uint32(self) -> int:
+        """Read an unsigned 32-bit integer (little-endian)."""
+        return int.from_bytes(self.read_bytes(4), "little", signed=False)
+
+    def read_int32(self) -> int:
+        """Read a signed 32-bit integer (little-endian)."""
+        return int.from_bytes(self.read_bytes(4), "little", signed=True)
+
+    def read_uint16(self) -> int:
+        """Read an unsigned 16-bit integer (little-endian)."""
+        return int.from_bytes(self.read_bytes(2), "little", signed=False)
+
+    def read_int16(self) -> int:
+        """Read a signed 16-bit integer (little-endian)."""
+        return int.from_bytes(self.read_bytes(2), "little", signed=True)
+
+    def read_float32(self) -> float:
+        """Read a 32-bit float (little-endian)."""
+        return struct.unpack("<f", self.read_bytes(4))[0]
+
+    def read_float64(self) -> float:
+        """Read a 64-bit float (double, little-endian)."""
+        return struct.unpack("<d", self.read_bytes(8))[0]
+
+    # pylint: disable=too-many-return-statements
+    def read_array(self, array_type: str, num_rows: int):  # type: ignore
+        """
+        Limited implementation of array reading for basic types.
+
+        Args:
+            array_type: Python struct format character
+                'B' = UInt8, 'H' = UInt16, 'I' = UInt32, 'Q' = UInt64
+                'b' = Int8, 'h' = Int16, 'i' = Int32, 'q' = Int64
+                'f' = Float32, 'd' = Float64
+            num_rows: Number of elements to read
+
+        Returns:
+            List of values
+        """
+        if array_type == "B":
+            return [self.read_byte() for _ in range(num_rows)]
+        if array_type == "H":
+            return [self.read_uint16() for _ in range(num_rows)]
+        if array_type == "I":
+            return [self.read_uint32() for _ in range(num_rows)]
+        if array_type == "Q":
+            return [self.read_uint64() for _ in range(num_rows)]
+        if array_type == "b":
+            return [int.from_bytes([self.read_byte()], "little", signed=True) for _ in range(num_rows)]
+        if array_type == "h":
+            return [self.read_int16() for _ in range(num_rows)]
+        if array_type == "i":
+            return [self.read_int32() for _ in range(num_rows)]
+        if array_type == "q":
+            return [self.read_int64() for _ in range(num_rows)]
+        if array_type == "f":
+            return [self.read_float32() for _ in range(num_rows)]
+        if array_type == "d":
+            return [self.read_float64() for _ in range(num_rows)]
+        raise NotImplementedError(f"Array type {array_type} not implemented for ByteArraySource")
+
+    def read_str_col(self, num_rows, encoding, nullable=False, null_obj=None):  # type: ignore
+        """
+        Read a column of strings.
+        For single-value decoding (num_rows=1), read one LEB128 length-prefixed string.
+        """
+        if num_rows != 1:
+            raise NotImplementedError("read_str_col only supports num_rows=1 for single-value decoding")
+
+        length = self.read_leb128()
+        string_bytes = self.read_bytes(length)
+
+        if encoding is None:
+            return [string_bytes]
+
+        return [string_bytes.decode(encoding)]
+
+    def read_bytes_col(self, sz, num_rows):
+        """Not used for single-value decoding."""
+        raise NotImplementedError("read_bytes_col not needed for single-value decoding")
+
+    def read_fixed_str_col(self, sz, num_rows, encoding):
+        """Not used for single-value decoding."""
+        raise NotImplementedError("read_fixed_str_col not needed for single-value decoding")
+
+    def close(self):
+        """No cleanup needed for byte arrays."""

--- a/tests/integration_tests/test_dynamic.py
+++ b/tests/integration_tests/test_dynamic.py
@@ -579,7 +579,7 @@ def test_json_shared_data_nested_keys(test_client: Client, table_context: Callab
             "top_a": "stays_dynamic",
             "top_b": "stays_dynamic_too",
             "nested.level1.level2": "deep_value",
-            "nested.level1.other": 42,
+            "nested.level1.other": 79,
             "nested.sibling": "sibling_value",
             "flat_overflow": "flat_value",
         }
@@ -589,6 +589,59 @@ def test_json_shared_data_nested_keys(test_client: Client, table_context: Callab
         returned = result[0][1]
         assert isinstance(returned, dict)
         assert returned["nested"]["level1"]["level2"] == "deep_value"
-        assert returned["nested"]["level1"]["other"] == 42
+        assert returned["nested"]["level1"]["other"] == 79
         assert returned["nested"]["sibling"] == "sibling_value"
         assert returned["flat_overflow"] == "flat_value"
+
+
+def test_json_dynamic_variant_decoding(test_client: Client, table_context: Callable):
+    """Test with one nested JSON path changing type across rows."""
+    type_available(test_client, "json")
+    with table_context("json_dyn_variant", ["id Int32", "attributes JSON"]):
+        rows = [
+            [1, {"agent.value": "computer-use", "meta.region": "us-west-2"}],
+            [2, {"agent.value": 2164330, "meta.region": "us-east-1"}],
+            [3, {"agent.value": True, "meta.region": "eu-central-1"}],
+            [4, {"agent.value": 2.81, "meta.region": "ap-southeast-1"}],
+        ]
+        test_client.insert("json_dyn_variant", rows)
+        result = test_client.query("SELECT * FROM json_dyn_variant ORDER BY id").result_set
+
+        assert result[0][1]["agent"]["value"] == "computer-use"
+        assert result[1][1]["agent"]["value"] == 2164330
+        assert result[2][1]["agent"]["value"] is True
+        assert result[3][1]["agent"]["value"] == pytest.approx(2.81)
+        assert result[0][1]["meta"]["region"] == "us-west-2"
+        assert result[1][1]["meta"]["region"] == "us-east-1"
+        assert result[2][1]["meta"]["region"] == "eu-central-1"
+        assert result[3][1]["meta"]["region"] == "ap-southeast-1"
+
+
+def test_json_dynamic_variant_multiple_rows(test_client: Client, table_context: Callable):
+    """Test with top-level JSON keys changing type across rows."""
+    type_available(test_client, "json")
+    with table_context("json_dyn_multi", ["id Int32", "data JSON"]):
+        rows = [
+            [1, {"value": 95, "status": "user_1"}],
+            [2, {"value": "user_2", "status": False}],
+            [3, {"value": True, "status": 4.5}],
+            [4, {"value": 0.0, "status": -10}],
+        ]
+        test_client.insert("json_dyn_multi", rows)
+        result = test_client.query("SELECT * FROM json_dyn_multi ORDER BY id").result_set
+
+        r1 = result[0][1]
+        assert r1["value"] == 95
+        assert r1["status"] == "user_1"
+
+        r2 = result[1][1]
+        assert r2["value"] == "user_2"
+        assert r2["status"] is False
+
+        r3 = result[2][1]
+        assert r3["value"] is True
+        assert r3["status"] == pytest.approx(4.5)
+
+        r4 = result[3][1]
+        assert r4["value"] == pytest.approx(0.0)
+        assert r4["status"] == -10

--- a/tests/integration_tests/test_dynamic.py
+++ b/tests/integration_tests/test_dynamic.py
@@ -17,7 +17,7 @@ from tests.integration_tests.conftest import TestConfig
 def type_available(test_client: Client, data_type: str):
     if test_client.get_client_setting(f'allow_experimental_{data_type}_type') is None:
         return
-    setting_def = test_client.server_settings.get(f'allow_experimental_{data_type}_value', None)
+    setting_def = test_client.server_settings.get(f'allow_experimental_{data_type}_type', None)
     if setting_def is not None and setting_def.value == '1':
         return
     pytest.skip(f'New {data_type.upper()} type not available in this version: {test_client.server_version}')
@@ -198,6 +198,25 @@ def test_dynamic(test_client: Client, table_context: Callable):
         assert result[2][1] == 'bef56f14-0870-4f82-a35e-9a47eff45a5b'
         assert result[3][1] == '[120, 250]'
         assert result[2][2] == '777.25'
+
+
+def test_dynamic_shared_variant_unsupported_types(test_client: Client, table_context: Callable):
+    type_available(test_client, "dynamic")
+    with table_context("dynamic_shared_variant", [
+        "id UInt8",
+        "d Dynamic(max_types=0)",
+    ]):
+        test_client.command("INSERT INTO dynamic_shared_variant SELECT 1, toDate('2024-01-02')")
+        test_client.command("INSERT INTO dynamic_shared_variant SELECT 2, toDateTime('2024-01-02 03:04:05')")
+        test_client.command("INSERT INTO dynamic_shared_variant SELECT 3, [1, 2, 3]")
+        test_client.command("INSERT INTO dynamic_shared_variant SELECT 4, 'hello'")
+
+        result = test_client.query("SELECT * FROM dynamic_shared_variant ORDER BY id").result_set
+
+        assert result[0][1] == b"\x0f\x0cM"
+        assert result[1][1] == b"\x11%}\x93e"
+        assert result[2][1] == b"\x1e\x01\x03\x01\x02\x03"
+        assert result[3][1] == "hello"
 
 
 def test_basic_json(test_client: Client, table_context: Callable):
@@ -404,3 +423,172 @@ def test_typed_variant_name_normalization(test_client: Client, table_context: Ca
         test_client.insert('variant_norm', data)
         result = test_client.query('SELECT * FROM variant_norm ORDER BY key').result_set
         assert result[0][1] == decimal.Decimal('1.50')
+
+
+def test_json_with_many_paths(test_client: Client, table_context: Callable):
+    """Test JSON with many dynamic paths to exercise the shared data structure."""
+    type_available(test_client, "json")
+    with table_context("json_many_paths", ["id Int32", "data JSON(max_dynamic_paths=5)"]):
+        large_json = {f"key_{i}": f"value_{i}" for i in range(20)}
+        test_client.insert("json_many_paths", [[1, large_json]])
+        result = test_client.query("SELECT * FROM json_many_paths").result_set
+
+        assert result[0][0] == 1
+        returned_json = result[0][1]
+        assert isinstance(returned_json, dict)
+        assert len(returned_json) == 20
+        for i in range(20):
+            assert f"key_{i}" in returned_json
+            assert returned_json[f"key_{i}"] == f"value_{i}"
+
+
+def test_json_with_long_values(test_client: Client, table_context: Callable):
+    """Test JSON shared data with long string values (>127 chars) to verify VarInt decoding."""
+    type_available(test_client, "json")
+    with table_context("json_long_values", ["id Int32", "data JSON(max_dynamic_paths=2)"]):
+        short_val = "a" * 10
+        medium_val = "b" * 150
+        long_val = "c" * 300
+
+        test_json = {
+            "key_0": short_val,
+            "key_1": medium_val,
+            "key_2": long_val,
+        }
+        test_client.insert("json_long_values", [[1, test_json]])
+        result = test_client.query("SELECT * FROM json_long_values").result_set
+
+        assert result[0][0] == 1
+        returned_json = result[0][1]
+        assert isinstance(returned_json, dict)
+        assert returned_json["key_0"] == short_val
+        assert returned_json["key_1"] == medium_val
+        assert returned_json["key_2"] == long_val
+
+
+def test_json_shared_data_primitive_types(test_client: Client, table_context: Callable):
+    """Tests round-trip of integers, floats, booleans, strings, and NULL in shared data."""
+    type_available(test_client, "json")
+
+    with table_context("json_primitive_types", ["id Int32", "data JSON(max_dynamic_paths=2)"]):
+        test_data = {
+            "int8_val": -100,
+            "int16_val": -30000,
+            "int32_val": -2000000000,
+            "int64_val": -9000000000000000000,
+            "uint8_val": 200,
+            "uint16_val": 60000,
+            "uint32_val": 4000000000,
+            "uint64_val": 18000000000000000000,
+            "float32_val": 3.14159,
+            "float64_val": 2.718281828459045,
+            "bool_true": True,
+            "bool_false": False,
+            "string_val": "Hello, shared data!",
+            "empty_string": "",
+            "long_string": "x" * 200,
+            "null_val": None,
+            "zero_int": 0,
+            "zero_float": 0.0,
+            "negative_float": -123.456,
+            "negative_int": -1,
+        }
+
+        test_client.insert("json_primitive_types", [[1, test_data]])
+        result = test_client.query("SELECT * FROM json_primitive_types").result_set
+
+        assert result[0][0] == 1
+        returned = result[0][1]
+        assert isinstance(returned, dict)
+
+        assert returned["int8_val"] == test_data["int8_val"]
+        assert returned["int16_val"] == test_data["int16_val"]
+        assert returned["int32_val"] == test_data["int32_val"]
+        assert returned["int64_val"] == test_data["int64_val"]
+        assert returned["uint8_val"] == test_data["uint8_val"]
+        assert returned["uint16_val"] == test_data["uint16_val"]
+        assert returned["uint32_val"] == test_data["uint32_val"]
+        assert returned["uint64_val"] == test_data["uint64_val"]
+        assert returned["float32_val"] == pytest.approx(test_data["float32_val"])
+        assert returned["float64_val"] == pytest.approx(test_data["float64_val"])
+        assert returned["bool_true"] is test_data["bool_true"]
+        assert returned["bool_false"] is test_data["bool_false"]
+        assert returned["string_val"] == test_data["string_val"]
+        assert returned["empty_string"] == test_data["empty_string"]
+        assert returned["long_string"] == test_data["long_string"]
+        assert "null_val" not in returned
+        assert returned["zero_int"] == test_data["zero_int"]
+        assert returned["zero_float"] == pytest.approx(test_data["zero_float"])
+        assert returned["negative_float"] == pytest.approx(test_data["negative_float"])
+        assert returned["negative_int"] == test_data["negative_int"]
+
+
+def test_json_shared_data_multiple_rows(test_client: Client, table_context: Callable):
+    """Test JSON shared data with multiple rows to ensure consistent decoding."""
+    type_available(test_client, "json")
+
+    with table_context("json_multirow", ["id Int32", "data JSON(max_dynamic_paths=2)"]):
+        test_data = [
+            {"a": "string_val", "b": 100, "c": 3.14, "d": True, "e": "more"},
+            {"a": 42, "b": "different", "c": False, "d": 2.718, "e": -999},
+            {"a": 0, "b": 0.0, "c": "", "d": None, "e": False},
+        ]
+        rows = [[i + 1, data] for i, data in enumerate(test_data)]
+
+        test_client.insert("json_multirow", rows)
+        result = test_client.query("SELECT * FROM json_multirow ORDER BY id").result_set
+
+        # Row 1
+        assert result[0][0] == 1
+        row1 = result[0][1]
+        assert row1["a"] == test_data[0]["a"]
+        assert row1["b"] == test_data[0]["b"]
+        assert row1["c"] == pytest.approx(test_data[0]["c"])
+        assert row1["d"] is test_data[0]["d"]
+        assert row1["e"] == test_data[0]["e"]
+
+        # Row 2
+        assert result[1][0] == 2
+        row2 = result[1][1]
+        assert row2["a"] == test_data[1]["a"]
+        assert row2["b"] == test_data[1]["b"]
+        assert row2["c"] is test_data[1]["c"]
+        assert row2["d"] == pytest.approx(test_data[1]["d"])
+        assert row2["e"] == test_data[1]["e"]
+
+        # Row 3
+        assert result[2][0] == 3
+        row3 = result[2][1]
+        assert row3["a"] == test_data[2]["a"]
+        assert row3["b"] == pytest.approx(test_data[2]["b"])
+        assert row3["c"] == test_data[2]["c"]
+        assert "d" not in row3
+        assert row3["e"] is test_data[2]["e"]
+
+        # Query column with nulls via dot notation
+        result_w_nulls = test_client.query("SELECT data.d FROM json_multirow ORDER BY id").result_set
+        assert [result[0] for result in result_w_nulls] == [item["d"] for item in test_data]
+
+
+def test_json_shared_data_nested_keys(test_client: Client, table_context: Callable):
+    """Test that dotted keys in shared data are properly nested into dicts."""
+    type_available(test_client, "json")
+
+    with table_context("json_shared_nested", ["id Int32", "data JSON(max_dynamic_paths=2)"]):
+        test_data = {
+            "top_a": "stays_dynamic",
+            "top_b": "stays_dynamic_too",
+            "nested.level1.level2": "deep_value",
+            "nested.level1.other": 42,
+            "nested.sibling": "sibling_value",
+            "flat_overflow": "flat_value",
+        }
+        test_client.insert("json_shared_nested", [[1, test_data]])
+        result = test_client.query("SELECT * FROM json_shared_nested").result_set
+
+        returned = result[0][1]
+        assert isinstance(returned, dict)
+        assert returned["nested"]["level1"]["level2"] == "deep_value"
+        assert returned["nested"]["level1"]["other"] == 42
+        assert returned["nested"]["sibling"] == "sibling_value"
+        assert returned["flat_overflow"] == "flat_value"

--- a/tests/unit_tests/test_bytesource.py
+++ b/tests/unit_tests/test_bytesource.py
@@ -1,0 +1,167 @@
+import struct
+
+import pytest
+
+from clickhouse_connect.driver.bytesource import ByteArraySource
+
+
+def test_read_byte():
+    src = ByteArraySource(b"\x42\xff")
+    assert src.read_byte() == 0x42
+    assert src.read_byte() == 0xFF
+
+
+def test_read_byte_eof():
+    src = ByteArraySource(b"")
+    with pytest.raises(EOFError):
+        src.read_byte()
+
+
+def test_read_bytes():
+    src = ByteArraySource(b"\x01\x02\x03\x04\x05")
+    assert src.read_bytes(3) == b"\x01\x02\x03"
+    assert src.read_bytes(2) == b"\x04\x05"
+
+
+def test_read_bytes_eof():
+    src = ByteArraySource(b"\x01\x02")
+    with pytest.raises(EOFError):
+        src.read_bytes(5)
+
+
+def test_read_leb128_single_byte():
+    src = ByteArraySource(b"\x7f")
+    assert src.read_leb128() == 127
+
+
+def test_read_leb128_multi_byte():
+    # 300 = 0b100101100 => LEB128: 0xAC 0x02
+    src = ByteArraySource(b"\xac\x02")
+    assert src.read_leb128() == 300
+
+
+def test_read_leb128_zero():
+    src = ByteArraySource(b"\x00")
+    assert src.read_leb128() == 0
+
+
+def test_read_leb128_str():
+    # "hello" = 5 bytes, LEB128 length = 0x05
+    src = ByteArraySource(b"\x05hello")
+    assert src.read_leb128_str() == "hello"
+
+
+def test_read_uint64():
+    val = 18000000000000000000
+    data = val.to_bytes(8, "little", signed=False)
+    src = ByteArraySource(data)
+    assert src.read_uint64() == val
+
+
+def test_read_uint64_zero():
+    src = ByteArraySource(b"\x00" * 8)
+    assert src.read_uint64() == 0
+
+
+def test_read_array_uint8():
+    src = ByteArraySource(b"\x01\x02\x03")
+    assert src.read_array("B", 3) == [1, 2, 3]
+
+
+def test_read_array_int8():
+    # -1 as signed byte = 0xFF
+    src = ByteArraySource(b"\xff\x80\x01")
+    result = src.read_array("b", 3)
+    assert result == [-1, -128, 1]
+
+
+def test_read_array_uint16():
+    data = struct.pack("<HH", 1000, 60000)
+    src = ByteArraySource(data)
+    assert src.read_array("H", 2) == [1000, 60000]
+
+
+def test_read_array_uint32():
+    data = struct.pack("<II", 100000, 4000000000)
+    src = ByteArraySource(data)
+    assert src.read_array("I", 2) == [100000, 4000000000]
+
+
+def test_read_array_uint64():
+    data = struct.pack("<QQ", 0, 2**64 - 1)
+    src = ByteArraySource(data)
+    assert src.read_array("Q", 2) == [0, 2**64 - 1]
+
+
+def test_read_array_int64():
+    data = struct.pack("<qq", -9000000000000000000, 42)
+    src = ByteArraySource(data)
+    assert src.read_array("q", 2) == [-9000000000000000000, 42]
+
+
+def test_read_array_float32():
+    data = struct.pack("<f", 3.14)
+    src = ByteArraySource(data)
+    result = src.read_array("f", 1)
+    assert result[0] == pytest.approx(3.14, rel=1e-5)
+
+
+def test_read_array_float64():
+    data = struct.pack("<d", 2.718281828459045)
+    src = ByteArraySource(data)
+    result = src.read_array("d", 1)
+    assert result[0] == pytest.approx(2.718281828459045)
+
+
+def test_read_array_unsupported():
+    src = ByteArraySource(b"\x00")
+    with pytest.raises(NotImplementedError):
+        src.read_array("Z", 1)
+
+
+def test_read_str_col():
+    # LEB128 length 5 + "hello"
+    src = ByteArraySource(b"\x05hello")
+    result = src.read_str_col(1, "utf-8")
+    assert result == ["hello"]
+
+
+def test_read_str_col_raw_bytes():
+    src = ByteArraySource(b"\x03abc")
+    result = src.read_str_col(1, None)
+    assert result == [b"abc"]
+
+
+def test_read_str_col_multi_row_raises():
+    src = ByteArraySource(b"\x00")
+    with pytest.raises(NotImplementedError):
+        src.read_str_col(2, "utf-8")
+
+
+def test_read_bytes_col_raises():
+    src = ByteArraySource(b"\x00")
+    with pytest.raises(NotImplementedError):
+        src.read_bytes_col(1, 1)
+
+
+def test_read_fixed_str_col_raises():
+    src = ByteArraySource(b"\x00")
+    with pytest.raises(NotImplementedError):
+        src.read_fixed_str_col(1, 1, "utf-8")
+
+
+def test_close_is_noop():
+    src = ByteArraySource(b"\x00")
+    src.close()  # should not raise
+
+
+def test_sequential_reads():
+    """Test that position tracking works correctly across mixed reads."""
+    data = b"\x42"  # read_byte
+    data += b"\x03abc"  # read_leb128_str
+    data += struct.pack("<Q", 999)  # read_uint64
+    src = ByteArraySource(data)
+
+    assert src.read_byte() == 0x42
+    assert src.read_leb128_str() == "abc"
+    assert src.read_uint64() == 999


### PR DESCRIPTION
## Summary
- Fixes incorrect client decoding of ClickHouse `JSON` and `Dynamic` values when data is stored in shared overflow structures rather than ordinary typed subcolumns. This affected `JSON` path overflow cases, `Dynamic` shared-variant cases, and mixed-type JSON paths across rows.
- Adds client-side decoding for shared binary values using ClickHouse’s binary type encoding, reuses existing datatype readers through an in-memory `ByteSource`, and safely falls back to raw bytes for unsupported types.
- Adds regression coverage for
  - `JSON` shared-data overflow
  - Dynamic shared-variant overflow
  - Mixed-type JSON paths across rows

Closes #599
Closes #615
Closes #674
Closes #466

## Checklist
Delete items not relevant to your PR:
- [X] Unit and integration tests covering the common scenarios were added
- [X] A human-readable description of the changes was provided to include in CHANGELOG