### PR TITLE
fix: handle TabSeparated response for DDL ON CLUSTER with comments

### DIFF
--- a/clickhouse_connect/driver/transform.py
+++ b/clickhouse_connect/driver/transform.py
@@ -39,6 +39,8 @@ class NativeTransform:
                         if exception_tag:
                             error_msg = extract_exception_with_tag(source.last_message, exception_tag)
                         if error_msg:
+                            if "Code: " not in error_msg and b"\t" in (source.last_message or b""):
+                                return None
                             raise StreamFailureError(error_msg) from None
                     return None
                 num_rows = source.read_leb128()
@@ -70,7 +72,10 @@ class NativeTransform:
                             error_msg = extract_exception_with_tag(source.last_message, exception_tag)
                         if not error_msg:
                             error_msg = extract_error_message(source.last_message)
-                        raise StreamFailureError(error_msg) from None
+                        if error_msg:
+                            if "Code: " not in error_msg and b"\t" in (source.last_message or b""):
+                                return None
+                            raise StreamFailureError(error_msg) from None
                 raise
             block_num += 1
             return result_block


### PR DESCRIPTION
## Summary
Fixes #499.
**Root cause:** DDL ON CLUSTER queries with leading SQL comments cause the server to return TabSeparated format instead of the requested Native format. The Native parser cannot parse TabSeparated data and raises `StreamFailureError`, even though the DDL was executed successfully.
**Fix:** In the error handling path, when the response doesn't contain a ClickHouse error marker (`Code: `) and looks like tabular data (contains tab characters), treat it as a successful empty result instead of raising `StreamFailureError`.
## Changes
- `clickhouse_connect/driver/transform.py`: Added check for non-error TabSeparated responses in `get_block` error handler
## Testing
- Verified fix addresses reported scenario (DDL ON CLUSTER with leading comments no longer raises StreamFailureError)
- Change is minimal and follows existing code patterns

Made with [Cursor](https://cursor.com)