### PR TITLE
drop python 3.9

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -17,8 +17,8 @@ jobs:
     name: Build x86 manylinux wheels on Linux
     runs-on: ubuntu-latest
     env:
-      CIBW_SKIP: '*-musllinux* pp38-* pp311-* cp38-* cp313t-*'
-      CIBW_ENABLE: 'pypy pypy-eol cpython-freethreading'
+      CIBW_SKIP: '*-musllinux* pp38-* pp39-* pp311-* cp38-* cp39-* cp313t-*'
+      CIBW_ENABLE: 'pypy cpython-freethreading'
     steps:
       - uses: actions/checkout@v4
       - name: Build wheels
@@ -32,8 +32,8 @@ jobs:
     name: Build x86 musllinux wheels on Linux
     runs-on: ubuntu-latest
     env:
-      CIBW_SKIP: '*-manylinux* pp38-* pp311-* cp38-* cp313t-*'
-      CIBW_ENABLE: 'pypy pypy-eol cpython-freethreading'
+      CIBW_SKIP: '*-manylinux* pp38-* pp39-* pp311-* cp38-* cp39-* cp313t-*'
+      CIBW_ENABLE: 'pypy cpython-freethreading'
     steps:
       - uses: actions/checkout@v4
       - name: Build wheels
@@ -48,7 +48,7 @@ jobs:
     runs-on: ubuntu-latest
     env:
       CIBW_ARCHS_LINUX: aarch64
-      CIBW_SKIP: '*-musllinux* cp38-* cp313t-*'
+      CIBW_SKIP: '*-musllinux* cp38-* cp39-* cp313t-*'
       CIBW_ENABLE: 'cpython-freethreading'
     steps:
       - uses: actions/checkout@v4
@@ -68,7 +68,7 @@ jobs:
     runs-on: ubuntu-latest
     env:
       CIBW_ARCHS_LINUX: aarch64
-      CIBW_SKIP: '*-manylinux* cp38-* cp313t-*'
+      CIBW_SKIP: '*-manylinux* cp38-* cp39-* cp313t-*'
       CIBW_ENABLE: 'cpython-freethreading'
     steps:
       - uses: actions/checkout@v4
@@ -88,8 +88,8 @@ jobs:
     runs-on: ubuntu-latest
     env:
       CIBW_ARCHS_LINUX: aarch64
-      CIBW_BUILD: 'pp39-* pp310-*'
-      CIBW_ENABLE: 'pypy pypy-eol'
+      CIBW_BUILD: 'pp310-*'
+      CIBW_ENABLE: 'pypy'
     steps:
       - uses: actions/checkout@v4
       - name: Set up QEMU
@@ -108,8 +108,8 @@ jobs:
     runs-on: macos-14
     env:
       CIBW_ARCHS_MACOS: x86_64 arm64
-      CIBW_ENABLE: 'pypy pypy-eol cpython-freethreading'
-      CIBW_SKIP: 'pp38-* pp311-* cp38-* cp313t-*'
+      CIBW_ENABLE: 'pypy cpython-freethreading'
+      CIBW_SKIP: 'pp38-* pp39-* pp311-* cp38-* cp39-* cp313t-*'
     steps:
       - uses: actions/checkout@v4
       - name: Build wheels
@@ -126,8 +126,8 @@ jobs:
     runs-on: windows-latest
     env:
       CIBW_BUILD_VERBOSITY: 2
-      CIBW_ENABLE: 'pypy pypy-eol cpython-freethreading'
-      CIBW_SKIP: 'pp38-* pp311-* cp38-* cp313t-*'
+      CIBW_ENABLE: 'pypy cpython-freethreading'
+      CIBW_SKIP: 'pp38-* pp39-* pp311-* cp38-* cp39-* cp313t-*'
     steps:
       - uses: actions/checkout@v4
       - name: Build wheels

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -18,7 +18,7 @@ jobs:
     runs-on: ubuntu-latest
     env:
       CIBW_SKIP: '*-musllinux* pp38-* pp39-* pp311-* cp38-* cp39-* cp313t-*'
-      CIBW_ENABLE: 'pypy cpython-freethreading'
+      CIBW_ENABLE: 'pypy pypy-eol cpython-freethreading'
     steps:
       - uses: actions/checkout@v4
       - name: Build wheels
@@ -33,7 +33,7 @@ jobs:
     runs-on: ubuntu-latest
     env:
       CIBW_SKIP: '*-manylinux* pp38-* pp39-* pp311-* cp38-* cp39-* cp313t-*'
-      CIBW_ENABLE: 'pypy cpython-freethreading'
+      CIBW_ENABLE: 'pypy pypy-eol cpython-freethreading'
     steps:
       - uses: actions/checkout@v4
       - name: Build wheels
@@ -89,7 +89,7 @@ jobs:
     env:
       CIBW_ARCHS_LINUX: aarch64
       CIBW_BUILD: 'pp310-*'
-      CIBW_ENABLE: 'pypy'
+      CIBW_ENABLE: 'pypy pypy-eol'
     steps:
       - uses: actions/checkout@v4
       - name: Set up QEMU
@@ -108,7 +108,7 @@ jobs:
     runs-on: macos-14
     env:
       CIBW_ARCHS_MACOS: x86_64 arm64
-      CIBW_ENABLE: 'pypy cpython-freethreading'
+      CIBW_ENABLE: 'pypy pypy-eol cpython-freethreading'
       CIBW_SKIP: 'pp38-* pp39-* pp311-* cp38-* cp39-* cp313t-*'
     steps:
       - uses: actions/checkout@v4
@@ -126,7 +126,7 @@ jobs:
     runs-on: windows-latest
     env:
       CIBW_BUILD_VERBOSITY: 2
-      CIBW_ENABLE: 'pypy cpython-freethreading'
+      CIBW_ENABLE: 'pypy pypy-eol cpython-freethreading'
       CIBW_SKIP: 'pp38-* pp39-* pp311-* cp38-* cp39-* cp313t-*'
     steps:
       - uses: actions/checkout@v4

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,7 @@ The supported method of passing ClickHouse server settings is to prefix such arg
 - Removed the deprecated `apply_server_timezone` parameter entirely. Use `tz_source` instead: `"auto"` (default), `"server"` (was `True`), or `"local"` (was `False`).
 - Dropped pandas 1.x support. Minimum pandas version is now 2.0. Users with pandas < 2.0 will get a `NotSupportedError` at import time. Non-pandas usage is unaffected. Closes [#661](https://github.com/ClickHouse/clickhouse-connect/issues/661)
 - Removed the `preserve_pandas_datetime_resolution` common setting. Datetime columns now always return their natural resolution, e.g. `datetime64[s]` for `DateTime`, `datetime64[ms]` for `DateTime64(3)`, instead of coercing everything to `datetime64[ns]`. Closes [#662](https://github.com/ClickHouse/clickhouse-connect/issues/662)
+- Dropped Python 3.9 support. The minimum supported Python version is now 3.10. 0.15.x is the last series supporting Python 3.9.
 
 ### Improvements
 - Lazy loading of optional dependencies (numpy, pandas, pyarrow, polars) now applies to the async client as well, matching the pattern established in 0.15.0 for the sync client.

--- a/README.md
+++ b/README.md
@@ -17,8 +17,7 @@ ClickHouse Connect currently uses the ClickHouse HTTP interface for maximum comp
 pip install clickhouse-connect
 ```
 
-ClickHouse Connect requires Python 3.9 or higher. We officially test against Python 3.10 through 3.14.
-Python 3.9 is deprecated and support will be removed entirely in 1.0.
+ClickHouse Connect requires Python 3.10 or higher.
 
 ### Superset Connectivity
 

--- a/clickhouse_connect/__init__.py
+++ b/clickhouse_connect/__init__.py
@@ -1,15 +1,12 @@
 import sys
-import warnings
 
 from clickhouse_connect.driver import create_client, create_async_client
 
 
 if sys.version_info < (3, 10):
-    warnings.warn(
-        "Python 3.9 support is deprecated and will be removed in a future release. "
-        "This version of clickhouse-connect may stop working with Python 3.9 unexpectedly.",
-        DeprecationWarning,
-        stacklevel=2
+    raise RuntimeError(
+        "clickhouse-connect 1.0+ requires Python 3.10 or later. "
+        "Python 3.9 users should pin to clickhouse-connect<1.0."
     )
 
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ requires = ["setuptools", "cython>=3.0.11,<4"]
 build-backend = "setuptools.build_meta"
 
 [tool.cibuildwheel]
-skip = "cp38-* pp38-*"
+skip = "cp38-* cp39-* pp38-* pp39-*"
 
 [tool.pytest.ini_options]
 log_cli = true

--- a/setup.py
+++ b/setup.py
@@ -53,7 +53,7 @@ def run_setup(try_c: bool = True):
         long_description_content_type='text/markdown',
         url='https://github.com/ClickHouse/clickhouse-connect',
         packages=find_packages(exclude=['tests*']),
-        python_requires='>=3.9,<3.15',
+        python_requires='>=3.10,<3.15',
         license='Apache License 2.0',
         install_requires=[
             'certifi',
@@ -83,7 +83,6 @@ def run_setup(try_c: bool = True):
             'Development Status :: 4 - Beta',
             'Intended Audience :: Developers',
             'License :: OSI Approved :: Apache Software License',
-            'Programming Language :: Python :: 3.9',
             'Programming Language :: Python :: 3.10',
             'Programming Language :: Python :: 3.11',
             'Programming Language :: Python :: 3.12',


### PR DESCRIPTION
## Summary
This PR fully drops support for Python 3.9. Specifically we:

- Raise minimum supported Python version from 3.9 to 3.10
- Remove Python 3.9 package metadata/classifiers
- Stop building and publishing cp39/pp39 wheels
- Replace the current runtime deprecation warning with a hard failure for Python < 3.10
- Update user-facing docs/release notes to state that 0.15.x is the last series supporting Python 3.9

Closes #700