### PR TITLE
Joe/742 async client does not support ca certcertifi

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Bug Fixes
 - Async client: `ca_cert="certifi"` shorthand now resolves to `certifi.where()`, matching the sync client. Previously the async path passed the literal string to `ssl_context.load_verify_locations`, producing `FileNotFoundError`. Closes [#742](https://github.com/ClickHouse/clickhouse-connect/issues/742)
+- Fix SQLAlchemy dialect rendering for `ILIKE` and `NOT ILIKE` expressions to use native ClickHouse syntax instead of the generic SQLAlchemy `lower(...) LIKE lower(...)` fallback.
 
 ## 1.0.0, 2026-05-13
 
@@ -15,7 +16,6 @@ Upgrading from a 0.15.x or earlier release? See [MIGRATION.md](MIGRATION.md) for
 
 ### Bug Fixes
 - Fix intermittent `Code: 62. Empty query. (SYNTAX_ERROR)` on inserts when a pooled keep-alive connection is reset between attempts. The retry path now rebuilds the insert body instead of replaying an already-drained generator. Affects both sync and async clients. Closes [#731](https://github.com/ClickHouse/clickhouse-connect/issues/731)
-- Fix SQLAlchemy dialect rendering for `ILIKE` and `NOT ILIKE` expressions to use native ClickHouse syntax instead of the generic SQLAlchemy `lower(...) LIKE lower(...)` fallback.
 
 ## 1.0.0rc2, 2026-05-05
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## UNRELEASED
 
+### Bug Fixes
+- Async client: `ca_cert="certifi"` shorthand now resolves to `certifi.where()`, matching the sync client. Previously the async path passed the literal string to `ssl_context.load_verify_locations`, producing `FileNotFoundError`. Closes [#742](https://github.com/ClickHouse/clickhouse-connect/issues/742)
+
 ## 1.0.0, 2026-05-13
 
 No code changes since `1.0.0rc3`. See the `1.0.0rc1`, `1.0.0rc2`, and `1.0.0rc3` entries below for the full set of changes included in the 1.0.0 release.

--- a/clickhouse_connect/driver/asyncclient.py
+++ b/clickhouse_connect/driver/asyncclient.py
@@ -231,7 +231,7 @@ class AsyncClient(Client):
                 ssl_context.check_hostname = False
                 ssl_context.verify_mode = ssl.CERT_NONE
             elif ca_cert:
-                ssl_context.load_verify_locations(ca_cert)
+                ssl_context.load_verify_locations(httputil.resolve_ca_cert(ca_cert))
             if client_cert:
                 ssl_context.load_cert_chain(client_cert, client_cert_key)
 

--- a/clickhouse_connect/driver/httputil.py
+++ b/clickhouse_connect/driver/httputil.py
@@ -52,6 +52,12 @@ def close_managers():
         manager.clear()
 
 
+def resolve_ca_cert(ca_cert: str | None) -> str | None:
+    if ca_cert == "certifi":
+        return certifi.where()
+    return ca_cert
+
+
 def get_pool_manager_options(
     keep_interval: int = DEFAULT_KEEP_INTERVAL,
     keep_count: int = DEFAULT_KEEP_COUNT,
@@ -73,8 +79,7 @@ def get_pool_manager_options(
         socket_options.append((SOCKET_TCP, getattr(socket, "TCP_KEEPALIVE", 0x10), keep_interval))
     options["maxsize"] = options.get("maxsize", 8)
     options["retries"] = options.get("retries", 1)
-    if ca_cert == "certifi":
-        ca_cert = certifi.where()
+    ca_cert = resolve_ca_cert(ca_cert)
     options["cert_reqs"] = "CERT_REQUIRED" if verify else "CERT_NONE"
     if ca_cert:
         options["ca_certs"] = ca_cert


### PR DESCRIPTION
The async client documented support for `ca_cert="certifi"` but passed the literal string to `ssl_context.load_verify_locations`, producing `FileNotFoundError`. Sync client transformed it to `certifi.where()` inside `httputil.get_pool_manager_options`.

The code now extracts to `resolve_ca_cert` helper in `httputil.py` and  both `get_pool_manager_options` (sync) and `AsyncClient.__init__` (async) now route through it.

Closes #742.

## Checklist
Delete items not relevant to your PR:
- X ] A human-readable description of the changes was provided to include in CHANGELOG