### PR TITLE
Fix: Wrap SQL strings with text() for SQLAlchemy 2.x compatibility

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,7 @@ The supported method of passing ClickHouse server settings is to prefix such arg
 
 ### Bug Fixes
 - Fix async streaming race condition that caused unhandled `InvalidStateError` exceptions on early stream termination. When breaking out of an async stream early, `shutdown()` scheduled a `set_result` callback for pending futures via `call_soon_threadsafe`, but `Task.cancel()` could cancel the future before the callback ran. The done-check is now deferred into the callback itself so it sees the actual future state at execution time.
+- SQLAlchemy: Wrap raw SQL strings in `text()` in `ChClickHouseDialect.get_schema_names()` and `get_table_names()`, so `Inspector.get_schema_names()` and `get_table_names()` work on SQLAlchemy 2.x instead of raising `ObjectNotExecutableError`.
 
 ### Development
 - Replaced pylint with [Ruff](https://docs.astral.sh/ruff/) for linting and formatting. Double quotes are now the standard quote style. Bulk formatting commits are listed in `.git-blame-ignore-revs`. CI lint job no longer requires building C extensions or installing project dependencies, significantly reducing lint check time.
@@ -40,9 +41,6 @@ The supported method of passing ClickHouse server settings is to prefix such arg
 - Clearer error message when attempting to use the async client without aiohttp installed.
 - The `generic_args` parameter is now properly parsed on the async client creation path, matching the sync client behavior.
 - Pandas 3.x compatibility. Removed deprecated `copy=False` parameter from `Series()`, `concat()`, and `astype()` calls. Updated datetime insert path to use vectorized numpy conversion instead of element-by-element nanosecond arithmetic.
-
-### Bug Fixes
-- SQLAlchemy: Wrap raw SQL strings in `text()` in `ChClickHouseDialect.get_schema_names()` and `get_table_names()`, so `Inspector.get_schema_names()` and `get_table_names()` work on SQLAlchemy 2.x instead of raising `ObjectNotExecutableError`.
 
 ## 0.15.1, 2026-03-30
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,6 +41,9 @@ The supported method of passing ClickHouse server settings is to prefix such arg
 - The `generic_args` parameter is now properly parsed on the async client creation path, matching the sync client behavior.
 - Pandas 3.x compatibility. Removed deprecated `copy=False` parameter from `Series()`, `concat()`, and `astype()` calls. Updated datetime insert path to use vectorized numpy conversion instead of element-by-element nanosecond arithmetic.
 
+### Bug Fixes
+- SQLAlchemy: Wrap raw SQL strings in `text()` in `ChClickHouseDialect.get_schema_names()` and `get_table_names()`, so `Inspector.get_schema_names()` and `get_table_names()` work on SQLAlchemy 2.x instead of raising `ObjectNotExecutableError`.
+
 ## 0.15.1, 2026-03-30
 
 ### Bug Fixes

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -82,6 +82,7 @@ To disable this behavior, set the `CLICKHOUSE_CONNECT_TEST_DOCKER` environment v
 
 ```bash
 export CLICKHOUSE_CONNECT_TEST_DOCKER=0
+
 ```
 
 The easiest way to start all the required ClickHouse instances is to use the provided Docker Compose file (the integrations tests [setup script](tests/integration_tests/conftest.py) uses the same file).

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -82,7 +82,6 @@ To disable this behavior, set the `CLICKHOUSE_CONNECT_TEST_DOCKER` environment v
 
 ```bash
 export CLICKHOUSE_CONNECT_TEST_DOCKER=0
-
 ```
 
 The easiest way to start all the required ClickHouse instances is to use the provided Docker Compose file (the integrations tests [setup script](tests/integration_tests/conftest.py) uses the same file).

--- a/clickhouse_connect/cc_sqlalchemy/dialect.py
+++ b/clickhouse_connect/cc_sqlalchemy/dialect.py
@@ -49,7 +49,7 @@ class ClickHouseDialect(DefaultDialect):
         pass
 
     def get_schema_names(self, connection, **_):
-        return [row.name for row in connection.execute("SHOW DATABASES")]
+        return [row.name for row in connection.execute(text("SHOW DATABASES"))]
 
     @staticmethod
     def has_database(connection, db_name):
@@ -59,7 +59,7 @@ class ClickHouseDialect(DefaultDialect):
         cmd = "SHOW TABLES"
         if schema:
             cmd += " FROM " + quote_identifier(schema)
-        return [row.name for row in connection.execute(cmd)]
+        return [row.name for row in connection.execute(text(cmd))]
 
     def get_primary_keys(self, connection, table_name, schema=None, **kw):
         return []

--- a/tests/integration_tests/test_sqlalchemy/test_reflect.py
+++ b/tests/integration_tests/test_sqlalchemy/test_reflect.py
@@ -1,5 +1,5 @@
 import sqlalchemy as db
-from sqlalchemy import text
+from sqlalchemy import inspect, text
 from sqlalchemy.engine import Engine
 
 from clickhouse_connect import common
@@ -49,6 +49,24 @@ def test_types_reflection(test_engine: Engine, test_db: str):
 
 def test_table_exists(test_engine: Engine):
     common.set_setting("invalid_setting_action", "drop")
-    with test_engine.begin() as conn:
-        assert test_engine.dialect.has_table(conn, "columns", "system")
-        assert not test_engine.dialect.has_table(conn, "nope", "fake_db")
+    inspector = inspect(test_engine)
+    assert inspector.has_table(table_name="columns", schema="system")
+    assert not inspector.has_table(table_name="nope", schema="fake_db")
+
+
+def test_get_schema_names(test_engine: Engine):
+    common.set_setting("invalid_setting_action", "drop")
+    inspector = inspect(test_engine)
+    schema_names = inspector.get_schema_names()
+    assert isinstance(schema_names, list)
+    assert "system" in schema_names
+    assert "fake_db" not in schema_names
+
+
+def test_get_table_names(test_engine: Engine, test_db: str):
+    common.set_setting("invalid_setting_action", "drop")
+    inspector = inspect(test_engine)
+    system_tables = inspector.get_table_names(schema="system")
+    assert isinstance(system_tables, list)
+    assert "columns" in system_tables
+    assert "fake_table" not in system_tables


### PR DESCRIPTION
## Summary
  Fixes SQLAlchemy 2.x compatibility issue where `get_schema_names()` and `get_table_names()`
  raise `ObjectNotExecutableError` due to missing `text()` wrapper around SQL strings.
  The methods now wrap SQL commands with `text()`, consistent with the pattern used in
  `has_database()` and `has_table()` methods in the same file.
