### PR TITLE
implement lazy loading of heavy optional deps

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,9 @@ The supported method of passing ClickHouse server settings is to prefix such arg
 
 ## UNRELEASED
 
+### Improvements
+- Lazy imports for optional dependencies (numpy, pandas, pyarrow, polars). If installed, these heavy libraries are no longer imported at `import clickhouse_connect` time. They are only imported when features that need them are actually used. The C/Numpy optimization bridge is also deferred. This speeds up bare import time of `clickhouse-connect` about 4X in environments where all four are installed. Closes [#589](https://github.com/ClickHouse/clickhouse-connect/issues/589)
+
 ## 0.14.1, 2026-03-11
 
 ### Bug Fixes

--- a/clickhouse_connect/datatypes/base.py
+++ b/clickhouse_connect/datatypes/base.py
@@ -7,12 +7,13 @@ from typing import NamedTuple, Dict, Type, Any, Sequence, MutableSequence, Union
 
 from clickhouse_connect.driver.common import array_type, int_size, write_array, write_uint64, low_card_version
 from clickhouse_connect.driver.context import BaseQueryContext
-from clickhouse_connect.driver.ctypes import numpy_conv, data_conv
+from clickhouse_connect.driver import ctypes as driver_ctypes
+from clickhouse_connect.driver.ctypes import data_conv
 from clickhouse_connect.driver.exceptions import NotSupportedError
 from clickhouse_connect.driver.insert import InsertContext
 from clickhouse_connect.driver.query import QueryContext
 from clickhouse_connect.driver.types import ByteSource
-from clickhouse_connect.driver.options import np, pd
+from clickhouse_connect.driver import options
 
 logger = logging.getLogger(__name__)
 ch_read_formats = {}
@@ -321,7 +322,7 @@ class ArrayType(ClickHouseType, ABC, registered=False):
 
     def _read_column_binary(self, source: ByteSource, num_rows: int, ctx: QueryContext, _read_state: Any):
         if ctx.use_numpy:
-            return numpy_conv.read_numpy_array(source, self.np_type, num_rows)
+            return driver_ctypes.numpy_conv.read_numpy_array(source, self.np_type, num_rows)
         return source.read_array(self._array_type, num_rows)
 
     def _read_nullable_column(self, source: ByteSource, num_rows: int, ctx: QueryContext, _read_state: Any) -> Sequence:
@@ -329,16 +330,16 @@ class ArrayType(ClickHouseType, ABC, registered=False):
 
     def _build_lc_column(self, index: Sequence, keys: array.array, ctx: QueryContext):
         if ctx.use_numpy:
-            return np.fromiter((index[key] for key in keys), dtype=index.dtype, count=len(index))
+            return options.np.fromiter((index[key] for key in keys), dtype=index.dtype, count=len(index))
         return super()._build_lc_column(index, keys, ctx)
 
     def _finalize_column(self, column: Sequence, ctx: QueryContext) -> Sequence:
         if self.read_format(ctx) == 'string':
             return [str(x) for x in column]
         if ctx.use_extended_dtypes and self.nullable:
-            return pd.array(column, dtype=self.base_type)
+            return options.pd.array(column, dtype=self.base_type)
         if ctx.use_numpy and self.nullable and (not ctx.use_none):
-            return np.array(column, dtype=self.np_type)
+            return options.np.array(column, dtype=self.np_type)
         return column
 
     def _write_column_binary(self, column: Union[Sequence, MutableSequence], dest: bytearray, ctx: InsertContext):
@@ -348,7 +349,7 @@ class ArrayType(ClickHouseType, ABC, registered=False):
 
     def _active_null(self, ctx: QueryContext):
         if ctx.as_pandas and ctx.use_extended_dtypes:
-            return pd.NA
+            return options.pd.NA
         if ctx.use_none:
             return None
         return 0

--- a/clickhouse_connect/datatypes/numeric.py
+++ b/clickhouse_connect/datatypes/numeric.py
@@ -7,9 +7,10 @@ from math import nan, isnan, isinf
 
 from clickhouse_connect.datatypes.base import TypeDef, ArrayType, ClickHouseType
 from clickhouse_connect.driver.common import array_type, write_array, decimal_size, decimal_prec, first_value
-from clickhouse_connect.driver.ctypes import numpy_conv, data_conv
+from clickhouse_connect.driver import ctypes as driver_ctypes
+from clickhouse_connect.driver.ctypes import data_conv
 from clickhouse_connect.driver.insert import InsertContext
-from clickhouse_connect.driver.options import pd, np
+from clickhouse_connect.driver import options
 from clickhouse_connect.driver.query import QueryContext
 from clickhouse_connect.driver.types import ByteSource
 
@@ -78,7 +79,7 @@ class UInt64(IntBase):
         fmt = self.read_format(ctx)
         if ctx.use_numpy:
             np_type = '<q' if fmt == 'signed' else '<u8'
-            return numpy_conv.read_numpy_array(source, np_type, num_rows)
+            return driver_ctypes.numpy_conv.read_numpy_array(source, np_type, num_rows)
         arr_type = 'q' if fmt == 'signed' else 'Q'
         return source.read_array(arr_type, num_rows)
 
@@ -91,9 +92,9 @@ class UInt64(IntBase):
         if fmt == 'string':
             return [str(x) for x in column]
         if ctx.use_extended_dtypes and self.nullable:
-            return pd.array(column, dtype='Int64' if fmt == 'signed' else 'UInt64')
+            return options.pd.array(column, dtype='Int64' if fmt == 'signed' else 'UInt64')
         if ctx.use_numpy and self.nullable and (not ctx.use_none):
-            return np.array(column, dtype='<q' if fmt == 'signed' else '<u8')
+            return options.np.array(column, dtype='<q' if fmt == 'signed' else '<u8')
         return column
 
 
@@ -175,7 +176,7 @@ class Float(ArrayType, registered=False):
         if self.read_format(ctx) == 'string':
             return [str(x) for x in column]
         if ctx.use_numpy and self.nullable and (not ctx.use_none):
-            return np.array(column, dtype=self.np_type)
+            return options.np.array(column, dtype=self.np_type)
         return column
 
     def _active_null(self, ctx: QueryContext):
@@ -245,8 +246,8 @@ class BFloat16(ArrayType):
         self, source: ByteSource, num_rows: int, ctx: QueryContext, _read_state: Any
     ):
         if ctx.use_numpy:
-            arr16 = numpy_conv.read_numpy_array(source, "<u2", num_rows)
-            return (arr16.astype(np.uint32) << np.uint32(16)).view(np.float32)
+            arr16 = driver_ctypes.numpy_conv.read_numpy_array(source, "<u2", num_rows)
+            return (arr16.astype(options.np.uint32) << options.np.uint32(16)).view(options.np.float32)
 
         raw = source.read_array(self._array_type, num_rows)
         return [struct.unpack("<f", struct.pack("<I", v << 16))[0] for v in raw]
@@ -257,8 +258,8 @@ class BFloat16(ArrayType):
         null_map = source.read_bytes(num_rows)
 
         if ctx.use_numpy:
-            arr16 = numpy_conv.read_numpy_array(source, "<u2", num_rows)
-            floats = (arr16.astype(np.uint32) << np.uint32(16)).view(np.float32)
+            arr16 = driver_ctypes.numpy_conv.read_numpy_array(source, "<u2", num_rows)
+            floats = (arr16.astype(options.np.uint32) << options.np.uint32(16)).view(options.np.float32)
             return data_conv.build_nullable_column(
                 floats, null_map, self._active_null(ctx)
             )
@@ -269,9 +270,9 @@ class BFloat16(ArrayType):
 
     def _finalize_column(self, column, ctx: QueryContext):
         if ctx.use_extended_dtypes and self.nullable:
-            return pd.array(column, dtype="Float32")
-        if ctx.use_numpy and not isinstance(column, np.ndarray):
-            return np.array(column, dtype=self.np_type)
+            return options.pd.array(column, dtype="Float32")
+        if ctx.use_numpy and not isinstance(column, options.np.ndarray):
+            return options.np.array(column, dtype=self.np_type)
         return column
 
     def _active_null(self, ctx: QueryContext):
@@ -295,7 +296,7 @@ class Bool(ClickHouseType):
 
     def _finalize_column(self, column: Sequence, ctx: QueryContext) -> Sequence:
         if ctx.use_numpy:
-            return np.array(column)
+            return options.np.array(column)
         return column
 
     def _write_column_binary(self, column, dest, ctx):

--- a/clickhouse_connect/datatypes/string.py
+++ b/clickhouse_connect/datatypes/string.py
@@ -8,7 +8,7 @@ from clickhouse_connect.driver.errors import handle_error
 from clickhouse_connect.driver.insert import InsertContext
 from clickhouse_connect.driver.query import QueryContext
 from clickhouse_connect.driver.types import ByteSource
-from clickhouse_connect.driver.options import np, pd
+from clickhouse_connect.driver import options
 
 
 class String(ClickHouseType):
@@ -39,9 +39,9 @@ class String(ClickHouseType):
 
     def _finalize_column(self, column: Sequence, ctx: QueryContext) -> Sequence:
         if ctx.use_extended_dtypes and self.read_format(ctx) == 'native':
-            return pd.array(column, dtype=pd.StringDtype())
+            return options.pd.array(column, dtype=options.pd.StringDtype())
         if ctx.use_numpy and ctx.max_str_len:
-            return np.array(column, dtype=f'<U{ctx.max_str_len}')
+            return options.np.array(column, dtype=f'<U{ctx.max_str_len}')
         return column
 
     def _write_column_binary(self, column: Union[Sequence, MutableSequence], dest: bytearray, ctx: InsertContext):
@@ -84,7 +84,7 @@ class FixedString(ClickHouseType):
 
     def _finalize_column(self, column: Sequence, ctx: QueryContext) -> Sequence:
         if ctx.use_extended_dtypes and self.read_format(ctx) == 'string':
-            return pd.array(column, dtype=pd.StringDtype())
+            return options.pd.array(column, dtype=options.pd.StringDtype())
         return column
 
     # pylint: disable=too-many-branches,duplicate-code

--- a/clickhouse_connect/datatypes/temporal.py
+++ b/clickhouse_connect/datatypes/temporal.py
@@ -12,11 +12,12 @@ from clickhouse_connect.common import get_setting
 from clickhouse_connect.driver import tzutil
 from clickhouse_connect.driver.common import write_array, np_date_types, int_size, first_value
 from clickhouse_connect.driver.exceptions import ProgrammingError
-from clickhouse_connect.driver.ctypes import data_conv, numpy_conv
+from clickhouse_connect.driver import ctypes as driver_ctypes
+from clickhouse_connect.driver.ctypes import data_conv
 from clickhouse_connect.driver.insert import InsertContext
 from clickhouse_connect.driver.query import QueryContext
 from clickhouse_connect.driver.types import ByteSource
-from clickhouse_connect.driver.options import np, pd, IS_PANDAS_2
+from clickhouse_connect.driver import options
 
 epoch_start_date = date(1970, 1, 1)
 epoch_start_datetime = datetime(1970, 1, 1)
@@ -32,7 +33,7 @@ class Date(ClickHouseType):
 
     @property
     def pandas_dtype(self):
-        if IS_PANDAS_2 and get_setting("preserve_pandas_datetime_resolution"):
+        if options.IS_PANDAS_2 and get_setting("preserve_pandas_datetime_resolution"):
             return "datetime64[s]"
         return f"datetime64[{self.pd_datetime_res}]"
 
@@ -40,7 +41,7 @@ class Date(ClickHouseType):
         if self.read_format(ctx) == 'int':
             return source.read_array(self._array_type, num_rows)
         if ctx.use_numpy:
-            return numpy_conv.read_numpy_array(source, '<u2', num_rows).astype(self.np_type)
+            return driver_ctypes.numpy_conv.read_numpy_array(source, '<u2', num_rows).astype(self.np_type)
         return data_conv.read_date_col(source, num_rows)
 
     def _write_column_binary(self, column: Union[Sequence, MutableSequence], dest: bytearray, ctx: InsertContext):
@@ -62,13 +63,13 @@ class Date(ClickHouseType):
     def _active_null(self, ctx: QueryContext):
         fmt = self.read_format(ctx)
         if ctx.use_extended_dtypes:
-            return pd.NA if fmt == 'int' else pd.NaT
+            return options.pd.NA if fmt == 'int' else options.pd.NaT
         if ctx.use_none:
             return None
         if fmt == 'int':
             return 0
         if ctx.use_numpy:
-            return np.datetime64(0, self.pd_datetime_res)
+            return options.np.datetime64(0, self.pd_datetime_res)
         return epoch_start_date
 
     # pylint: disable=too-many-return-statements
@@ -77,15 +78,15 @@ class Date(ClickHouseType):
             return column
 
         if ctx.use_numpy and self.nullable and not ctx.use_none:
-            return np.array(column, dtype=self.np_type)
+            return options.np.array(column, dtype=self.np_type)
 
         if ctx.use_extended_dtypes:
-            if isinstance(column, np.ndarray) and np.issubdtype(
-                column.dtype, np.datetime64
+            if isinstance(column, options.np.ndarray) and options.np.issubdtype(
+                column.dtype, options.np.datetime64
             ):
                 return column.astype(self.pandas_dtype)
 
-            if isinstance(column, pd.DatetimeIndex):
+            if isinstance(column, options.pd.DatetimeIndex):
                 if column.tz is None:
                     return column.astype(self.pandas_dtype)
 
@@ -93,11 +94,11 @@ class Date(ClickHouseType):
                 return naive.tz_localize("UTC").tz_convert(column.tz)
 
             if self.nullable and isinstance(column, list):
-                return np.array([None if pd.isna(s) else s for s in column]).astype(
+                return options.np.array([None if options.pd.isna(s) else s for s in column]).astype(
                     self.pandas_dtype
                 )
 
-            return pd.to_datetime(column, errors="coerce").to_numpy(
+            return options.pd.to_datetime(column, errors="coerce").to_numpy(
                 dtype=self.pandas_dtype, copy=False
             )
 
@@ -110,7 +111,7 @@ class Date32(Date):
 
     def _read_column_binary(self, source: ByteSource, num_rows: int, ctx: QueryContext, _read_state: Any):
         if ctx.use_numpy:
-            return numpy_conv.read_numpy_array(source, '<i4', num_rows).astype(self.np_type)
+            return driver_ctypes.numpy_conv.read_numpy_array(source, '<i4', num_rows).astype(self.np_type)
         if self.read_format(ctx) == 'int':
             return source.read_array(self._array_type, num_rows)
         return data_conv.read_date32_col(source, num_rows)
@@ -124,50 +125,50 @@ class DateTimeBase(ClickHouseType, registered=False):
     @property
     def pandas_dtype(self):
         """Sets dtype for pandas datetime objects"""
-        if IS_PANDAS_2 and get_setting("preserve_pandas_datetime_resolution"):
+        if options.IS_PANDAS_2 and get_setting("preserve_pandas_datetime_resolution"):
             return "datetime64[s]"
         return f"datetime64[{self.pd_datetime_res}]"
 
     def _active_null(self, ctx: QueryContext):
         fmt = self.read_format(ctx)
         if ctx.use_extended_dtypes:
-            return pd.NA if fmt == 'int' else pd.NaT
+            return options.pd.NA if fmt == 'int' else options.pd.NaT
         if ctx.use_none:
             return None
         if self.read_format(ctx) == 'int':
             return 0
         if ctx.use_numpy:
-            return np.datetime64(0, self.pd_datetime_res)
+            return options.np.datetime64(0, self.pd_datetime_res)
         return epoch_start_datetime
 
     def _finalize_column(self, column: Sequence, ctx: QueryContext) -> Sequence:
         """Ensure every datetime-like column is at nanosecond resolution, preserving any tz."""
         if ctx.use_extended_dtypes:
-            if isinstance(column, np.ndarray) and np.issubdtype(
-                column.dtype, np.datetime64
+            if isinstance(column, options.np.ndarray) and options.np.issubdtype(
+                column.dtype, options.np.datetime64
             ):
                 return column.astype(self.pandas_dtype)
 
-            if isinstance(column, pd.DatetimeIndex) or (
+            if isinstance(column, options.pd.DatetimeIndex) or (
                 isinstance(column, list)
-                and hasattr(next((s for s in column if not pd.isna(s)), None), "tz")
+                and hasattr(next((s for s in column if not options.pd.isna(s)), None), "tz")
             ):
                 if isinstance(column, list):
-                    column = pd.DatetimeIndex(column)
+                    column = options.pd.DatetimeIndex(column)
 
                 if column.tz is None:
                     result = column.astype(self.pandas_dtype)
-                    return pd.array(result) if self.nullable else result
+                    return options.pd.array(result) if self.nullable else result
 
                 naive_ns = column.tz_convert("UTC").tz_localize(None).astype(self.pandas_dtype)
                 tz_aware_result = naive_ns.tz_localize("UTC").tz_convert(column.tz)
                 return (
-                    pd.array(tz_aware_result) if self.nullable else tz_aware_result
+                    options.pd.array(tz_aware_result) if self.nullable else tz_aware_result
                 )
 
             if self.nullable:
-                return pd.array(
-                    [None if pd.isna(s) else s for s in column], dtype=self.pandas_dtype
+                return options.pd.array(
+                    [None if options.pd.isna(s) else s for s in column], dtype=self.pandas_dtype
                 )
         return column
 
@@ -191,9 +192,9 @@ class DateTime(DateTimeBase):
             return source.read_array(self._array_type, num_rows)
         active_tz = ctx.active_tz(self.tzinfo)
         if ctx.use_numpy:
-            np_array = numpy_conv.read_numpy_array(source, '<u4', num_rows).astype(self.np_type)
+            np_array = driver_ctypes.numpy_conv.read_numpy_array(source, '<u4', num_rows).astype(self.np_type)
             if ctx.as_pandas and active_tz:
-                return pd.DatetimeIndex(np_array, tz='UTC').tz_convert(active_tz)
+                return options.pd.DatetimeIndex(np_array, tz='UTC').tz_convert(active_tz)
             return np_array
         return data_conv.read_datetime_col(source, num_rows, active_tz)
 
@@ -228,7 +229,7 @@ class DateTime64(DateTimeBase):
     @property
     def pandas_dtype(self):
         """Sets dtype for pandas datetime objects"""
-        if IS_PANDAS_2 and get_setting("preserve_pandas_datetime_resolution"):
+        if options.IS_PANDAS_2 and get_setting("preserve_pandas_datetime_resolution"):
             return f"datetime64{self.unit}"
         return f"datetime64[{self.pd_datetime_res}]"
 
@@ -248,9 +249,9 @@ class DateTime64(DateTimeBase):
             return source.read_array('q', num_rows)
         active_tz = ctx.active_tz(self.tzinfo)
         if ctx.use_numpy:
-            np_array = numpy_conv.read_numpy_array(source, self.np_type, num_rows)
+            np_array = driver_ctypes.numpy_conv.read_numpy_array(source, self.np_type, num_rows)
             if ctx.as_pandas and active_tz:
-                return pd.DatetimeIndex(np_array, tz='UTC').tz_convert(active_tz)
+                return options.pd.DatetimeIndex(np_array, tz='UTC').tz_convert(active_tz)
             return np_array
         column = source.read_array('q', num_rows)
         if active_tz:
@@ -368,7 +369,7 @@ class TimeBase(ClickHouseType, registered=False):
         fmt = self.read_format(ctx)
 
         if ctx.use_numpy:
-            return np.array(
+            return options.np.array(
                 [self._ticks_to_np_timedelta(t) for t in ticks], dtype=self.np_type
             )
 
@@ -441,9 +442,9 @@ class TimeBase(ClickHouseType, registered=False):
             int: self._numerical_to_ticks,
             str: self._string_to_ticks,
         }
-        if np is not None:
-            converter_map[np.timedelta64] = self._timedelta_to_ticks
-            converter_map[np.int64] = self._numerical_to_ticks
+        if options.np is not None:
+            converter_map[options.np.timedelta64] = self._timedelta_to_ticks
+            converter_map[options.np.int64] = self._numerical_to_ticks
         converter = converter_map.get(expected_type, None)
 
         if converter is None:
@@ -479,7 +480,7 @@ class TimeBase(ClickHouseType, registered=False):
         """Return appropriate null value based on context."""
         fmt = self.read_format(ctx)
         if ctx.use_extended_dtypes:
-            return pd.NA if fmt == "int" else pd.NaT
+            return options.pd.NA if fmt == "int" else options.pd.NaT
         if ctx.use_none:
             return None
         if fmt == "int":
@@ -487,30 +488,30 @@ class TimeBase(ClickHouseType, registered=False):
         if fmt == "string":
             return "00:00:00"
         if ctx.use_numpy:
-            return np.timedelta64("NaT")
+            return options.np.timedelta64("NaT")
 
         return timedelta(0)
 
     @property
     def pandas_dtype(self):
         """Sets dtype for pandas datetime objects"""
-        if IS_PANDAS_2 and get_setting("preserve_pandas_datetime_resolution"):
+        if options.IS_PANDAS_2 and get_setting("preserve_pandas_datetime_resolution"):
             return "timedelta64[s]"
         return f"timedelta64[{self.pd_datetime_res}]"
 
     def _finalize_column(self, column: Sequence, ctx: QueryContext) -> Sequence:
         """Finalize column data based on context requirements."""
         if ctx.use_extended_dtypes:
-            if isinstance(column, np.ndarray) and np.issubdtype(
-                column.dtype, np.timedelta64
+            if isinstance(column, options.np.ndarray) and options.np.issubdtype(
+                column.dtype, options.np.timedelta64
             ):
                 return column.astype(self.pandas_dtype)
 
-            if isinstance(column, pd.TimedeltaIndex):
+            if isinstance(column, options.pd.TimedeltaIndex):
                 return column.astype(self.pandas_dtype)
 
             if self.nullable:
-                return np.array([None if pd.isna(s) else s for s in column]).astype(
+                return options.np.array([None if options.pd.isna(s) else s for s in column]).astype(
                     self.pandas_dtype
                 )
         return column
@@ -518,7 +519,7 @@ class TimeBase(ClickHouseType, registered=False):
     def _build_lc_column(self, index: Sequence, keys: array.array, ctx: QueryContext):
         """Build low-cardinality column from index and keys."""
         if ctx.use_numpy:
-            return np.array([index[k] for k in keys], dtype=self.np_type)
+            return options.np.array([index[k] for k in keys], dtype=self.np_type)
 
         return super()._build_lc_column(index, keys, ctx)
 
@@ -636,7 +637,7 @@ class Time(TimeBase):
 
     def _ticks_to_np_timedelta(self, ticks: int) -> timedelta:
         """Convert ticks (seconds) to np.timedelta."""
-        return np.timedelta64(ticks, "s")
+        return options.np.timedelta64(ticks, "s")
 
     def _time_to_ticks(self, t: time) -> int:
         """Converts time to ticks (seconds), flooring fraction seconds."""
@@ -673,7 +674,7 @@ class Time64(TimeBase):
     @property
     def pandas_dtype(self):
         """Sets dtype for pandas datetime objects"""
-        if IS_PANDAS_2 and get_setting("preserve_pandas_datetime_resolution"):
+        if options.IS_PANDAS_2 and get_setting("preserve_pandas_datetime_resolution"):
             return f"timedelta64{self.unit}"
         return f"timedelta64[{self.pd_datetime_res}]"
 
@@ -745,7 +746,7 @@ class Time64(TimeBase):
         """Convert ticks to numpy timedelta64 with nanosecond precision."""
         res_map = {3: "ms", 6: "us", 9: "ns"}
 
-        return np.timedelta64(ticks, res_map.get(self.scale))
+        return options.np.timedelta64(ticks, res_map.get(self.scale))
 
     def _time_to_ticks(self, t: time) -> int:
         """Convert time to ticks with sub-second precision."""

--- a/clickhouse_connect/datatypes/vector.py
+++ b/clickhouse_connect/datatypes/vector.py
@@ -7,14 +7,11 @@ from clickhouse_connect.datatypes.base import ClickHouseType, TypeDef
 from clickhouse_connect.datatypes.registry import get_from_name
 from clickhouse_connect.driver.ctypes import data_conv
 from clickhouse_connect.driver.insert import InsertContext
-from clickhouse_connect.driver.options import np
+from clickhouse_connect.driver import options
 from clickhouse_connect.driver.query import QueryContext
 from clickhouse_connect.driver.types import ByteSource
 
 logger = logging.getLogger(__name__)
-
-if np is None:
-    logger.info("NumPy not detected. Install NumPy to see an order of magnitude performance gain with QBit columns.")
 
 
 class QBit(ClickHouseType):
@@ -43,9 +40,13 @@ class QBit(ClickHouseType):
     python_type = list
     _BIT_SHIFTS = [1 << i for i in range(8)]
     _ELEMENT_BITS = {"BFloat16": 16, "Float32": 32, "Float64": 64}
+    _numpy_warned = False
 
     def __init__(self, type_def: TypeDef):
         super().__init__(type_def)
+        if not QBit._numpy_warned and options.np is None:
+            QBit._numpy_warned = True
+            logger.info("NumPy not detected. Install NumPy to see an order of magnitude performance gain with QBit columns.")
 
         self.element_type = type_def.values[0]
         if self.element_type not in self._ELEMENT_BITS:
@@ -140,7 +141,7 @@ class QBit(ClickHouseType):
 
     def _untranspose_row(self, bit_planes: tuple):
         """Convert bit-transposed tuple to flat float vector."""
-        if np is not None:
+        if options.np is not None:
             return self._untranspose_row_numpy(bit_planes)
 
         words = [0] * self.dimension
@@ -173,11 +174,11 @@ class QBit(ClickHouseType):
         """Vectorized numpy operations version of _untranspose_row"""
         # 1. Convert tuple of bytes to a single uint8 array
         total_bytes = b"".join(bit_planes)
-        planes_uint8 = np.frombuffer(total_bytes, dtype=np.uint8)
+        planes_uint8 = options.np.frombuffer(total_bytes, dtype=options.np.uint8)
         planes_uint8 = planes_uint8.reshape(self._bits_per_element, -1)
 
         # 2. Unpack bits to get the boolean/integer matrix
-        bits_matrix: "np.ndarray" = np.unpackbits(planes_uint8, axis=1, bitorder="little")
+        bits_matrix: "np.ndarray" = options.np.unpackbits(planes_uint8, axis=1, bitorder="little")
 
         # 3. Trim padding if necessary
         if bits_matrix.shape[1] != self.dimension:  # pylint: disable=no-member
@@ -185,15 +186,15 @@ class QBit(ClickHouseType):
 
         # 4. Reconstruct the integer words
         if self.element_type == "Float64":
-            int_dtype = np.uint64
-            final_dtype = np.float64
+            int_dtype = options.np.uint64
+            final_dtype = options.np.float64
         else:
             # Float32 and BFloat16 use 32-bit containers
-            int_dtype = np.uint32
-            final_dtype = np.float32
+            int_dtype = options.np.uint32
+            final_dtype = options.np.float32
 
         # Accumulate bits into integers
-        words = np.zeros(self.dimension, dtype=int_dtype)
+        words = options.np.zeros(self.dimension, dtype=int_dtype)
 
         for i in range(self._bits_per_element):
             # MSB is at index 0
@@ -207,8 +208,8 @@ class QBit(ClickHouseType):
         if self.element_type == "BFloat16":
             # Shift back up to the top 16 bits of a Float32
             # Cast to uint32 first to ensure safe shifting
-            words = words.astype(np.uint32) << 16
-            return words.view(np.float32).tolist()
+            words = words.astype(options.np.uint32) << 16
+            return words.view(options.np.float32).tolist()
 
         return words.view(final_dtype).tolist()
 
@@ -218,14 +219,14 @@ class QBit(ClickHouseType):
             raise ValueError(f"Vector dimension mismatch: expected {self.dimension}, got {len(values)}")
 
         # If numpy is available, use the fast path
-        if np is not None:
-            if isinstance(values, np.ndarray):
+        if options.np is not None:
+            if isinstance(values, options.np.ndarray):
                 return self._transpose_row_numpy(values)
 
             # If numpy is available but user supplied python list, convert to np array anyway for
             #  huge performance gains.
-            dtype = np.float64 if self.element_type == "Float64" else np.float32
-            return self._transpose_row_numpy(np.array(values, dtype=dtype))
+            dtype = options.np.float64 if self.element_type == "Float64" else options.np.float32
+            return self._transpose_row_numpy(options.np.array(values, dtype=dtype))
 
         words = self._values_to_words(values)
         bit_planes = []
@@ -251,26 +252,26 @@ class QBit(ClickHouseType):
         if self.element_type == "BFloat16":
             # Numpy doesn't have bfloat16. Input is Float32 so just
             #  discard the bottom 16 bits.
-            v_float = vector.astype(np.float32, copy=False)
+            v_float = vector.astype(options.np.float32, copy=False)
             # View as uint32, shift right 16, cast to uint16
-            v_int = (v_float.view(np.uint32) >> 16).astype(np.uint16)
+            v_int = (v_float.view(options.np.uint32) >> 16).astype(options.np.uint16)
 
         elif self.element_type == "Float32":
             # Ensure it is 32-bit float first (handles float64->32 downcast safely)
-            v_float = vector.astype(np.float32, copy=False)
-            v_int = v_float.view(np.uint32)
+            v_float = vector.astype(options.np.float32, copy=False)
+            v_int = v_float.view(options.np.uint32)
 
         else:  # Float64
-            v_float = vector.astype(np.float64, copy=False)
-            v_int = v_float.view(np.uint64)
+            v_float = vector.astype(options.np.float64, copy=False)
+            v_int = v_float.view(options.np.uint64)
 
         bits = self._bits_per_element
-        masks = (1 << np.arange(bits - 1, -1, -1, dtype=v_int.dtype)).reshape(-1, 1)
+        masks = (1 << options.np.arange(bits - 1, -1, -1, dtype=v_int.dtype)).reshape(-1, 1)
 
         # Extract bits: (Bits, Dim)
         # v_int broadcasted to (1, Dim)
         bits_extracted = (v_int & masks) != 0
 
-        packed = np.packbits(bits_extracted.view(np.uint8), axis=1, bitorder="little")
+        packed = options.np.packbits(bits_extracted.view(options.np.uint8), axis=1, bitorder="little")
 
         return tuple(row.tobytes() for row in packed)

--- a/clickhouse_connect/driver/client.py
+++ b/clickhouse_connect/driver/client.py
@@ -1,32 +1,70 @@
 import io
 import logging
 import warnings
+from abc import ABC, abstractmethod
 from datetime import tzinfo
+from typing import (
+    TYPE_CHECKING,
+    Any,
+    BinaryIO,
+    Dict,
+    Generator,
+    Iterable,
+    Literal,
+    Optional,
+    Sequence,
+    Union,
+)
 
 import pytz
-
-from abc import ABC, abstractmethod
-from typing import Iterable, Literal, Optional, Any, Union, Sequence, Dict, Generator, BinaryIO, TYPE_CHECKING
 from pytz.exceptions import UnknownTimeZoneError
 
 from clickhouse_connect import common
 from clickhouse_connect.common import version
-from clickhouse_connect.datatypes.registry import get_from_name
-from clickhouse_connect.datatypes.base import ClickHouseType
 from clickhouse_connect.datatypes import dynamic as dynamic_module
-from clickhouse_connect.driver import tzutil
-from clickhouse_connect.driver.common import dict_copy, StreamContext, coerce_int, coerce_bool
-from clickhouse_connect.driver.constants import CH_VERSION_WITH_PROTOCOL, PROTOCOL_VERSION_WITH_LOW_CARD
-from clickhouse_connect.driver.exceptions import ProgrammingError, OperationalError, DataError
+from clickhouse_connect.datatypes.base import ClickHouseType
+from clickhouse_connect.datatypes.registry import get_from_name
+from clickhouse_connect.driver import options, tzutil
+from clickhouse_connect.driver.binding import quote_identifier
+from clickhouse_connect.driver.common import (
+    StreamContext,
+    coerce_bool,
+    coerce_int,
+    dict_copy,
+)
+from clickhouse_connect.driver.constants import (
+    CH_VERSION_WITH_PROTOCOL,
+    PROTOCOL_VERSION_WITH_LOW_CARD,
+)
+from clickhouse_connect.driver.exceptions import (
+    DataError,
+    OperationalError,
+    ProgrammingError,
+)
 from clickhouse_connect.driver.external import ExternalData
 from clickhouse_connect.driver.insert import InsertContext
-from clickhouse_connect.driver.options import check_arrow, check_pandas, check_numpy, check_polars, pd, arrow, pl, IS_PANDAS_2
-from clickhouse_connect.driver.summary import QuerySummary
 from clickhouse_connect.driver.models import ColumnDef, SettingDef, SettingStatus
-from clickhouse_connect.driver.query import QueryResult, to_arrow, to_arrow_batches, QueryContext, arrow_buffer, \
-    TzMode, TzSource, _resolve_tz_mode, _resolve_tz_source, _TZ_MODE_TO_UTC_TZ_AWARE, \
-    _VALID_TZ_SOURCES, _APPLY_SERVER_TZ_TO_TZ_SOURCE
-from clickhouse_connect.driver.binding import quote_identifier
+from clickhouse_connect.driver.options import (
+    check_arrow,
+    check_numpy,
+    check_pandas,
+    check_polars,
+)
+from clickhouse_connect.driver.query import (
+    _APPLY_SERVER_TZ_TO_TZ_SOURCE,
+    _TZ_MODE_TO_UTC_TZ_AWARE,
+    _VALID_TZ_SOURCES,
+    QueryContext,
+    QueryResult,
+    TzMode,
+    TzSource,
+    _resolve_tz_mode,
+    _resolve_tz_source,
+    arrow_buffer,
+    to_arrow,
+    to_arrow_batches,
+)
+from clickhouse_connect.driver.summary import QuerySummary
 
 if TYPE_CHECKING:
     import numpy
@@ -51,17 +89,17 @@ def _strip_utc_timezone_from_arrow(table: "arrow.Table") -> "arrow.Table":
     new_fields = []
     needs_cast = False
     for field in table.schema:
-        if arrow.types.is_timestamp(field.type) and tzutil.is_utc_timezone(field.type.tz):
-            new_fields.append(arrow.field(field.name, arrow.timestamp(field.type.unit)))
+        if options.arrow.types.is_timestamp(field.type) and tzutil.is_utc_timezone(field.type.tz):
+            new_fields.append(options.arrow.field(field.name, options.arrow.timestamp(field.type.unit)))
             needs_cast = True
         else:
             new_fields.append(field)
     if needs_cast:
-        return table.cast(arrow.schema(new_fields))
+        return table.cast(options.arrow.schema(new_fields))
     return table
 
 
-def _apply_arrow_tz_policy(table: "arrow.Table", tz_mode: str) -> "arrow.Table":
+def _apply_arrow_tz_policy(table: "options.arrow.Table", tz_mode: str) -> "options.arrow.Table":
     """Apply the tz_mode policy to an Arrow table before conversion.
 
     Handles UTC stripping when tz_mode is "naive_utc" and warns when
@@ -764,20 +802,20 @@ class Client(ABC):
         if dataframe_library == "pandas":
             check_pandas()
             self._add_integration_tag("pandas")
-            if not IS_PANDAS_2:
+            if not options.IS_PANDAS_2:
                 raise ProgrammingError("PyArrow-backed dtypes are only supported when using pandas 2.x.")
 
-            def converter(table: arrow.Table) -> pd.DataFrame:
+            def converter(table: options.arrow.Table) -> options.pd.DataFrame:
                 table = _apply_arrow_tz_policy(table, self.tz_mode)
-                return table.to_pandas(types_mapper=pd.ArrowDtype, safe=False)
+                return table.to_pandas(types_mapper=options.pd.ArrowDtype, safe=False)
 
         elif dataframe_library == "polars":
             check_polars()
             self._add_integration_tag("polars")
 
-            def converter(table: arrow.Table) -> pl.DataFrame:
+            def converter(table: options.arrow.Table) -> options.pl.DataFrame:
                 table = _apply_arrow_tz_policy(table, self.tz_mode)
-                return pl.from_arrow(table)
+                return options.pl.from_arrow(table)
 
         else:
             raise ValueError(f"dataframe_library must be 'pandas' or 'polars', got '{dataframe_library}'")
@@ -818,26 +856,26 @@ class Client(ABC):
         if dataframe_library == "pandas":
             check_pandas()
             self._add_integration_tag("pandas")
-            if not IS_PANDAS_2:
+            if not options.IS_PANDAS_2:
                 raise ProgrammingError("PyArrow-backed dtypes are only supported when using pandas 2.x.")
 
-            def converter(table: "arrow.Table") -> "pd.DataFrame":
+            def converter(table: "options.arrow.Table") -> "options.pd.DataFrame":
                 table = _apply_arrow_tz_policy(table, self.tz_mode)
-                return table.to_pandas(types_mapper=pd.ArrowDtype, safe=False)
+                return table.to_pandas(types_mapper=options.pd.ArrowDtype, safe=False)
         elif dataframe_library == "polars":
             check_polars()
             self._add_integration_tag("polars")
 
-            def converter(table: arrow.Table) -> pl.DataFrame:
+            def converter(table: options.arrow.Table) -> options.pl.DataFrame:
                 table = _apply_arrow_tz_policy(table, self.tz_mode)
-                return pl.from_arrow(table)
+                return options.pl.from_arrow(table)
         else:
             raise ValueError(f"dataframe_library must be 'pandas' or 'polars', got '{dataframe_library}'")
         settings = self._update_arrow_settings(settings, use_strings)
         raw_stream = self.raw_stream(
             query, parameters, settings, fmt="ArrowStream", external_data=external_data, transport_settings=transport_settings
         )
-        reader = arrow.ipc.open_stream(raw_stream)
+        reader = options.arrow.ipc.open_stream(raw_stream)
 
         def df_generator():
             for batch in reader:
@@ -1025,26 +1063,26 @@ class Client(ABC):
         """
         check_arrow()
 
-        if pd is not None and isinstance(df, pd.DataFrame):
+        if options.pd is not None and isinstance(df, options.pd.DataFrame):
             df_lib = "pandas"
-        elif pl is not None and isinstance(df, pl.DataFrame):
+        elif options.pl is not None and isinstance(df, options.pl.DataFrame):
             df_lib = "polars"
         else:
-            if pd is None and pl is None:
+            if options.pd is None and options.pl is None:
                 raise ImportError("A DataFrame library (pandas or polars) must be installed to use insert_df_arrow.")
             raise TypeError(f"df must be either a pandas DataFrame or polars DataFrame, got {type(df).__name__}")
 
         if df_lib == "pandas":
-            if not IS_PANDAS_2:
+            if not options.IS_PANDAS_2:
                 raise ProgrammingError("PyArrow-backed dtypes are only supported when using pandas 2.x.")
 
-            non_arrow_cols = [col for col, dtype in df.dtypes.items() if not isinstance(dtype, pd.ArrowDtype)]
+            non_arrow_cols = [col for col, dtype in df.dtypes.items() if not isinstance(dtype, options.pd.ArrowDtype)]
             if non_arrow_cols:
                 raise ProgrammingError(
                     f"insert_df_arrow requires all columns to use PyArrow dtypes. Non-Arrow columns found: [{', '.join(non_arrow_cols)}]. "
                 )
             try:
-                arrow_table = arrow.Table.from_pandas(df, preserve_index=False)
+                arrow_table = options.arrow.Table.from_pandas(df, preserve_index=False)
             except Exception as e:
                 raise DataError(f"Failed to convert pandas DataFrame to Arrow table: {e}") from e
         else:

--- a/clickhouse_connect/driver/ctypes.py
+++ b/clickhouse_connect/driver/ctypes.py
@@ -10,7 +10,7 @@ logger = logging.getLogger(__name__)
 
 RespBuffCls = ResponseBuffer
 data_conv = pydc
-numpy_conv = pync
+# numpy_conv is resolved lazily via __getattr__ to avoid eagerly importing numpy
 
 
 # pylint: disable=import-outside-toplevel,global-statement
@@ -28,22 +28,31 @@ def connect_c_modules():
         data_conv = cdc
         RespBuffCls = CResponseBuffer
         logger.debug('Successfully imported ClickHouse Connect C data optimizations')
-        connect_numpy()
     except ImportError as ex:
         logger.warning('Unable to connect optimized C data functions [%s], falling back to pure Python',
                        str(ex))
 
 
-def connect_numpy():
-    global numpy_conv
-    try:
-        import clickhouse_connect.driverc.npconv as cnc
+def _resolve_numpy_conv():
+    if "numpy_conv" in globals():
+        return
+    if coerce_bool(os.environ.get('CLICKHOUSE_CONNECT_USE_C', True)):
+        try:
+            import clickhouse_connect.driverc.npconv as cnc
+            globals()["numpy_conv"] = cnc
+            logger.debug('Successfully import ClickHouse Connect C/Numpy optimizations')
+            return
+        except ImportError as ex:
+            logger.debug('Unable to connect ClickHouse Connect C to Numpy API [%s], falling back to pure Python',
+                         str(ex))
+    globals()["numpy_conv"] = pync
 
-        numpy_conv = cnc
-        logger.debug('Successfully import ClickHouse Connect C/Numpy optimizations')
-    except ImportError as ex:
-        logger.debug('Unable to connect ClickHouse Connect C to Numpy API [%s], falling back to pure Python',
-             str(ex))
+
+def __getattr__(name):
+    if name == "numpy_conv":
+        _resolve_numpy_conv()
+        return globals()["numpy_conv"]
+    raise AttributeError(f"module {__name__!r} has no attribute {name!r}")
 
 
 connect_c_modules()

--- a/clickhouse_connect/driver/dataconv.py
+++ b/clickhouse_connect/driver/dataconv.py
@@ -9,7 +9,7 @@ from clickhouse_connect.driver import tzutil
 from clickhouse_connect.driver.common import int_size
 from clickhouse_connect.driver.errors import NONE_IN_NULLABLE_COLUMN
 from clickhouse_connect.driver.types import ByteSource
-from clickhouse_connect.driver.options import np
+from clickhouse_connect.driver import options
 
 
 MONTH_DAYS = (0, 31, 59, 90, 120, 151, 181, 212, 243, 273, 304, 334, 365)
@@ -104,6 +104,7 @@ def build_lc_nullable_column(index: Sequence, keys: array.array, null_obj: Any):
 
 
 def to_numpy_array(column: Sequence):
+    np = options.np
     arr = np.empty((len(column),), dtype=np.object)
     arr[:] = column
     return arr

--- a/clickhouse_connect/driver/insert.py
+++ b/clickhouse_connect/driver/insert.py
@@ -6,7 +6,7 @@ from clickhouse_connect.driver.binding import quote_identifier
 
 from clickhouse_connect.driver.ctypes import data_conv
 from clickhouse_connect.driver.context import BaseQueryContext
-from clickhouse_connect.driver.options import np, pd, pd_time_test
+from clickhouse_connect.driver import options
 from clickhouse_connect.driver.exceptions import ProgrammingError, DataError
 
 if TYPE_CHECKING:
@@ -73,10 +73,10 @@ class InsertContext(BaseQueryContext):
         self._data = None
         if data is None or len(data) == 0:
             return
-        if pd and isinstance(data, pd.DataFrame):
+        if options.pd and isinstance(data, options.pd.DataFrame):
             data = self._convert_pandas(data)
             self.column_oriented = True
-        if np and isinstance(data, np.ndarray):
+        if options.np and isinstance(data, options.np.ndarray):
             data = self._convert_numpy(data)
         if self.column_oriented:
             self._next_block_data = self._column_block_data
@@ -156,21 +156,21 @@ class InsertContext(BaseQueryContext):
                 elif d_type_kind in ('i', 'u') and not df_col.hasnans:
                     data.append(df_col.to_list())
                     continue
-            elif 'datetime' in ch_type.np_type and (pd_time_test(df_col) or 'datetime64[ns' in str(df_col.dtype)):
+            elif 'datetime' in ch_type.np_type and (options.pd_time_test(df_col) or 'datetime64[ns' in str(df_col.dtype)):
                 div = ch_type.nano_divisor
-                data.append([None if pd.isnull(x) else x.value // div for x in df_col])
+                data.append([None if options.pd.isnull(x) else x.value // div for x in df_col])
                 self.column_formats[col_name] = 'int'
                 continue
             if ch_type.nullable:
                 if d_type_kind == 'O':
                     #  This is ugly, but the multiple replaces seem required as a result of this bug:
                     #  https://github.com/pandas-dev/pandas/issues/29024
-                    df_col = df_col.replace({pd.NaT: None}).replace({np.nan: None})
+                    df_col = df_col.replace({options.pd.NaT: None}).replace({options.np.nan: None})
                 elif 'Float' in ch_type.base_type:
-                    data.append([None if pd.isnull(x) else x for x in df_col])
+                    data.append([None if options.pd.isnull(x) else x for x in df_col])
                     continue
                 else:
-                    df_col = df_col.replace({np.nan: None})
+                    df_col = df_col.replace({options.np.nan: None})
             data.append(df_col.to_numpy(copy=False))
         return data
 

--- a/clickhouse_connect/driver/npconv.py
+++ b/clickhouse_connect/driver/npconv.py
@@ -1,9 +1,9 @@
-from clickhouse_connect.driver.options import np
-
+from clickhouse_connect.driver import options
 from clickhouse_connect.driver.types import ByteSource
 
 
 def read_numpy_array(source: ByteSource, np_type: str, num_rows: int):
+    np = options.np
     dtype = np.dtype(np_type)
     buffer = source.read_bytes(dtype.itemsize * num_rows)
     return np.frombuffer(buffer, dtype, num_rows)

--- a/clickhouse_connect/driver/npquery.py
+++ b/clickhouse_connect/driver/npquery.py
@@ -5,7 +5,7 @@ from typing import Generator, Sequence, Tuple
 from clickhouse_connect.driver.common import empty_gen, StreamContext
 from clickhouse_connect.driver.exceptions import StreamClosedError
 from clickhouse_connect.driver.types import Closable
-from clickhouse_connect.driver.options import np, pd
+from clickhouse_connect.driver import options
 
 logger = logging.getLogger(__name__)
 
@@ -39,20 +39,20 @@ class NumpyResult(Closable):
 
         d_types = self.np_types
         first_type = d_types[0]
-        if first_type != np.object_ and all(np.dtype(np_type) == first_type for np_type in d_types):
+        if first_type != options.np.object_ and all(options.np.dtype(np_type) == first_type for np_type in d_types):
             self.np_types = first_type
 
             def numpy_blocks():
                 for block in block_gen:
-                    yield np.array(block, first_type).transpose()
+                    yield options.np.array(block, first_type).transpose()
         else:
-            if any(x == np.object_ for x in d_types):
-                self.np_types = [np.object_] * len(self.np_types)
-            self.np_types = np.dtype(list(zip(self.column_names, d_types)))
+            if any(x == options.np.object_ for x in d_types):
+                self.np_types = [options.np.object_] * len(self.np_types)
+            self.np_types = options.np.dtype(list(zip(self.column_names, d_types)))
 
             def numpy_blocks():
                 for block in block_gen:
-                    np_array = np.empty(len(block[0]), dtype=self.np_types)
+                    np_array = options.np.empty(len(block[0]), dtype=self.np_types)
                     for col_name, data in zip(self.column_names, block):
                         np_array[col_name] = data
                     yield np_array
@@ -66,7 +66,7 @@ class NumpyResult(Closable):
 
         def pd_blocks():
             for block in block_gen:
-                yield pd.DataFrame(dict(zip(self.column_names, block)))
+                yield options.pd.DataFrame(dict(zip(self.column_names, block)))
 
         self._block_gen = None
         return pd_blocks()
@@ -80,16 +80,16 @@ class NumpyResult(Closable):
         for block in self._np_stream():
             blocks.append(block)
             if len(blocks) == chunk_size:
-                pieces.append(np.concatenate(blocks, dtype=self.np_types))
+                pieces.append(options.np.concatenate(blocks, dtype=self.np_types))
                 chunk_size *= 2
                 blocks = []
         pieces.extend(blocks)
         if len(pieces) > 1:
-            self._numpy_result = np.concatenate(pieces, dtype=self.np_types)
+            self._numpy_result = options.np.concatenate(pieces, dtype=self.np_types)
         elif len(pieces) == 1:
             self._numpy_result = pieces[0]
         else:
-            self._numpy_result = np.empty((0,))
+            self._numpy_result = options.np.empty((0,))
         self.close()
         return self
 
@@ -101,10 +101,10 @@ class NumpyResult(Closable):
         chains = [chain(b) for b in zip(*bg)]
         new_df_series = []
         for c in chains:
-            series = [pd.Series(piece, copy=False) for piece in c if len(piece) > 0]
+            series = [options.pd.Series(piece, copy=False) for piece in c if len(piece) > 0]
             if len(series) > 0:
-                new_df_series.append(pd.concat(series, copy=False, ignore_index=True))
-        self._df_result = pd.DataFrame(dict(zip(self.column_names, new_df_series)))
+                new_df_series.append(options.pd.concat(series, copy=False, ignore_index=True))
+        self._df_result = options.pd.DataFrame(dict(zip(self.column_names, new_df_series)))
         self.close()
         return self
 

--- a/clickhouse_connect/driver/options.py
+++ b/clickhouse_connect/driver/options.py
@@ -2,74 +2,138 @@ import warnings
 
 from clickhouse_connect.driver.exceptions import NotSupportedError
 
-pd_time_test = None
-pd_extended_dtypes = False
-PANDAS_VERSION = None
-IS_PANDAS_2 = None
+# Attributes resolved lazily by __getattr__ / _resolve_* functions:
+#   np, pd, arrow, pl, pd_time_test, pd_extended_dtypes, PANDAS_VERSION, IS_PANDAS_2
 
-try:
-    import numpy as np
-except ImportError:
-    np = None
+# pylint: disable=import-outside-toplevel
 
-try:
-    import pandas as pd
-    PANDAS_VERSION = tuple(map(int, pd.__version__.split(".")[:2]))
-    IS_PANDAS_2 = PANDAS_VERSION >= (2, 0)
-    pd_extended_dtypes = not pd.__version__.startswith('0')
-    if not IS_PANDAS_2:
-        warnings.warn(
-            "clickhouse-connect support for pandas 1.x is deprecated and will be removed in v1.0.0. "
-            "Please upgrade to pandas 2.x or later.",
-            DeprecationWarning,
-            stacklevel=2,
-        )
+_PANDAS_ATTRS = frozenset({"pd", "pd_time_test", "pd_extended_dtypes", "PANDAS_VERSION", "IS_PANDAS_2"})
+_ALL_LAZY = frozenset({"np", "arrow", "pl"}) | _PANDAS_ATTRS
+
+
+def _resolve_numpy():
+    if "np" in globals():
+        return
     try:
-        from pandas.core.dtypes.common import is_datetime64_dtype
-        from pandas.core.dtypes.common import is_timedelta64_dtype
+        import numpy
 
-        def combined_test(arr_or_dtype):
-            return is_datetime64_dtype(arr_or_dtype) or is_timedelta64_dtype(arr_or_dtype)
-
-        pd_time_test = combined_test
+        globals()["np"] = numpy
     except ImportError:
+        globals()["np"] = None
+
+
+def _resolve_pandas():
+    if "pd" in globals():
+        return
+    try:
+        import pandas
+
+        globals()["pd"] = pandas
+        version = tuple(map(int, pandas.__version__.split(".")[:2]))
+        globals()["PANDAS_VERSION"] = version
+        is_v2 = version >= (2, 0)
+        globals()["IS_PANDAS_2"] = is_v2
+        globals()["pd_extended_dtypes"] = not pandas.__version__.startswith("0")
+        if not is_v2:
+            warnings.warn(
+                "clickhouse-connect support for pandas 1.x is deprecated and will be removed in v1.0.0. "
+                "Please upgrade to pandas 2.x or later.",
+                DeprecationWarning,
+                stacklevel=2,
+            )
         try:
-            from pandas.core.dtypes.common import is_datetime_or_timedelta_dtype
-            pd_time_test = is_datetime_or_timedelta_dtype
-        except ImportError as ex:
-            raise NotSupportedError('pandas version does not contain expected test for temporal types') from ex
-except ImportError:
-    pd = None
+            from pandas.core.dtypes.common import (
+                is_datetime64_dtype,
+                is_timedelta64_dtype,
+            )
 
-try:
-    import pyarrow as arrow
-except ImportError:
-    arrow = None
+            def combined_test(arr_or_dtype):
+                return is_datetime64_dtype(arr_or_dtype) or is_timedelta64_dtype(arr_or_dtype)
 
-try:
-    import polars as pl
-except ImportError:
-    pl = None
+            globals()["pd_time_test"] = combined_test
+        except ImportError:
+            try:
+                from pandas.core.dtypes.common import is_datetime_or_timedelta_dtype
 
+                globals()["pd_time_test"] = is_datetime_or_timedelta_dtype
+            except ImportError as ex:
+                raise NotSupportedError("pandas version does not contain expected test for temporal types") from ex
+    except ImportError:
+        globals()["pd"] = None
+        globals()["PANDAS_VERSION"] = None
+        globals()["IS_PANDAS_2"] = None
+        globals()["pd_extended_dtypes"] = False
+        globals()["pd_time_test"] = None
+
+
+def _resolve_arrow():
+    if "arrow" in globals():
+        return
+    try:
+        import pyarrow
+
+        globals()["arrow"] = pyarrow
+    except ImportError:
+        globals()["arrow"] = None
+
+
+def _resolve_polars():
+    if "pl" in globals():
+        return
+    try:
+        import polars
+
+        globals()["pl"] = polars
+    except ImportError:
+        globals()["pl"] = None
+
+
+def __getattr__(name):
+    if name in _PANDAS_ATTRS:
+        _resolve_pandas()
+    elif name == "np":
+        _resolve_numpy()
+    elif name == "arrow":
+        _resolve_arrow()
+    elif name == "pl":
+        _resolve_polars()
+    else:
+        raise AttributeError(f"module {__name__!r} has no attribute {name!r}")
+    return globals()[name]
+
+
+def __dir__():
+    return list(globals().keys()) + list(_ALL_LAZY - globals().keys())
+
+
+# pylint: disable=redefined-outer-name
 def check_numpy():
+    _resolve_numpy()
+    np = globals()["np"]
     if np:
         return np
-    raise NotSupportedError('Numpy package is not installed')
+    raise NotSupportedError("Numpy package is not installed")
 
 
 def check_pandas():
+    _resolve_pandas()
+    pd = globals()["pd"]
     if pd:
         return pd
-    raise NotSupportedError('Pandas package is not installed')
+    raise NotSupportedError("Pandas package is not installed")
 
 
 def check_arrow():
+    _resolve_arrow()
+    arrow = globals()["arrow"]
     if arrow:
         return arrow
-    raise NotSupportedError('PyArrow package is not installed')
+    raise NotSupportedError("PyArrow package is not installed")
 
 
 def check_polars():
+    _resolve_polars()
+    pl = globals()["pl"]
     if pl:
         return pl
     raise NotSupportedError("Polars package is not installed")

--- a/clickhouse_connect/driver/query.py
+++ b/clickhouse_connect/driver/query.py
@@ -15,7 +15,8 @@ from clickhouse_connect.driver.common import dict_copy, empty_gen, StreamContext
 from clickhouse_connect.driver.external import ExternalData
 from clickhouse_connect.driver.types import Matrix, Closable
 from clickhouse_connect.driver.exceptions import StreamClosedError, ProgrammingError
-from clickhouse_connect.driver.options import check_arrow, pd_extended_dtypes
+from clickhouse_connect.driver import options
+from clickhouse_connect.driver.options import check_arrow
 from clickhouse_connect.driver.context import BaseQueryContext
 
 if TYPE_CHECKING:
@@ -251,7 +252,7 @@ class QueryContext(BaseQueryContext):
         self.response_tz = None
         self.block_info = False
         self.as_pandas = as_pandas
-        self.use_pandas_na = as_pandas and pd_extended_dtypes
+        self.use_pandas_na = as_pandas and options.pd_extended_dtypes
         self.streaming = streaming
         self._rename_response_column: Optional[str] = rename_response_column
         self.column_renamer = get_rename_method(rename_response_column)
@@ -550,10 +551,10 @@ def to_arrow_batches(buffer: IOBase) -> StreamContext:
 
 def arrow_buffer(table, compression: Optional[str] = None) -> Tuple[Sequence[str], Union[bytes, BinaryIO]]:
     pyarrow = check_arrow()
-    options = None
+    write_options = None
     if compression in ('zstd', 'lz4'):
-        options = pyarrow.ipc.IpcWriteOptions(compression=pyarrow.Codec(compression=compression))
+        write_options = pyarrow.ipc.IpcWriteOptions(compression=pyarrow.Codec(compression=compression))
     sink = pyarrow.BufferOutputStream()
-    with pyarrow.RecordBatchFileWriter(sink, table.schema, options=options) as writer:
+    with pyarrow.RecordBatchFileWriter(sink, table.schema, options=write_options) as writer:
         writer.write(table)
     return table.schema.names, sink.getvalue()

--- a/tests/integration_tests/test_arrow.py
+++ b/tests/integration_tests/test_arrow.py
@@ -5,7 +5,7 @@ import string
 import pytest
 
 from clickhouse_connect.driver import Client
-from clickhouse_connect.driver.options import arrow
+from clickhouse_connect.driver.options import arrow  # pylint: disable=no-name-in-module
 
 
 def test_arrow(test_client: Client, table_context: Callable):

--- a/tests/integration_tests/test_async_client.py
+++ b/tests/integration_tests/test_async_client.py
@@ -8,7 +8,7 @@ import numpy as np
 import pandas as pd
 import pytest
 
-from clickhouse_connect.driver.options import arrow, IS_PANDAS_2
+from clickhouse_connect.driver.options import arrow, IS_PANDAS_2  # pylint: disable=no-name-in-module
 from clickhouse_connect.driver.exceptions import ProgrammingError
 from clickhouse_connect.driver import AsyncClient
 

--- a/tests/integration_tests/test_external_data.py
+++ b/tests/integration_tests/test_external_data.py
@@ -5,7 +5,7 @@ import pytest
 from clickhouse_connect import get_client
 from clickhouse_connect.driver import Client
 from clickhouse_connect.driver.external import ExternalData
-from clickhouse_connect.driver.options import arrow
+from clickhouse_connect.driver.options import arrow  # pylint: disable=no-name-in-module
 from tests.integration_tests.conftest import TestConfig
 
 ext_settings = {'input_format_allow_errors_num': 10, 'input_format_allow_errors_ratio': .2}

--- a/tests/integration_tests/test_numpy.py
+++ b/tests/integration_tests/test_numpy.py
@@ -8,7 +8,7 @@ import pytest
 from clickhouse_connect.driver.exceptions import ProgrammingError
 
 from clickhouse_connect.driver import Client
-from clickhouse_connect.driver.options import np
+from clickhouse_connect.driver.options import np  # pylint: disable=no-name-in-module
 from tests.helpers import list_equal, random_query
 from tests.integration_tests.datasets import basic_ds, basic_ds_columns, basic_ds_types, basic_ds_types_ver19, \
     null_ds, null_ds_columns, null_ds_types, dt_ds, dt_ds_columns, dt_ds_types

--- a/tests/integration_tests/test_pandas.py
+++ b/tests/integration_tests/test_pandas.py
@@ -8,7 +8,7 @@ import pytest
 
 from clickhouse_connect.driver import Client
 from clickhouse_connect.driver.exceptions import DataError
-from clickhouse_connect.driver.options import np, pd
+from clickhouse_connect.driver.options import np, pd  # pylint: disable=no-name-in-module
 from tests.helpers import random_query
 from tests.integration_tests.conftest import TestConfig
 from tests.integration_tests.datasets import null_ds, null_ds_columns, null_ds_types

--- a/tests/integration_tests/test_pandas_compat.py
+++ b/tests/integration_tests/test_pandas_compat.py
@@ -2,7 +2,7 @@ import datetime
 from typing import Callable
 
 import pytest
-from clickhouse_connect.driver.options import pd, PANDAS_VERSION, arrow
+from clickhouse_connect.driver.options import pd, PANDAS_VERSION, arrow  # pylint: disable=no-name-in-module
 from clickhouse_connect.driver import Client
 from clickhouse_connect.driver.exceptions import ProgrammingError
 from clickhouse_connect.common import set_setting

--- a/tests/integration_tests/test_polars.py
+++ b/tests/integration_tests/test_polars.py
@@ -5,7 +5,7 @@ from typing import Callable
 import pytest
 
 from clickhouse_connect.driver import Client
-from clickhouse_connect.driver.options import pl, arrow
+from clickhouse_connect.driver.options import pl, arrow  # pylint: disable=no-name-in-module
 
 pytestmark = [
     pytest.mark.skipif(pl is None, reason="polars package not installed"),

--- a/tests/unit_tests/test_qbit_type.py
+++ b/tests/unit_tests/test_qbit_type.py
@@ -5,7 +5,7 @@ import pytest
 from clickhouse_connect.datatypes.registry import get_from_name
 from clickhouse_connect.datatypes.vector import QBit
 from clickhouse_connect.driver import options
-from clickhouse_connect.driver.options import np
+from clickhouse_connect.driver.options import np  # pylint: disable=no-name-in-module
 
 # pylint: disable=protected-access
 

--- a/tests/unit_tests/test_qbit_type.py
+++ b/tests/unit_tests/test_qbit_type.py
@@ -2,9 +2,9 @@ import math
 
 import pytest
 
-import clickhouse_connect.datatypes.vector as vector_module
 from clickhouse_connect.datatypes.registry import get_from_name
 from clickhouse_connect.datatypes.vector import QBit
+from clickhouse_connect.driver import options
 from clickhouse_connect.driver.options import np
 
 # pylint: disable=protected-access
@@ -600,13 +600,13 @@ def test_transpose_numpy_vs_pure_python_equivalence():
         qbit = get_from_name(f"QBit({elem_type}, {dimension})")
 
         # Get pure Python result by temporarily disabling numpy
-        original_np = vector_module.np
+        original_np = options.np
         try:
             # Disable numpy to force pure Python path
-            vector_module.np = None
+            options.np = None
             result_python = qbit._transpose_row(test_vector)
         finally:
-            vector_module.np = original_np
+            options.np = original_np
 
         dtype = np.float64 if elem_type == "Float64" else np.float32
         np_vector = np.array(test_vector, dtype=dtype)
@@ -638,13 +638,13 @@ def test_untranspose_numpy_vs_pure_python_equivalence():
         bit_planes = qbit._transpose_row_numpy(np_vector)
 
         # Get pure Python result by temporarily disabling numpy
-        original_np = vector_module.np
+        original_np = options.np
         try:
             # Disable numpy to force pure Python path
-            vector_module.np = None
+            options.np = None
             result_python = qbit._untranspose_row(bit_planes)
         finally:
-            vector_module.np = original_np
+            options.np = original_np
 
         result_numpy = qbit._untranspose_row_numpy(bit_planes)
         assert len(result_python) == len(result_numpy)


### PR DESCRIPTION
## Summary
- Implements lazy imports for optional dependencies (`numpy`, `pandas`, `pyarrow`, `polars`) so they are only loaded when actually used, not on `import clickhouse_connect`
- Defers the C/Numpy optimization bridge in `ctypes.py`
- Improves bare import time of `clickhouse_connect` by about 4X in environments where all four are installed.

## Approach
I chose to go with PEP 562 module-level `__getattr__` on `options.py` and `ctypes.py`. This is the standard approach for lazy loading. An alternative approach is to use `importlib.util.LazyLoader`, but that has hit some speed bumps in recent years related to thread safety and just seems more "magical" than the PEP 562 which is zero-dependency and simple.

The trade-off is that consumer modules must access lazy attributes via `options.np` rather than `from options import np`, since the latter triggers `__getattr__` at import time and defeats laziness. This is a mechanical change across a lot of files but is the only way to get actual deferral with PEP 562.

Closes #589

## Checklist
Delete items not relevant to your PR:
- [X] Unit and integration tests covering the common scenarios were added
- [X] A human-readable description of the changes was provided to include in CHANGELOG