### PR TITLE
rebuild body on connection-reset insert retry

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## UNRELEASED
 
+### Bug Fixes
+- Fix intermittent `Code: 62. Empty query. (SYNTAX_ERROR)` on inserts when a pooled keep-alive connection is reset between attempts. The retry path now rebuilds the insert body instead of replaying an already-drained generator. Affects both sync and async clients. Closes [#731](https://github.com/ClickHouse/clickhouse-connect/issues/731)
+
 ## 1.0.0rc2, 2026-05-05
 
 ### Improvements

--- a/clickhouse_connect/driver/asyncclient.py
+++ b/clickhouse_connect/driver/asyncclient.py
@@ -1561,7 +1561,7 @@ class AsyncClient(Client):
 
         async def rebuild_body():
             nonlocal active_source
-            await active_source.close()
+            await active_source.close(timeout=None)
             context.current_row = 0
             context.current_block = 0
             active_source = StreamingInsertSource(transform=self._transform, context=context, loop=loop, maxsize=10)

--- a/clickhouse_connect/driver/asyncclient.py
+++ b/clickhouse_connect/driver/asyncclient.py
@@ -13,7 +13,7 @@ import uuid
 import zlib
 import zoneinfo
 from base64 import b64encode
-from collections.abc import Generator, Iterable, Sequence
+from collections.abc import Awaitable, Callable, Generator, Iterable, Sequence
 from datetime import timezone, tzinfo
 from importlib import import_module
 from importlib.metadata import version as dist_version
@@ -1556,9 +1556,17 @@ class AsyncClient(Client):
 
         loop = asyncio.get_running_loop()
 
-        streaming_source = StreamingInsertSource(transform=self._transform, context=context, loop=loop, maxsize=10)
+        active_source = StreamingInsertSource(transform=self._transform, context=context, loop=loop, maxsize=10)
+        active_source.start_producer()
 
-        streaming_source.start_producer()
+        async def rebuild_body():
+            nonlocal active_source
+            await active_source.close()
+            context.current_row = 0
+            context.current_block = 0
+            active_source = StreamingInsertSource(transform=self._transform, context=context, loop=loop, maxsize=10)
+            active_source.start_producer()
+            return active_source.async_generator()
 
         headers = {"Content-Type": "application/octet-stream"}
         if context.compression:
@@ -1571,10 +1579,16 @@ class AsyncClient(Client):
         headers = dict_copy(headers, context.transport_settings)
 
         try:
-            response = await self._raw_request(streaming_source.async_generator(), params, headers=headers, server_wait=False)
+            response = await self._raw_request(
+                active_source.async_generator(),
+                params,
+                headers=headers,
+                server_wait=False,
+                retry_body=rebuild_body,
+            )
             logger.debug("Context insert response code: %d", response.status)
         except Exception:
-            await streaming_source.close()
+            await active_source.close()
 
             if context.insert_exception:
                 ex = context.insert_exception
@@ -1582,7 +1596,7 @@ class AsyncClient(Client):
                 raise ex from None
             raise
         finally:
-            await streaming_source.close()
+            await active_source.close()
             context.data = None
 
         return QuerySummary(self._summary(response))
@@ -1772,6 +1786,7 @@ class AsyncClient(Client):
         stream=False,
         server_wait=True,
         retries: int = 0,
+        retry_body: Callable[[], Awaitable[Any]] | None = None,
     ) -> aiohttp.ClientResponse:
         if self._session is None:
             raise ProgrammingError(
@@ -1860,8 +1875,13 @@ class AsyncClient(Client):
                 msg = str(e)
                 if "Connection reset" in msg or "Remote end closed" in msg or "Cannot connect" in msg or "Server disconnected" in msg:
                     if attempts == 1:
-                        logger.debug("Retrying after connection error from remote host")
-                        continue
+                        if retry_body is not None:
+                            data = await retry_body()
+                            logger.debug("Retrying after connection error with rebuilt body")
+                            continue
+                        if data is None or isinstance(data, (bytes, bytearray, str, dict)):
+                            logger.debug("Retrying after connection error from remote host")
+                            continue
                 raise OperationalError(f"Network Error: {msg}") from e
 
             except (aiohttp.ClientError, asyncio.TimeoutError) as e:

--- a/clickhouse_connect/driver/httpclient.py
+++ b/clickhouse_connect/driver/httpclient.py
@@ -357,13 +357,25 @@ class HttpClient(Client):
             headers["Content-Encoding"] = context.compression
         block_gen = self._transform.build_insert(context)
 
+        def rebuild_block_gen():
+            context.current_row = 0
+            context.current_block = 0
+            return self._transform.build_insert(context)
+
         params = {}
         if self.database:
             params["database"] = self.database
         params.update(self._validate_settings(context.settings))
         headers = dict_copy(headers, context.transport_settings)
         try:
-            response = self._raw_request(block_gen, params, headers, error_handler=error_handler, server_wait=False)
+            response = self._raw_request(
+                block_gen,
+                params,
+                headers,
+                error_handler=error_handler,
+                server_wait=False,
+                retry_body=rebuild_block_gen,
+            )
             logger.debug("Context insert response code: %d, content: %s", response.status, response.data)
             return QuerySummary(self._summary(response))
         finally:
@@ -509,6 +521,7 @@ class HttpClient(Client):
         server_wait: bool = True,
         fields: dict[str, tuple] | None = None,
         error_handler: Callable = None,
+        retry_body: Callable[[], Any] | None = None,
     ) -> HTTPResponse:
         if isinstance(data, str):
             data = data.encode()
@@ -555,12 +568,17 @@ class HttpClient(Client):
             try:
                 response = self.http.request(method, url, **kwargs)
             except HTTPError as ex:
-                if isinstance(ex.__context__, ConnectionResetError):
+                if isinstance(ex.__context__, ConnectionResetError) and attempts == 1:
                     # The server closed the connection, probably because the Keep Alive has expired
                     # We should be safe to retry, as ClickHouse should not have processed anything on a connection
                     # that it killed.  We also only retry this once, as multiple disconnects are unlikely to be
                     # related to the Keep Alive settings
-                    if attempts == 1:
+                    body = kwargs.get("body")
+                    if retry_body is not None:
+                        kwargs["body"] = retry_body()
+                        logger.debug("Retrying remotely closed connection with rebuilt body")
+                        continue
+                    if body is None or isinstance(body, (bytes, bytearray, str)):
                         logger.debug("Retrying remotely closed connection")
                         continue
                 logger.warning("Unexpected Http Driver Exception")

--- a/clickhouse_connect/driver/streaming.py
+++ b/clickhouse_connect/driver/streaming.py
@@ -303,11 +303,15 @@ class StreamingInsertSource:
                 except Exception:
                     pass
 
-    async def close(self):
+    async def close(self, timeout: float | None = 1.0):
+        """Shut down the queue and wait for the producer thread to terminate. Pass ``timeout=None`` to wait without a deadline."""
         self.queue.shutdown()
         if self._producer_future and not self._producer_future.done():
             try:
-                await asyncio.wait_for(self._producer_future, timeout=1.0)
+                if timeout is None:
+                    await self._producer_future
+                else:
+                    await asyncio.wait_for(asyncio.shield(self._producer_future), timeout=timeout)
             except asyncio.TimeoutError:
                 logger.warning("Insert producer did not finish within timeout")
             except Exception:

--- a/tests/integration_tests/test_error_handling.py
+++ b/tests/integration_tests/test_error_handling.py
@@ -2,8 +2,10 @@ import logging
 
 import aiohttp
 import pytest
+import urllib3.exceptions
 
 from clickhouse_connect.driver.exceptions import DatabaseError, OperationalError
+from clickhouse_connect.driver.options import pd
 from tests.integration_tests.conftest import TestConfig
 
 
@@ -134,3 +136,75 @@ async def test_async_retry_on_connection_reset(test_native_async_client, mocker)
 
     assert attempts == 2
     assert result.result_rows[0][0] == 79
+
+
+def _install_one_shot_reset_mock(client, client_mode, mocker):
+    """Drain and reset the first generator-bodied request, then defer to the real transport."""
+    attempts = [0]
+
+    if client_mode == "sync":
+        real_request = client.http.request
+
+        def flaky_request(method, url, **kwargs):
+            body = kwargs.get("body")
+            if body is not None and not isinstance(body, (bytes, bytearray, str)):
+                attempts[0] += 1
+                if attempts[0] == 1:
+                    for _ in body:
+                        pass
+                    try:
+                        raise ConnectionResetError("Connection reset by peer")
+                    except ConnectionResetError:
+                        raise urllib3.exceptions.ProtocolError("Connection aborted.")  # noqa: B904
+            return real_request(method, url, **kwargs)
+
+        mocker.patch.object(client.http, "request", side_effect=flaky_request)
+    else:
+        real_request = client._session.request
+
+        async def flaky_request(*args, **kwargs):
+            data = kwargs.get("data")
+            if data is not None and hasattr(data, "__aiter__"):
+                attempts[0] += 1
+                if attempts[0] == 1:
+                    async for _ in data:
+                        pass
+                    raise aiohttp.ServerDisconnectedError("Connection reset by peer")
+            return await real_request(*args, **kwargs)
+
+        mocker.patch.object(client._session, "request", side_effect=flaky_request)
+
+    return lambda: attempts[0]
+
+
+def test_insert_retry_on_connection_reset(param_client, call, client_mode, table_context, mocker):
+    """Insert retries and succeeds when the first attempt is hit by a connection reset."""
+    with table_context("insert_retry_reset", ["key Int32", "name String"]):
+        attempts = _install_one_shot_reset_mock(param_client, client_mode, mocker)
+
+        call(
+            param_client.insert,
+            "insert_retry_reset",
+            [[13, "user_1"], [79, "user_2"]],
+            column_names=["key", "name"],
+        )
+        assert attempts() == 2
+
+        rows = call(param_client.query, "SELECT key, name FROM insert_retry_reset ORDER BY key").result_rows
+        assert rows == [(13, "user_1"), (79, "user_2")]
+
+
+def test_insert_df_retry_on_connection_reset(param_client, call, client_mode, table_context, mocker):
+    """insert_df retries and succeeds when the first attempt is hit by a connection reset."""
+    if pd is None:
+        pytest.skip("pandas not available")
+
+    with table_context("insert_df_retry_reset", ["key Int32", "name String"]):
+        attempts = _install_one_shot_reset_mock(param_client, client_mode, mocker)
+
+        df = pd.DataFrame({"key": [13, 79], "name": ["user_1", "user_2"]})
+        call(param_client.insert_df, "insert_df_retry_reset", df)
+        assert attempts() == 2
+
+        rows = call(param_client.query, "SELECT key, name FROM insert_df_retry_reset ORDER BY key").result_rows
+        assert rows == [(13, "user_1"), (79, "user_2")]


### PR DESCRIPTION
## Summary
Fixes intermittent `Code: 62 Empty query (SYNTAX_ERROR)` on inserts when a pooled keep-alive connection was reset between attempts. The retry path replayed an already-drained generator body, sending zero bytes to the server. `_raw_request` (sync and async) now accepts a `retry_body` callable. `data_insert` passes one that resets the `InsertContext` cursor and rebuilds a fresh generator/`StreamingInsertSource` before retry. Replayable bodies (bytes/str/None, plus dict on async) keep retrying as before.

Closes #731

## Checklist
Delete items not relevant to your PR:
- [X] Unit and integration tests covering the common scenarios were added
- [X] A human-readable description of the changes was provided to include in CHANGELOG
- [ ] For significant changes, documentation in https://github.com/ClickHouse/clickhouse-docs was updated with further explanations or tutorials
