### PR TITLE
drain in-flight requests before closing async session

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## UNRELEASED
 
 ### Bug Fixes
+- Async client: drain in-flight requests before closing the underlying aiohttp session. Sharing a single `AsyncClient` across concurrent coroutines previously raised `RuntimeError: Session is closed` (and related `Connection reset` / `QUERY_WITH_SAME_ID_IS_ALREADY_RUNNING` cascades) whenever `max_connection_age` triggered a pool rotation while other tasks had requests in flight. `close_connections()` now installs the new session before retiring the old one, and waits for outstanding requests (including streaming responses) to release their lease before tearing it down. `close()` clears `self._session` so post-close calls fail with `ProgrammingError` instead of leaking aiohttp's `RuntimeError`. Closes [#744](https://github.com/ClickHouse/clickhouse-connect/issues/744)
 - Async client: `ca_cert="certifi"` shorthand now resolves to `certifi.where()`, matching the sync client. Previously the async path passed the literal string to `ssl_context.load_verify_locations`, producing `FileNotFoundError`. Closes [#742](https://github.com/ClickHouse/clickhouse-connect/issues/742)
 - Fix SQLAlchemy dialect rendering for `ILIKE` and `NOT ILIKE` expressions to use native ClickHouse syntax instead of the generic SQLAlchemy `lower(...) LIKE lower(...)` fallback.
 

--- a/clickhouse_connect/driver/asyncclient.py
+++ b/clickhouse_connect/driver/asyncclient.py
@@ -98,6 +98,53 @@ class BytesSource:
         """No-op close method for compatibility."""
 
 
+class _SessionLease:
+    """An aiohttp.ClientSession with an in-flight request count, so close()
+    can wait for outstanding requests to drain before tearing down the session."""
+
+    __slots__ = ("session", "_inflight", "_drained")
+
+    def __init__(self, session: aiohttp.ClientSession):
+        self.session = session
+        self._inflight = 0
+        self._drained = asyncio.Event()
+        self._drained.set()
+
+    def acquire(self) -> None:
+        self._inflight += 1
+        if self._inflight == 1:
+            self._drained.clear()
+
+    def release(self) -> None:
+        self._inflight -= 1
+        if self._inflight == 0:
+            self._drained.set()
+
+    async def wait_drained(self) -> None:
+        await self._drained.wait()
+
+
+def _one_shot(fn: Callable[[], None]) -> Callable[[], None]:
+    """Returns a wrapper that invokes fn at most once."""
+    fired = False
+
+    def call():
+        nonlocal fired
+        if not fired:
+            fired = True
+            fn()
+
+    return call
+
+
+def _release_lease(response: aiohttp.ClientResponse | None) -> None:
+    if response is None:
+        return
+    release = getattr(response, "_lease_release", None)
+    if release is not None:
+        release()
+
+
 class AsyncClient(Client):
     valid_transport_settings = {
         "database",
@@ -250,7 +297,8 @@ class AsyncClient(Client):
         if sys.version_info < (3, 12, 7) or sys.version_info[:3] == (3, 13, 0):
             self._connector_kwargs["enable_cleanup_closed"] = True
 
-        self._session = None
+        self._session_lease: _SessionLease | None = None
+        self._session_lock = asyncio.Lock()
         self._read_format = "Native"
         self._write_format = "Native"
         self._transform = NativeTransform()
@@ -283,6 +331,15 @@ class AsyncClient(Client):
             show_clickhouse_errors=show_clickhouse_errors,
             autoconnect=False,
         )
+
+    @property
+    def _session(self) -> aiohttp.ClientSession | None:
+        lease = self._session_lease
+        return lease.session if lease is not None else None
+
+    @_session.setter
+    def _session(self, value: aiohttp.ClientSession | None) -> None:
+        self._session_lease = _SessionLease(value) if value is not None else None
 
     async def _initialize(self):
         """
@@ -420,22 +477,31 @@ class AsyncClient(Client):
         return False
 
     async def close(self):  # type: ignore[override]
-        if self._session:
-            await self._session.close()
+        async with self._session_lock:
+            old_lease = self._session_lease
+            self._session_lease = None
+        if old_lease is not None:
+            await old_lease.wait_drained()
+            await old_lease.session.close()
 
     async def close_connections(self):  # type: ignore[override]
-        """Close all pooled connections and recreate session"""
-        if self._session:
-            await self._session.close()
-        connector = aiohttp.TCPConnector(**self._connector_kwargs)
-        self._session = aiohttp.ClientSession(
-            connector=connector,
-            timeout=self._timeout,
-            headers=self.headers,
-            trust_env=False,
-            auto_decompress=False,
-            skip_auto_headers={"Accept-Encoding"},
-        )
+        """Rotate the connection pool: new requests use a fresh session; in-flight
+        requests keep using the old session until they complete, then it's closed."""
+        async with self._session_lock:
+            old_lease = self._session_lease
+            connector = aiohttp.TCPConnector(**self._connector_kwargs)
+            new_session = aiohttp.ClientSession(
+                connector=connector,
+                timeout=self._timeout,
+                headers=self.headers,
+                trust_env=False,
+                auto_decompress=False,
+                skip_auto_headers={"Accept-Encoding"},
+            )
+            self._session_lease = _SessionLease(new_session)
+        if old_lease is not None:
+            await old_lease.wait_drained()
+            await old_lease.session.close()
 
     def set_client_setting(self, key, value):
         str_value = self._validate_setting(key, value, common.get_setting("invalid_setting_action"))
@@ -496,8 +562,11 @@ class AsyncClient(Client):
                 params.update(context.bind_params)
                 response = await self._raw_request(fmt_json_query, params, headers, retries=self.query_retries)
 
-            body = await response.read()
-            encoding = response.headers.get("Content-Encoding")
+            try:
+                body = await response.read()
+                encoding = response.headers.get("Content-Encoding")
+            finally:
+                _release_lease(response)
             loop = asyncio.get_running_loop()
 
             def decompress_and_parse_json():
@@ -874,9 +943,12 @@ class AsyncClient(Client):
         headers = dict_copy(headers, transport_settings)
         method = "POST" if payload or files else "GET"
         response = await self._raw_request(payload, params, headers, files=files, method=method, server_wait=False)
-        body = await response.read()
-        encoding = response.headers.get("Content-Encoding")
-        summary = self._summary(response)
+        try:
+            body = await response.read()
+            encoding = response.headers.get("Content-Encoding")
+            summary = self._summary(response)
+        finally:
+            _release_lease(response)
 
         if not body:
             return QuerySummary(summary)
@@ -902,14 +974,22 @@ class AsyncClient(Client):
         return await loop.run_in_executor(None, decompress_and_decode)
 
     async def ping(self) -> bool:  # type: ignore[override]
+        async with self._session_lock:
+            lease = self._session_lease
+            if lease is None or lease.session.closed:
+                return False
+            session = lease.session
+            lease.acquire()
         try:
             url = f"{self.url}/ping"
             timeout = aiohttp.ClientTimeout(total=3.0)
-            async with self._session.get(url, timeout=timeout) as response:
+            async with session.get(url, timeout=timeout) as response:
                 return 200 <= response.status < 300
         except (aiohttp.ClientError, asyncio.TimeoutError):
             logger.debug("ping failed", exc_info=True)
             return False
+        finally:
+            lease.release()
 
     async def raw_query(  # type: ignore[override]
         self,
@@ -929,8 +1009,11 @@ class AsyncClient(Client):
             headers = dict_copy(headers, transport_settings)
 
         response = await self._raw_request(body, params, headers=headers, files=files, retries=self.query_retries)
-        response_data = await response.read()
-        encoding = response.headers.get("Content-Encoding")
+        try:
+            response_data = await response.read()
+            encoding = response.headers.get("Content-Encoding")
+        finally:
+            _release_lease(response)
 
         if encoding:
             loop = asyncio.get_running_loop()
@@ -961,7 +1044,14 @@ class AsyncClient(Client):
             async for chunk in response.content.iter_any():
                 yield chunk
 
-        return StreamContext(response, byte_iterator())
+        class _RawStreamSource:
+            def close(self):
+                try:
+                    response.close()
+                finally:
+                    _release_lease(response)
+
+        return StreamContext(_RawStreamSource(), byte_iterator())
 
     def _prep_raw_query(self, query, parameters, settings, fmt, use_database, external_data):
         """
@@ -1578,6 +1668,7 @@ class AsyncClient(Client):
         params.update(self._validate_settings(context.settings))
         headers = dict_copy(headers, context.transport_settings)
 
+        response = None
         try:
             response = await self._raw_request(
                 active_source.async_generator(),
@@ -1587,6 +1678,7 @@ class AsyncClient(Client):
                 retry_body=rebuild_body,
             )
             logger.debug("Context insert response code: %d", response.status)
+            summary = self._summary(response)
         except Exception:
             await active_source.close()
 
@@ -1598,8 +1690,11 @@ class AsyncClient(Client):
         finally:
             await active_source.close()
             context.data = None
+            if response is not None:
+                response.close()
+                _release_lease(response)
 
-        return QuerySummary(self._summary(response))
+        return QuerySummary(summary)
 
     async def insert_df(  # type: ignore[override]
         self,
@@ -1684,8 +1779,12 @@ class AsyncClient(Client):
         headers = dict_copy(headers, transport_settings)
 
         response = await self._raw_request(insert_block, params, headers, server_wait=False)
-        logger.debug("Raw insert response code: %d", response.status)
-        return QuerySummary(self._summary(response))
+        try:
+            logger.debug("Raw insert response code: %d", response.status)
+            return QuerySummary(self._summary(response))
+        finally:
+            response.close()
+            _release_lease(response)
 
     def _add_integration_tag(self, name: str):
         """
@@ -1799,9 +1898,10 @@ class AsyncClient(Client):
             if self._last_pool_reset is None:
                 self._last_pool_reset = now
             elif self._last_pool_reset < now - reset_seconds:
+                # Stamp before await so concurrent callers don't all queue redundant resets.
+                self._last_pool_reset = now
                 logger.debug("connection expiration - resetting connection pool")
                 await self.close_connections()
-                self._last_pool_reset = now
 
         final_params = dict_copy(self._client_settings, params)
         if server_wait:
@@ -1830,6 +1930,17 @@ class AsyncClient(Client):
                     )
                 self._active_session = query_session
 
+            # Snapshot+acquire under lock so close_connections() can't pass the
+            # drain check between our session read and our refcount increment.
+            async with self._session_lock:
+                lease = self._session_lease
+                if lease is None or lease.session.closed:
+                    if query_session:
+                        self._active_session = None
+                    raise ProgrammingError("Client session is unavailable; the client may have been closed.")
+                session = lease.session
+                lease.acquire()
+            lease_released = False
             try:
                 # Construct full URL (aiohttp doesn't have base_url)
                 url = f"{self.url}/"
@@ -1857,8 +1968,11 @@ class AsyncClient(Client):
                 else:
                     request_kwargs["data"] = data
 
-                response = await self._session.request(**request_kwargs)
+                response = await session.request(**request_kwargs)
                 if 200 <= response.status < 300 and not response.headers.get(ex_header):
+                    # Caller releases lease after consuming the body.
+                    response._lease_release = _one_shot(lease.release)
+                    lease_released = True
                     return response
 
                 if response.status in (429, 503, 504):
@@ -1888,6 +2002,8 @@ class AsyncClient(Client):
                 raise OperationalError(f"Network Error: {str(e)}") from e
 
             finally:
+                if not lease_released:
+                    lease.release()
                 if query_session:
                     self._active_session = None
 

--- a/clickhouse_connect/driver/streaming.py
+++ b/clickhouse_connect/driver/streaming.py
@@ -46,6 +46,11 @@ class StreamingResponseSource(Closable):
         self._producer_error: Exception | None = None
         self._producer_completed = False
 
+    def _release_lease(self):
+        release = getattr(self.response, "_lease_release", None)
+        if release is not None:
+            release()
+
     async def start_producer(self, loop: asyncio.AbstractEventLoop):
         """Start the async producer task.
         Must be called from the event loop thread before consuming.
@@ -78,6 +83,7 @@ class StreamingResponseSource(Closable):
 
             finally:
                 self.queue.shutdown()
+                self._release_lease()
 
         self._producer_task = loop.create_task(producer())
         self._producer_started.set()
@@ -179,6 +185,7 @@ class StreamingResponseSource(Closable):
             if not self._producer_completed:
                 self.response.close()
                 await asyncio.sleep(0.05)
+        self._release_lease()
 
     def close(self):
         """Synchronous cleanup resources"""
@@ -190,6 +197,7 @@ class StreamingResponseSource(Closable):
         if self.response and not self.response.closed:
             if not self._producer_completed:
                 self.response.close()
+        self._release_lease()
 
 
 class StreamingFileAdapter:

--- a/tests/integration_tests/test_async_features.py
+++ b/tests/integration_tests/test_async_features.py
@@ -84,9 +84,9 @@ async def test_context_manager_cleanup(test_config):
         result = await client.query("SELECT 1")
         assert result.result_rows[0][0] == 1
 
-    assert client._session is None or client._session.closed
+    assert client._session is None
 
-    with pytest.raises((RuntimeError, OperationalError)):
+    with pytest.raises((ProgrammingError, RuntimeError, OperationalError)):
         await client.query("SELECT 1")
 
 
@@ -287,3 +287,137 @@ async def test_async_insert_df_arrow(test_config, table_context: Callable):
             await client.insert_df_arrow("test_async_df_arrow_i", df)
             res = await client.query("SELECT * FROM test_async_df_arrow_i ORDER BY i64")
             assert res.result_rows == [(51, 421, "b"), (78, None, "a")]
+
+
+@pytest.mark.asyncio
+async def test_close_connections_replaces_session_atomically(test_config):
+    """Test close_connections() installs the new session before closing the old."""
+    async with await get_async_client(**make_client_config(test_config)) as client:
+        old_session = client._session
+        await client.close_connections()
+        assert client._session is not None
+        assert not client._session.closed
+        assert client._session is not old_session
+        assert old_session.closed
+
+
+@pytest.mark.asyncio
+async def test_close_clears_session_reference(test_config):
+    """Test close() must clear self._session so post-close calls fail cleanly."""
+    client = await get_async_client(**make_client_config(test_config))
+    await client.query("SELECT 1")
+    await client.close()
+    assert client._session is None
+    with pytest.raises(ProgrammingError):
+        await client.query("SELECT 1")
+
+
+@pytest.mark.asyncio
+async def test_concurrent_queries_survive_pool_reset(test_config):
+    """Test concurrent queries complete without errors across direct close_connections() calls."""
+    async with await get_async_client(**make_client_config(test_config, autogenerate_session_id=False)) as client:
+        stop = asyncio.Event()
+
+        async def worker(idx: int) -> int:
+            count = 0
+            while not stop.is_set():
+                result = await client.query(f"SELECT {idx}, {count}")
+                assert result.result_rows[0] == (idx, count)
+                count += 1
+                await asyncio.sleep(0.01)
+            return count
+
+        async def pool_resetter() -> None:
+            while not stop.is_set():
+                await asyncio.sleep(0.3)
+                await client.close_connections()
+
+        workers = [asyncio.create_task(worker(i)) for i in range(6)]
+        resetter = asyncio.create_task(pool_resetter())
+
+        await asyncio.sleep(2.0)
+        stop.set()
+
+        worker_counts = await asyncio.gather(*workers)
+        await resetter
+        assert all(c > 0 for c in worker_counts)
+
+
+@pytest.mark.asyncio
+async def test_long_query_survives_pool_reset(test_config):
+    """Test a SELECT sleep(1) on the old session completes even when close_connections() rotates the pool mid-flight."""
+    async with await get_async_client(**make_client_config(test_config, autogenerate_session_id=False)) as client:
+
+        async def reset_after_delay():
+            await asyncio.sleep(0.2)
+            await client.close_connections()
+
+        long_task = asyncio.create_task(client.query("SELECT sleep(1), 79"))
+        reset_task = asyncio.create_task(reset_after_delay())
+
+        result = await long_task
+        await reset_task
+        assert result.result_rows[0][1] == 79
+
+
+@pytest.mark.asyncio
+async def test_ping_survives_pool_reset(test_config):
+    """Test ping() takes the lease and doesn't fail when close_connections() rotates the pool."""
+    async with await get_async_client(**make_client_config(test_config, autogenerate_session_id=False)) as client:
+        stop = asyncio.Event()
+
+        async def pinger() -> int:
+            count = 0
+            while not stop.is_set():
+                assert await client.ping() is True
+                count += 1
+                await asyncio.sleep(0.01)
+            return count
+
+        async def pool_resetter() -> None:
+            while not stop.is_set():
+                await asyncio.sleep(0.05)
+                await client.close_connections()
+
+        pingers = [asyncio.create_task(pinger()) for _ in range(4)]
+        resetter = asyncio.create_task(pool_resetter())
+
+        await asyncio.sleep(1.5)
+        stop.set()
+
+        counts = await asyncio.gather(*pingers)
+        await resetter
+        assert all(c > 0 for c in counts)
+
+
+@pytest.mark.asyncio
+async def test_max_connection_age_trigger_path(test_config):
+    """Test the max_connection_age auto-reset path."""
+    from clickhouse_connect import common as cc_common
+
+    original = cc_common.get_setting("max_connection_age")
+    cc_common.set_setting("max_connection_age", 1)
+    try:
+        async with await get_async_client(**make_client_config(test_config, autogenerate_session_id=False)) as client:
+            initial_session = client._session
+            await client.query("SELECT 1")
+            await asyncio.sleep(1.2)
+
+            stop = asyncio.Event()
+
+            async def worker(idx: int) -> int:
+                count = 0
+                while not stop.is_set():
+                    result = await client.query(f"SELECT {idx}, {count}, sleep(0.1)")
+                    assert result.result_rows[0][:2] == (idx, count)
+                    count += 1
+                return count
+
+            workers = [asyncio.create_task(worker(i)) for i in range(4)]
+            await asyncio.sleep(1.5)
+            stop.set()
+            counts = await asyncio.gather(*workers)
+            assert all(c > 0 for c in counts)
+            assert client._session is not initial_session
+    finally:
+        cc_common.set_setting("max_connection_age", original)


### PR DESCRIPTION
## Summary
Fixes `RuntimeError: Session is closed` (and related `Connection reset` / `QUERY_WITH_SAME_ID_IS_ALREADY_RUNNING` cascades) raised by `AsyncClient` when `max_connection_age` triggers a pool rotation while other coroutines have requests in flight on the same client.

This happens because `AsyncClient.close_connections()` closes the old `aiohttp.ClientSession` before installing the new one and aggressively tore down its connector which terminated any request in flight on the old session. `AsyncClient.close()` also left `self._session` pointing at a closed session, defeating the post-close guard.

This fix treats `close_connections()` as a pool rotation rather than a hard close.

Specifically,

- `AsyncClient` now wraps its session in a private `_SessionLease` that refcounts in-flight requests with an `asyncio.Event` drain signal.
- `_raw_request` and `ping()` snapshot & acquire the lease under `self._session_lock`. The lock is held only for the snapshot, not the HTTP request so a concurrent rotation can't slip between the open-session check and the refcount increment.
- The lease release is wired through every response consumption site (materialized `read()`, `command`, `raw_query`, `raw_stream`, `_insert_with_context`, `raw_insert`, the JSON-meta path) and through `StreamingResponseSource`'s producer-finally and `close()`/`aclose()`.
- `close_connections()` installs the new session synchronously under the lock, then `wait_drained()` + closes the old session outside the lock. `close()` clears `self._session` so post-close calls raise `ProgrammingError`.

## Behavior changes
- None in public API surface.
- `close()` and `close_connections()` now block until in-flight requests drain. Long-lived user-held streams will hold the rotation. In practice this I think this should be very rare and easy to diagnose.
- Post-`close()` calls raise `ProgrammingError` instead of leaking aiohttp's `RuntimeError`.

Closes #744

## Checklist
Delete items not relevant to your PR:
- [X] Unit and integration tests covering the common scenarios were added
- [X] A human-readable description of the changes was provided to include in CHANGELOG
- [ ] For significant changes, documentation in https://github.com/ClickHouse/clickhouse-docs was updated with further explanations or tutorials
