### PR TITLE
Fix SQLAlchemy ILIKE and NOT ILIKE rendering

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 ### Bug Fixes
 - Fix intermittent `Code: 62. Empty query. (SYNTAX_ERROR)` on inserts when a pooled keep-alive connection is reset between attempts. The retry path now rebuilds the insert body instead of replaying an already-drained generator. Affects both sync and async clients. Closes [#731](https://github.com/ClickHouse/clickhouse-connect/issues/731)
+- Fix SQLAlchemy dialect rendering for `ILIKE` and `NOT ILIKE` expressions to use native ClickHouse syntax instead of the generic SQLAlchemy `lower(...) LIKE lower(...)` fallback.
 
 ## 1.0.0rc2, 2026-05-05
 

--- a/clickhouse_connect/cc_sqlalchemy/sql/compiler.py
+++ b/clickhouse_connect/cc_sqlalchemy/sql/compiler.py
@@ -261,3 +261,13 @@ class ChStatementCompiler(SQLCompiler):
             if mods and alias in mods:
                 result += " " + mods[alias]
         return result
+
+    def visit_ilike_op_binary(self, binary, operator, **kw):
+        left = self.process(binary.left, **kw)
+        right = self.process(binary.right, **kw)
+        return f"{left} ILIKE {right}"
+
+    def visit_not_ilike_op_binary(self, binary, operator, **kw):
+        left = self.process(binary.left, **kw)
+        right = self.process(binary.right, **kw)
+        return f"{left} NOT ILIKE {right}"

--- a/clickhouse_connect/cc_sqlalchemy/sql/compiler.py
+++ b/clickhouse_connect/cc_sqlalchemy/sql/compiler.py
@@ -40,6 +40,10 @@ def _resolve_ch_type_name(sqla_type):
 
 
 class ChStatementCompiler(SQLCompiler):
+    def _raise_on_escape(self, binary, operator_name: str):
+        if binary.modifiers.get("escape") is not None:
+            raise CompileError(f"ClickHouse does not support the ESCAPE clause on {operator_name}")
+
     def visit_delete(self, delete_stmt, visiting_cte=None, **kw):
         table = delete_stmt.table
         text = f"DELETE FROM {format_table(table)}"
@@ -262,12 +266,22 @@ class ChStatementCompiler(SQLCompiler):
                 result += " " + mods[alias]
         return result
 
+    def visit_like_op_binary(self, binary, operator, **kw):
+        self._raise_on_escape(binary, "LIKE")
+        return super().visit_like_op_binary(binary, operator, **kw)
+
+    def visit_not_like_op_binary(self, binary, operator, **kw):
+        self._raise_on_escape(binary, "LIKE")
+        return super().visit_not_like_op_binary(binary, operator, **kw)
+
     def visit_ilike_op_binary(self, binary, operator, **kw):
+        self._raise_on_escape(binary, "ILIKE")
         left = self.process(binary.left, **kw)
         right = self.process(binary.right, **kw)
         return f"{left} ILIKE {right}"
 
     def visit_not_ilike_op_binary(self, binary, operator, **kw):
+        self._raise_on_escape(binary, "ILIKE")
         left = self.process(binary.left, **kw)
         right = self.process(binary.right, **kw)
         return f"{left} NOT ILIKE {right}"

--- a/tests/unit_tests/test_sqlalchemy/test_ilike.py
+++ b/tests/unit_tests/test_sqlalchemy/test_ilike.py
@@ -1,0 +1,20 @@
+from sqlalchemy import column, table
+
+from clickhouse_connect import dbapi
+from clickhouse_connect.cc_sqlalchemy.dialect import ClickHouseDialect
+
+
+def _compile_clause(clause):
+    return str(clause.compile(dialect=ClickHouseDialect(dbapi=dbapi)))
+
+
+def test_ilike_compiles_to_clickhouse_ilike():
+    users = table("users", column("name"))
+
+    assert _compile_clause(users.c.name.ilike("%user_1%")) == "`users`.`name` ILIKE %(name_1)s"
+
+
+def test_not_ilike_compiles_to_clickhouse_not_ilike():
+    users = table("users", column("name"))
+
+    assert _compile_clause(users.c.name.not_ilike("%user_1%")) == "`users`.`name` NOT ILIKE %(name_1)s"

--- a/tests/unit_tests/test_sqlalchemy/test_ilike.py
+++ b/tests/unit_tests/test_sqlalchemy/test_ilike.py
@@ -1,4 +1,6 @@
+import pytest
 from sqlalchemy import column, table
+from sqlalchemy.exc import CompileError
 
 from clickhouse_connect import dbapi
 from clickhouse_connect.cc_sqlalchemy.dialect import ClickHouseDialect
@@ -18,3 +20,26 @@ def test_not_ilike_compiles_to_clickhouse_not_ilike():
     users = table("users", column("name"))
 
     assert _compile_clause(users.c.name.not_ilike("%user_1%")) == "`users`.`name` NOT ILIKE %(name_1)s"
+
+
+def test_like_compiles_without_escape_clause():
+    users = table("users", column("name"))
+
+    assert _compile_clause(users.c.name.like("%user_1%")) == "`users`.`name` LIKE %(name_1)s"
+
+
+@pytest.mark.parametrize(
+    ("clause_name", "operator_name"),
+    (
+        ("like", "LIKE"),
+        ("not_like", "LIKE"),
+        ("ilike", "ILIKE"),
+        ("not_ilike", "ILIKE"),
+    ),
+)
+def test_like_escape_clause_raises_compile_error(clause_name, operator_name):
+    users = table("users", column("name"))
+    clause = getattr(users.c.name, clause_name)("%!_%", escape="!")
+
+    with pytest.raises(CompileError, match=f"ClickHouse does not support the ESCAPE clause on {operator_name}"):
+        _compile_clause(clause)


### PR DESCRIPTION
## Summary
Fixes SQLAlchemy dialect rendering for `ILIKE` and `NOT ILIKE` expressions.

SQLAlchemy's generic compiler fallback renders `ilike()` / `not_ilike()` as `lower(...) LIKE lower(...)` / `lower(...) NOT LIKE lower(...)`, which can break matching logic for non-ASCII text. ClickHouse supports native `ILIKE`, so the dialect now renders these expressions directly as `ILIKE` and `NOT ILIKE`.

## Checklist
Delete items not relevant to your PR:
- [x] Unit tests covering the common scenarios were added
- [x] A human-readable description of the changes was provided to include in CHANGELOG