### PR TITLE
fix sqlalchemy empty result metadata for orm queries

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@ The supported method of passing ClickHouse server settings is to prefix such arg
 
 ### Bug Fixes
 - Fix JSON and Dynamic column read paths to properly decode shared variant data instead of returning raw binary with discriminator byte prefixes. Shared data values, used when paths exceed `max_dynamic_paths` or types exceed `max_dynamic_types` are now decoded from ClickHouse's binary variant encoding. Scalar types like integers, floats, strings, booleans, and nulls as well as nested objects are now fully decoded. Compound types like Array, Tuple, Map, DateTime, Date, Decimal, and UUID are not yet decoded and will be returned as raw bytes. Fixes [#599](https://github.com/ClickHouse/clickhouse-connect/issues/599), [#615](https://github.com/ClickHouse/clickhouse-connect/issues/615), and [#674](https://github.com/ClickHouse/clickhouse-connect/issues/674)
+- SQLAlchemy: Fixed empty ORM/DBAPI SELECT results so `cursor.description` is still populated when ClickHouse Native format returns no data blocks. This restores correct handling for empty result sets, including parameterized and limited queries. Closes [#675](https://github.com/ClickHouse/clickhouse-connect/issues/675)
 
 ## 0.14.0, 2026-03-09
 

--- a/clickhouse_connect/dbapi/cursor.py
+++ b/clickhouse_connect/dbapi/cursor.py
@@ -97,7 +97,7 @@ class Cursor:
         if 'VALUES' not in temp.upper():
             return False
         col_names = list(data[0].keys())
-        if op_columns and {unescape_identifier(str(x)) for x in op_columns} != set(col_names):
+        if op_columns and {unescape_identifier(x) for x in op_columns} != set(col_names):
             return False  # Data sent in doesn't match the columns in the insert statement
         data_values = [list(row.values()) for row in data]
         self.client.insert(table, data_values, col_names)

--- a/clickhouse_connect/dbapi/cursor.py
+++ b/clickhouse_connect/dbapi/cursor.py
@@ -74,6 +74,13 @@ class Cursor:
         elif self.data:
             self.names = [f'col_{x}' for x in range(len(self.data[0]))]
             self.types = [x.__class__ for x in self.data[0]]
+        else:
+            stripped = operation.strip().rstrip(";").strip()
+            if stripped.upper().startswith(("SELECT", "WITH")):
+                meta_result = self.client.query(f"SELECT * FROM ({stripped}) LIMIT 0", parameters)
+                if meta_result.column_names:
+                    self.names = meta_result.column_names
+                    self.types = [x.name for x in meta_result.column_types]
 
     def _try_bulk_insert(self, operation: str, data):
         match = insert_re.match(remove_sql_comments(operation))
@@ -90,7 +97,7 @@ class Cursor:
         if 'VALUES' not in temp.upper():
             return False
         col_names = list(data[0].keys())
-        if op_columns and {unescape_identifier(x) for x in op_columns} != set(col_names):
+        if op_columns and {unescape_identifier(str(x)) for x in op_columns} != set(col_names):
             return False  # Data sent in doesn't match the columns in the insert statement
         data_values = [list(row.values()) for row in data]
         self.client.insert(table, data_values, col_names)
@@ -122,12 +129,14 @@ class Cursor:
 
     def fetchall(self):
         self.check_valid()
+        assert self.data is not None
         ret = self.data[self._ix:]
         self._ix = self._rowcount
         return ret
 
     def fetchone(self):
         self.check_valid()
+        assert self.data is not None
         if self._ix >= self._rowcount:
             return None
         val = self.data[self._ix]
@@ -136,6 +145,7 @@ class Cursor:
 
     def fetchmany(self, size: int = -1):
         self.check_valid()
+        assert self.data is not None
 
         if size < 0:
             # Fetch all remaining rows

--- a/clickhouse_connect/dbapi/cursor.py
+++ b/clickhouse_connect/dbapi/cursor.py
@@ -129,14 +129,12 @@ class Cursor:
 
     def fetchall(self):
         self.check_valid()
-        assert self.data is not None
         ret = self.data[self._ix:]
         self._ix = self._rowcount
         return ret
 
     def fetchone(self):
         self.check_valid()
-        assert self.data is not None
         if self._ix >= self._rowcount:
             return None
         val = self.data[self._ix]
@@ -145,7 +143,6 @@ class Cursor:
 
     def fetchmany(self, size: int = -1):
         self.check_valid()
-        assert self.data is not None
 
         if size < 0:
             # Fetch all remaining rows

--- a/tests/unit_tests/test_driver/test_cursor.py
+++ b/tests/unit_tests/test_driver/test_cursor.py
@@ -1,3 +1,4 @@
+from types import SimpleNamespace
 from unittest.mock import Mock
 import pytest
 
@@ -16,6 +17,16 @@ def create_mock_client(result_data):
     query_result.summary = {"rows": len(result_data)}
     client.query.return_value = query_result
     return client
+
+
+def create_mock_query_result(result_data, column_names=None, column_types=None):
+    """Create a mock query result with optional metadata."""
+    query_result = Mock()
+    query_result.result_set = result_data
+    query_result.column_names = column_names or []
+    query_result.column_types = column_types or []
+    query_result.summary = {"rows": len(result_data)}
+    return query_result
 
 
 def test_fetchall_respects_cursor_position():
@@ -267,3 +278,50 @@ def test_execute_unescapes_multiple_percents():
 
     actual_query = client.query.call_args[0][0]
     assert actual_query == "SELECT formatDateTime(now(), '%Y-%m-%d %H:%M:%S')"
+
+
+def test_execute_empty_result_fetches_metadata_with_parameters():
+    """Empty SELECT results should still populate description metadata."""
+    client = Mock()
+    client.query.side_effect = [
+        create_mock_query_result([]),
+        create_mock_query_result(
+            [],
+            column_names=["value_1"],
+            column_types=[SimpleNamespace(name="UInt64")],
+        ),
+    ]
+    cursor = Cursor(client)
+
+    cursor.execute(
+        "SELECT value_1 FROM test_table WHERE value_1 = %(value_1)s LIMIT %(param_1)s",
+        {"value_1": 13, "param_1": 1},
+    )
+
+    assert cursor.description == [("value_1", "UInt64", None, None, None, None, True)]
+    assert client.query.call_args_list[1].args == (
+        "SELECT * FROM (SELECT value_1 FROM test_table WHERE value_1 = %(value_1)s LIMIT %(param_1)s) LIMIT 0",
+        {"value_1": 13, "param_1": 1},
+    )
+
+
+def test_execute_empty_with_query_fetches_metadata():
+    """CTE queries should use the same metadata fallback."""
+    client = Mock()
+    client.query.side_effect = [
+        create_mock_query_result([]),
+        create_mock_query_result(
+            [],
+            column_names=["value_1"],
+            column_types=[SimpleNamespace(name="UInt64")],
+        ),
+    ]
+    cursor = Cursor(client)
+
+    cursor.execute("WITH value_1 AS 13 SELECT value_1 WHERE value_1 = 79")
+
+    assert cursor.description == [("value_1", "UInt64", None, None, None, None, True)]
+    assert client.query.call_args_list[1].args == (
+        "SELECT * FROM (WITH value_1 AS 13 SELECT value_1 WHERE value_1 = 79) LIMIT 0",
+        None,
+    )

--- a/tests/unit_tests/test_sqlalchemy/test_percent_encoding.py
+++ b/tests/unit_tests/test_sqlalchemy/test_percent_encoding.py
@@ -28,8 +28,8 @@ def _make_cursor():
     client = Mock()
     query_result = Mock()
     query_result.result_set = []
-    query_result.column_names = []
-    query_result.column_types = []
+    query_result.column_names = ["formatted"]
+    query_result.column_types = [Mock(name="String")]
     query_result.summary = {}
     client.query.return_value = query_result
     return Cursor(client), client


### PR DESCRIPTION
## Summary
- Fix `cursor.description` for empty `SELECT` results when ClickHouse Native format returns no data blocks
- Add a metadata fallback query in the DBAPI cursor so SQLAlchemy can still build its column keymap for empty result sets.

Closes #675

## Checklist
Delete items not relevant to your PR:
- [X] Unit and integration tests covering the common scenarios were added
- [X] A human-readable description of the changes was provided to include in CHANGELOG