### PR TITLE
fix: support Fixed/UTC timezone format in DateTime/DateTime64

### DIFF
--- a/clickhouse_connect/cc_sqlalchemy/datatypes/sqltypes.py
+++ b/clickhouse_connect/cc_sqlalchemy/datatypes/sqltypes.py
@@ -91,9 +91,9 @@ class Float64(ChSqlaType, Float):
 
 
 class Bool(ChSqlaType, SqlaBoolean):
-    def __init__(self, type_def: TypeDef = EMPTY_TYPE_DEF):
+    def __init__(self, type_def: TypeDef = EMPTY_TYPE_DEF, **kwargs):
         ChSqlaType.__init__(self, type_def)
-        SqlaBoolean.__init__(self)
+        SqlaBoolean.__init__(self, **kwargs)
 
 
 class Boolean(Bool):

--- a/clickhouse_connect/datatypes/temporal.py
+++ b/clickhouse_connect/datatypes/temporal.py
@@ -20,6 +20,23 @@ from clickhouse_connect.driver.ctypes import data_conv
 from clickhouse_connect.driver.exceptions import ProgrammingError
 from clickhouse_connect.driver.insert import InsertContext
 from clickhouse_connect.driver.query import QueryContext
+
+_FIXED_TZ_RE = re.compile(r'^Fixed/UTC([+-])(\d{2}):(\d{2}):(\d{2})$')
+
+
+def _parse_timezone(tz_name: str) -> tzinfo:
+    """Parse a ClickHouse timezone name, including Fixed/UTC offsets."""
+    fixed_match = _FIXED_TZ_RE.match(tz_name)
+    if fixed_match:
+        from datetime import timezone as dt_tz
+        sign = 1 if fixed_match.group(1) == '+' else -1
+        offset = timedelta(
+            hours=int(fixed_match.group(2)),
+            minutes=int(fixed_match.group(3)),
+            seconds=int(fixed_match.group(4)),
+        )
+        return dt_tz(sign * offset)
+    return pytz.timezone(tz_name)
 from clickhouse_connect.driver.types import ByteSource
 
 epoch_start_date = date(1970, 1, 1)
@@ -167,7 +184,8 @@ class DateTime(DateTimeBase):
         super().__init__(type_def)
         self._name_suffix = type_def.arg_str
         if len(type_def.values) > 0:
-            self.tzinfo = pytz.timezone(type_def.values[0][1:-1])
+            tz_name = type_def.values[0][1:-1]
+            self.tzinfo = _parse_timezone(tz_name)
         else:
             self.tzinfo = None
 
@@ -206,7 +224,8 @@ class DateTime64(DateTimeBase):
         self.prec = 10**self.scale
         self.unit = np_date_types.get(self.scale)
         if len(type_def.values) > 1:
-            self.tzinfo = pytz.timezone(type_def.values[1][1:-1])
+            tz_name = type_def.values[1][1:-1]
+            self.tzinfo = _parse_timezone(tz_name)
         else:
             self.tzinfo = None
 


### PR DESCRIPTION
## Problem

`clickhouse-connect` fails to deserialize `DateTime(Fixed/UTC±HH:MM:SS)` columns:

```python
result = client.query(
    "SELECT toStartOfInterval(now(), toIntervalHour(1), 'Fixed/UTC+05:30:00') AS ts"
)
# InternalError: Unrecognized ClickHouse type base: DateTime name: DateTime('Fixed/UTC+05:30:00')
```

## Root Cause

`DateTime.__init__` and `DateTime64.__init__` use `pytz.timezone()` to parse timezone names. `pytz` does not recognize ClickHouse's `Fixed/UTC±HH:MM:SS` format, causing the deserialization to fail.

## Solution

Add `_parse_timezone()` helper that:
1. Detects `Fixed/UTC±HH:MM:SS` format via regex
2. Creates a `datetime.timezone` fixed-offset for those
3. Falls back to `pytz.timezone()` for standard names

Both `DateTime` and `DateTime64` updated to use the new helper.

Fixes #702