### PR TITLE
Add SQLAlchemy DDL support for missing replicated MergeTree engines

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,12 @@ The supported method of passing ClickHouse server settings is to prefix such arg
 
 ## UNRELEASED
 
+### New Features
+- SQLAlchemy: Add missing Replicated table engine variants: `ReplicatedReplacingMergeTree`, `ReplicatedCollapsingMergeTree`, `ReplicatedVersionedCollapsingMergeTree`, and `ReplicatedGraphiteMergeTree`. Closes [#687](https://github.com/ClickHouse/clickhouse-connect/issues/687)
+
+### Bug Fixes
+- SQLAlchemy: Fix `GraphiteMergeTree` and `ReplicatedGraphiteMergeTree` to properly single-quote the `config_section` argument as ClickHouse requires.
+
 ## 0.14.1, 2026-03-11
 
 ### Bug Fixes

--- a/clickhouse_connect/cc_sqlalchemy/ddl/tableengine.py
+++ b/clickhouse_connect/cc_sqlalchemy/ddl/tableengine.py
@@ -198,6 +198,7 @@ class VersionedCollapsingMergeTree(TableEngine):
 
 class GraphiteMergeTree(TableEngine):
     arg_names = ['config_section']
+    quoted_args = set(arg_names)
     eng_params = MergeTree.eng_params
 
     # pylint: disable=unused-argument
@@ -228,6 +229,95 @@ class ReplicatedAggregatingMergeTree(ReplicatedMergeTree):
 
 class ReplicatedSummingMergeTree(ReplicatedMergeTree):
     pass
+
+
+class ReplicatedReplacingMergeTree(TableEngine):
+    arg_names = ["zk_path", "replica", "ver"]
+    quoted_args = {"zk_path", "replica"}
+    optional_args = {"zk_path", "replica", "ver"}
+    eng_params = MergeTree.eng_params
+
+    # pylint: disable=unused-argument
+    def __init__(
+        self,
+        ver: str = None,
+        order_by: str = None,
+        primary_key: str = None,
+        partition_by: str = None,
+        sample_by: str = None,
+        zk_path: str = None,
+        replica: str = None,
+    ):
+        if not order_by and not primary_key:
+            raise ArgumentError(None, "Either PRIMARY KEY or ORDER BY must be specified")
+        super().__init__(locals())
+
+
+class ReplicatedCollapsingMergeTree(TableEngine):
+    arg_names = ["zk_path", "replica", "sign"]
+    quoted_args = {"zk_path", "replica"}
+    optional_args = {"zk_path", "replica"}
+    eng_params = MergeTree.eng_params
+
+    # pylint: disable=unused-argument
+    def __init__(
+        self,
+        sign: str = None,
+        order_by: str = None,
+        primary_key: str = None,
+        partition_by: str = None,
+        sample_by: str = None,
+        zk_path: str = None,
+        replica: str = None,
+    ):
+        if not order_by and not primary_key:
+            raise ArgumentError(None, "Either PRIMARY KEY or ORDER BY must be specified")
+        super().__init__(locals())
+
+
+class ReplicatedVersionedCollapsingMergeTree(TableEngine):
+    arg_names = ["zk_path", "replica", "sign", "version"]
+    quoted_args = {"zk_path", "replica"}
+    optional_args = {"zk_path", "replica"}
+    eng_params = MergeTree.eng_params
+
+    # pylint: disable=unused-argument
+    def __init__(
+        self,
+        sign: str = None,
+        version: str = None,
+        order_by: str = None,
+        primary_key: str = None,
+        partition_by: str = None,
+        sample_by: str = None,
+        zk_path: str = None,
+        replica: str = None,
+    ):
+        if not order_by and not primary_key:
+            raise ArgumentError(None, "Either PRIMARY KEY or ORDER BY must be specified")
+        super().__init__(locals())
+
+
+class ReplicatedGraphiteMergeTree(TableEngine):
+    arg_names = ["zk_path", "replica", "config_section"]
+    quoted_args = {"zk_path", "replica", "config_section"}
+    optional_args = {"zk_path", "replica"}
+    eng_params = MergeTree.eng_params
+
+    # pylint: disable=unused-argument
+    def __init__(
+        self,
+        config_section: str = None,
+        order_by: str = None,
+        primary_key: str = None,
+        partition_by: str = None,
+        sample_by: str = None,
+        zk_path: str = None,
+        replica: str = None,
+    ):
+        if not order_by and not primary_key:
+            raise ArgumentError(None, "Either PRIMARY KEY or ORDER BY must be specified")
+        super().__init__(locals())
 
 
 class SharedReplacingMergeTree(ReplacingMergeTree):

--- a/tests/unit_tests/test_sqlalchemy/test_ddl.py
+++ b/tests/unit_tests/test_sqlalchemy/test_ddl.py
@@ -2,7 +2,15 @@ import sqlalchemy as db
 from sqlalchemy.sql.ddl import CreateTable
 
 from clickhouse_connect.cc_sqlalchemy.datatypes.sqltypes import UInt64, UInt32, DateTime
-from clickhouse_connect.cc_sqlalchemy.ddl.tableengine import ReplicatedMergeTree, ReplacingMergeTree
+from clickhouse_connect.cc_sqlalchemy.ddl.tableengine import (
+    ReplicatedMergeTree,
+    ReplacingMergeTree,
+    ReplicatedReplacingMergeTree,
+    ReplicatedCollapsingMergeTree,
+    ReplicatedVersionedCollapsingMergeTree,
+    ReplicatedGraphiteMergeTree,
+    GraphiteMergeTree,
+)
 from clickhouse_connect.cc_sqlalchemy.dialect import ClickHouseDialect
 
 dialect = ClickHouseDialect()
@@ -31,3 +39,110 @@ def test_table_def():
 
     ddl = str(CreateTable(table).compile('', dialect=dialect))
     assert ddl == replacing_mt_ddl
+
+
+repl_replacing_mt_ddl = """\
+CREATE TABLE `repl_replacing_mt` (`key` UInt64, `ver_col` UInt32) Engine \
+ReplicatedReplacingMergeTree('/clickhouse/tables/repl_replacing', '{replica}', ver_col) ORDER BY key\
+"""
+
+repl_replacing_mt_no_ver_ddl = """\
+CREATE TABLE `repl_replacing_mt_no_ver` (`key` UInt64) Engine \
+ReplicatedReplacingMergeTree('/clickhouse/tables/repl_replacing_nv', '{replica}') ORDER BY key\
+"""
+
+repl_collapsing_mt_ddl = """\
+CREATE TABLE `repl_collapsing_mt` (`key` UInt64, `sign_col` UInt32) Engine \
+ReplicatedCollapsingMergeTree('/clickhouse/tables/repl_collapsing', '{replica}', sign_col) ORDER BY key\
+"""
+
+repl_ver_collapsing_mt_ddl = """\
+CREATE TABLE `repl_ver_collapsing_mt` (`key` UInt64, `sign_col` UInt32, `ver_col` UInt32) Engine \
+ReplicatedVersionedCollapsingMergeTree('/clickhouse/tables/repl_ver_collapsing', '{replica}', sign_col, ver_col) ORDER BY key\
+"""
+
+repl_graphite_mt_ddl = """\
+CREATE TABLE `repl_graphite_mt` (`key` UInt64) Engine \
+ReplicatedGraphiteMergeTree('/clickhouse/tables/repl_graphite', '{replica}', 'graphite_rollup') ORDER BY key\
+"""
+
+graphite_mt_ddl = """\
+CREATE TABLE `graphite_mt` (`key` UInt64) Engine GraphiteMergeTree('graphite_rollup') ORDER BY key\
+"""
+
+
+def test_replicated_replacing_merge_tree():
+    metadata = db.MetaData()
+
+    table = db.Table(
+        "repl_replacing_mt",
+        metadata,
+        db.Column("key", UInt64),
+        db.Column("ver_col", UInt32),
+        ReplicatedReplacingMergeTree(ver="ver_col", order_by="key", zk_path="/clickhouse/tables/repl_replacing", replica="{replica}"),
+    )
+    ddl = str(CreateTable(table).compile("", dialect=dialect))
+    assert ddl == repl_replacing_mt_ddl
+
+    table = db.Table(
+        "repl_replacing_mt_no_ver",
+        metadata,
+        db.Column("key", UInt64),
+        ReplicatedReplacingMergeTree(order_by="key", zk_path="/clickhouse/tables/repl_replacing_nv", replica="{replica}"),
+    )
+    ddl = str(CreateTable(table).compile("", dialect=dialect))
+    assert ddl == repl_replacing_mt_no_ver_ddl
+
+
+def test_replicated_collapsing_merge_tree():
+    metadata = db.MetaData()
+
+    table = db.Table(
+        "repl_collapsing_mt",
+        metadata,
+        db.Column("key", UInt64),
+        db.Column("sign_col", UInt32),
+        ReplicatedCollapsingMergeTree(sign="sign_col", order_by="key", zk_path="/clickhouse/tables/repl_collapsing", replica="{replica}"),
+    )
+    ddl = str(CreateTable(table).compile("", dialect=dialect))
+    assert ddl == repl_collapsing_mt_ddl
+
+
+def test_replicated_versioned_collapsing_merge_tree():
+    metadata = db.MetaData()
+
+    table = db.Table(
+        "repl_ver_collapsing_mt",
+        metadata,
+        db.Column("key", UInt64),
+        db.Column("sign_col", UInt32),
+        db.Column("ver_col", UInt32),
+        ReplicatedVersionedCollapsingMergeTree(
+            sign="sign_col", version="ver_col", order_by="key", zk_path="/clickhouse/tables/repl_ver_collapsing", replica="{replica}"
+        ),
+    )
+    ddl = str(CreateTable(table).compile("", dialect=dialect))
+    assert ddl == repl_ver_collapsing_mt_ddl
+
+
+def test_replicated_graphite_merge_tree():
+    metadata = db.MetaData()
+
+    table = db.Table(
+        "repl_graphite_mt",
+        metadata,
+        db.Column("key", UInt64),
+        ReplicatedGraphiteMergeTree(
+            config_section="graphite_rollup", order_by="key", zk_path="/clickhouse/tables/repl_graphite", replica="{replica}"
+        ),
+    )
+    ddl = str(CreateTable(table).compile("", dialect=dialect))
+    assert ddl == repl_graphite_mt_ddl
+
+
+def test_graphite_merge_tree_quoting():
+    metadata = db.MetaData()
+
+    table = db.Table("graphite_mt", metadata, db.Column("key", UInt64), GraphiteMergeTree(config_section="graphite_rollup", order_by="key"))
+    ddl = str(CreateTable(table).compile("", dialect=dialect))
+    assert ddl == graphite_mt_ddl


### PR DESCRIPTION
## Summary
- Adds missing table engine classes in `clickhouse_connect/cc_sqlalchemy/ddl/tableengine.py` for:
  - `ReplicatedReplacingMergeTree`
  - `ReplicatedCollapsingMergeTree`
  - `ReplicatedVersionedCollapsingMergeTree`
  - `ReplicatedGraphiteMergeTree`

so SQLAlchemy can render DDL for those engines.

- Also fixes quoting for `GraphiteMergeTree` config sections which was a pre-existing issue.
- Adds unit coverage for the new replicated engines plus the Graphite quoting behavior.

Closes #687

## Checklist
Delete items not relevant to your PR:
- [X] Unit and integration tests covering the common scenarios were added
- [X] A human-readable description of the changes was provided to include in CHANGELOG