### PR TITLE
fix async streaming race

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,9 @@ The supported method of passing ClickHouse server settings is to prefix such arg
 - Removed the `preserve_pandas_datetime_resolution` common setting. Datetime columns now always return their natural resolution, e.g. `datetime64[s]` for `DateTime`, `datetime64[ms]` for `DateTime64(3)`, instead of coercing everything to `datetime64[ns]`. Closes [#662](https://github.com/ClickHouse/clickhouse-connect/issues/662)
 - Dropped Python 3.9 support. The minimum supported Python version is now 3.10. 0.15.x is the last series supporting Python 3.9.
 
+### Bug Fixes
+- Fix async streaming race condition that caused unhandled `InvalidStateError` exceptions on early stream termination. When breaking out of an async stream early, `shutdown()` scheduled a `set_result` callback for pending futures via `call_soon_threadsafe`, but `Task.cancel()` could cancel the future before the callback ran. The done-check is now deferred into the callback itself so it sees the actual future state at execution time.
+
 ### Development
 - Replaced pylint with [Ruff](https://docs.astral.sh/ruff/) for linting and formatting. Double quotes are now the standard quote style. Bulk formatting commits are listed in `.git-blame-ignore-revs`. CI lint job no longer requires building C extensions or installing project dependencies, significantly reducing lint check time.
 

--- a/clickhouse_connect/driver/asyncqueue.py
+++ b/clickhouse_connect/driver/asyncqueue.py
@@ -56,12 +56,24 @@ class AsyncSyncQueue(Generic[T]):
         except RuntimeError:
             pass
 
+    @staticmethod
+    def _safe_set_result(fut: asyncio.Future):
+        """Set result on a future only if it hasn't been cancelled or resolved.
+
+        This runs on the event loop thread after being scheduled via
+        call_soon_threadsafe. Between scheduling and execution the future
+        may have been cancelled (e.g. by Task.cancel()), so the done()
+        check must happen here, not at schedule time.
+        """
+        if not fut.done():
+            fut.set_result(None)
+
     def _wakeup_async_waiter(self, waiter_queue: deque[asyncio.Future]):
         """Helper: Wake up the next async waiter in the queue safely."""
         while waiter_queue:
             fut = waiter_queue.popleft()
             if not fut.done():
-                self._loop.call_soon_threadsafe(fut.set_result, None)
+                self._loop.call_soon_threadsafe(self._safe_set_result, fut)
                 break
 
     def shutdown(self):
@@ -75,10 +87,10 @@ class AsyncSyncQueue(Generic[T]):
             if self._loop and not self._loop.is_closed():
                 for fut in list(self._async_getters):
                     if not fut.done():
-                        self._loop.call_soon_threadsafe(fut.set_result, None)
+                        self._loop.call_soon_threadsafe(self._safe_set_result, fut)
                 for fut in list(self._async_putters):
                     if not fut.done():
-                        self._loop.call_soon_threadsafe(fut.set_result, None)
+                        self._loop.call_soon_threadsafe(self._safe_set_result, fut)
                 self._async_getters.clear()
                 self._async_putters.clear()
 

--- a/tests/unit_tests/test_asyncqueue.py
+++ b/tests/unit_tests/test_asyncqueue.py
@@ -291,5 +291,93 @@ def test_empty_exception_on_non_blocking_get():
         queue.sync_q.get(block=False)
 
 
+def test_shutdown_then_cancel_no_invalid_state():
+    """Regression: shutdown() + task.cancel() on a blocked putter must not
+    raise InvalidStateError.
+
+    Before the fix, shutdown() scheduled fut.set_result via call_soon_threadsafe
+    after a not-fut.done() check. task.cancel() could cancel the future before
+    the callback ran, so set_result hit an already-cancelled future.
+    """
+    errors = []
+
+    async def run_test():
+        loop = asyncio.get_running_loop()
+        old_handler = loop.get_exception_handler()
+
+        def exception_handler(_loop, context):
+            exc = context.get("exception")
+            if exc:
+                errors.append(exc)
+
+        loop.set_exception_handler(exception_handler)
+        try:
+            q = AsyncSyncQueue(maxsize=1)
+            producer_blocked = asyncio.Event()
+
+            async def producer():
+                await q.async_q.put(b"chunk_1")
+                producer_blocked.set()
+                await q.async_q.put(b"chunk_2")  # blocks, queue full
+
+            task = loop.create_task(producer())
+            await producer_blocked.wait()
+
+            for _ in range(200):
+                if len(q._async_putters) == 1:
+                    break
+                await asyncio.sleep(0.001)
+            assert len(q._async_putters) == 1, "Producer never registered its putter future"
+
+            q.shutdown()
+            task.cancel()
+
+            try:
+                await task
+            except asyncio.CancelledError:
+                pass
+
+            await asyncio.sleep(0)
+
+        finally:
+            loop.set_exception_handler(old_handler)
+
+    asyncio.run(run_test())
+
+    invalid_state_errors = [e for e in errors if isinstance(e, asyncio.InvalidStateError)]
+    assert not invalid_state_errors, (
+        f"Got {len(invalid_state_errors)} InvalidStateError(s). _safe_set_result should guard against set_result on cancelled futures."
+    )
+
+
+def test_shutdown_still_wakes_async_getter():
+    """After the _safe_set_result fix, shutdown() must still wake async getters
+    so they see EOF_SENTINEL instead of hanging."""
+
+    async def run_test():
+        q = AsyncSyncQueue(maxsize=10)
+        got_sentinel = asyncio.Event()
+
+        async def consumer():
+            result = await q.async_q.get()
+            if result is EOF_SENTINEL:
+                got_sentinel.set()
+
+        loop = asyncio.get_running_loop()
+        task = loop.create_task(consumer())
+
+        for _ in range(200):
+            if len(q._async_getters) == 1:
+                break
+            await asyncio.sleep(0.001)
+        assert len(q._async_getters) == 1, "Consumer never registered its getter future"
+
+        q.shutdown()
+        await asyncio.wait_for(task, timeout=2.0)
+        assert got_sentinel.is_set(), "Consumer should have received EOF_SENTINEL from shutdown"
+
+    asyncio.run(run_test())
+
+
 if __name__ == "__main__":
     pytest.main([__file__, "-v"])

--- a/tests/unit_tests/test_asyncqueue.py
+++ b/tests/unit_tests/test_asyncqueue.py
@@ -302,6 +302,13 @@ def test_shutdown_then_cancel_no_invalid_state():
     errors = []
 
     async def run_test():
+        async def wait_for_putter_registration(q: AsyncSyncQueue, timeout: float = 1.0):
+            async def _wait():
+                while len(q._async_putters) != 1:
+                    await asyncio.sleep(0)
+
+            await asyncio.wait_for(_wait(), timeout=timeout)
+
         loop = asyncio.get_running_loop()
         old_handler = loop.get_exception_handler()
 
@@ -323,10 +330,7 @@ def test_shutdown_then_cancel_no_invalid_state():
             task = loop.create_task(producer())
             await producer_blocked.wait()
 
-            for _ in range(200):
-                if len(q._async_putters) == 1:
-                    break
-                await asyncio.sleep(0.001)
+            await wait_for_putter_registration(q)
             assert len(q._async_putters) == 1, "Producer never registered its putter future"
 
             q.shutdown()


### PR DESCRIPTION
## Summary
Fix async queue race condition on early stream termination. `shutdown()` and `_wakeup_async_waiter()` checked `fut.done()` before scheduling `fut.set_result(None)` via `call_soon_threadsafe`. Between scheduling and callback execution, `Task.cancel()` could cancel the future, so the callback would call `set_result` on an already-cancelled future, raising an unhandled `InvalidStateError` on the event loop.

The fix defers the `done()` check into the callback itself (`_safe_set_result`) so it sees the actual future state at execution time.

## Checklist
Delete items not relevant to your PR:
- [X] Unit and integration tests covering the common scenarios were added
- [X] A human-readable description of the changes was provided to include in CHANGELOG