### PR TITLE
bump deprecated node 20 actions and refresh server test matrix

### DIFF
--- a/.github/workflows/clickhouse_ci.yml
+++ b/.github/workflows/clickhouse_ci.yml
@@ -14,9 +14,9 @@ jobs:
       CLICKHOUSE_CONNECT_TEST_FUZZ: 50
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
       - name: Set up Python 3.11
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: 3.11
       - name: Install pip
@@ -39,8 +39,14 @@ jobs:
         run: pytest tests/integration_tests -n 4
 
       - name: Run ClickHouse Container (HEAD)
-        run: CLICKHOUSE_CONNECT_TEST_CH_VERSION=head docker compose up -d clickhouse
+        env:
+          CLICKHOUSE_CONNECT_TEST_CH_VERSION: head
+          COMPOSE_PROJECT_NAME: clickhouse-connect-ci
+        run: docker compose -f docker-compose.yml up -d --wait clickhouse
       - name: Run HEAD tests
         run: pytest tests/integration_tests -n 4
       - name: remove HEAD container
-        run: docker compose down -v
+        if: ${{ always() && hashFiles('docker-compose.yml') != '' }}
+        env:
+          COMPOSE_PROJECT_NAME: clickhouse-connect-ci
+        run: docker compose -f docker-compose.yml down --volumes --remove-orphans

--- a/.github/workflows/on_push.yml
+++ b/.github/workflows/on_push.yml
@@ -30,9 +30,9 @@ jobs:
     runs-on: ubuntu-latest
     name: Ruff
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - name: Set up Python 3.11
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: "3.11"
       - name: Install Ruff
@@ -50,16 +50,14 @@ jobs:
     name: Bare Install Test (no extras)
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
       - name: Start ClickHouse (latest) in Docker
-        uses: hoverkraft-tech/compose-action@v2.0.0
         env:
           CLICKHOUSE_CONNECT_TEST_CH_VERSION: latest
-        with:
-          compose-file: 'docker-compose.yml'
-          down-flags: '--volumes'
+          COMPOSE_PROJECT_NAME: clickhouse-connect-ci
+        run: docker compose -f docker-compose.yml up -d --wait
       - name: Set up Python 3.12
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: '3.12'
       - name: Install only core dependencies (no extras)
@@ -69,6 +67,11 @@ jobs:
           pip install certifi urllib3 zstandard lz4
       - name: Bare import test and basic query
         run: python tests/test_bare_install.py
+      - name: Stop ClickHouse
+        if: ${{ always() && hashFiles('docker-compose.yml') != '' }}
+        env:
+          COMPOSE_PROJECT_NAME: clickhouse-connect-ci
+        run: docker compose -f docker-compose.yml down --volumes --remove-orphans
 
   tests:
     runs-on: ubuntu-latest
@@ -82,34 +85,31 @@ jobs:
           - '3.13'
           - '3.14'
         clickhouse-version:
-          - '25.3' # LTS
           - '25.8' # LTS
-          - '25.12' # Stable
-          - '26.1' # Stable
           - '26.2' # Stable
+          - '26.3' # LTS
+          - '26.4' # Stable
         use-c:
           - '1'
         include:
           - python-version: '3.10'
-            clickhouse-version: '25.3'
+            clickhouse-version: '25.8'
             use-c: '0'
           - python-version: '3.14'
-            clickhouse-version: '26.2'
+            clickhouse-version: '26.4'
             use-c: '0'
 
     name: Local Tests Py=${{ matrix.python-version }} CH=${{ matrix.clickhouse-version }} C=${{ matrix.use-c }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
       - name: Start ClickHouse (version - ${{ matrix.clickhouse-version }}) in Docker
-        uses: hoverkraft-tech/compose-action@v2.0.0
         env:
           CLICKHOUSE_CONNECT_TEST_CH_VERSION: ${{ matrix.clickhouse-version }}
-        with:
-          compose-file: 'docker-compose.yml'
-          down-flags: '--volumes'
+          COMPOSE_PROJECT_NAME: clickhouse-connect-ci
+        run: docker compose -f docker-compose.yml up -d --wait
       - name: Set up Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: ${{ matrix.python-version }}
       - name: Install pip
@@ -131,6 +131,11 @@ jobs:
           CLICKHOUSE_CONNECT_TEST_FUZZ: 50
           SQLALCHEMY_SILENCE_UBER_WARNING: 1
         run: pytest -n 4 tests
+      - name: Stop ClickHouse
+        if: ${{ always() && hashFiles('docker-compose.yml') != '' }}
+        env:
+          COMPOSE_PROJECT_NAME: clickhouse-connect-ci
+        run: docker compose -f docker-compose.yml down --volumes --remove-orphans
 
   pandas-3x-compat-test:
     runs-on: ubuntu-latest
@@ -138,16 +143,14 @@ jobs:
     name: Pandas 3.x Compatibility Tests
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
       - name: Start ClickHouse (version - latest) in Docker
-        uses: hoverkraft-tech/compose-action@v2.0.0
         env:
           CLICKHOUSE_CONNECT_TEST_CH_VERSION: latest
-        with:
-          compose-file: 'docker-compose.yml'
-          down-flags: '--volumes'
+          COMPOSE_PROJECT_NAME: clickhouse-connect-ci
+        run: docker compose -f docker-compose.yml up -d --wait
       - name: Set up Python 3.12
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: '3.12'
       - name: Install pip
@@ -169,6 +172,11 @@ jobs:
           CLICKHOUSE_CONNECT_TEST_DOCKER: 'False'
           SQLALCHEMY_SILENCE_UBER_WARNING: 1
         run: pytest -n 4 tests/unit_tests/test_pandas.py tests/integration_tests/test_pandas.py tests/integration_tests/test_async_features.py -k "pandas or arrow"
+      - name: Stop ClickHouse
+        if: ${{ always() && hashFiles('docker-compose.yml') != '' }}
+        env:
+          COMPOSE_PROJECT_NAME: clickhouse-connect-ci
+        run: docker compose -f docker-compose.yml down --volumes --remove-orphans
 
   sqlalchemy-1x-compat-test:
     runs-on: ubuntu-latest
@@ -176,16 +184,14 @@ jobs:
     name: SQLAlchemy 1.x Compatibility Tests
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
       - name: Start ClickHouse (version - latest) in Docker
-        uses: hoverkraft-tech/compose-action@v2.0.0
         env:
           CLICKHOUSE_CONNECT_TEST_CH_VERSION: latest
-        with:
-          compose-file: 'docker-compose.yml'
-          down-flags: '--volumes'
+          COMPOSE_PROJECT_NAME: clickhouse-connect-ci
+        run: docker compose -f docker-compose.yml up -d --wait
       - name: Set up Python 3.11
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: '3.11'
       - name: Install pip
@@ -207,6 +213,11 @@ jobs:
           CLICKHOUSE_CONNECT_TEST_DOCKER: 'False'
           SQLALCHEMY_SILENCE_UBER_WARNING: 1
         run: pytest -n 4 tests/integration_tests/test_sqlalchemy
+      - name: Stop ClickHouse
+        if: ${{ always() && hashFiles('docker-compose.yml') != '' }}
+        env:
+          COMPOSE_PROJECT_NAME: clickhouse-connect-ci
+        run: docker compose -f docker-compose.yml down --volumes --remove-orphans
 
   check-secret:
     runs-on: ubuntu-latest
@@ -237,9 +248,9 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
       - name: Set up Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: ${{ matrix.python-version }}
       - name: Install dependencies

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -20,10 +20,10 @@ jobs:
       CIBW_SKIP: '*-musllinux* pp38-* pp39-* pp311-* cp38-* cp39-* cp313t-*'
       CIBW_ENABLE: 'pypy pypy-eol cpython-freethreading'
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - name: Build wheels
         uses: pypa/cibuildwheel@v3.2.1
-      - uses: actions/upload-artifact@v4
+      - uses: actions/upload-artifact@v7
         with:
           name: build-x86-manylinux
           path: ./wheelhouse/*.whl
@@ -35,10 +35,10 @@ jobs:
       CIBW_SKIP: '*-manylinux* pp38-* pp39-* pp311-* cp38-* cp39-* cp313t-*'
       CIBW_ENABLE: 'pypy pypy-eol cpython-freethreading'
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - name: Build wheels
         uses: pypa/cibuildwheel@v3.2.1
-      - uses: actions/upload-artifact@v4
+      - uses: actions/upload-artifact@v7
         with:
           name: build-x86-musllinux
           path: ./wheelhouse/*.whl
@@ -51,14 +51,14 @@ jobs:
       CIBW_SKIP: '*-musllinux* cp38-* cp39-* cp313t-*'
       CIBW_ENABLE: 'cpython-freethreading'
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - name: Set up QEMU
-        uses: docker/setup-qemu-action@v3
+        uses: docker/setup-qemu-action@v4
         with:
           platforms: all
       - name: Build wheels
         uses: pypa/cibuildwheel@v3.2.1
-      - uses: actions/upload-artifact@v4
+      - uses: actions/upload-artifact@v7
         with:
           name: build-aarch64-manylinux
           path: ./wheelhouse/*.whl
@@ -71,14 +71,14 @@ jobs:
       CIBW_SKIP: '*-manylinux* cp38-* cp39-* cp313t-*'
       CIBW_ENABLE: 'cpython-freethreading'
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - name: Set up QEMU
-        uses: docker/setup-qemu-action@v3
+        uses: docker/setup-qemu-action@v4
         with:
           platforms: all
       - name: Build wheels
         uses: pypa/cibuildwheel@v3.2.1
-      - uses: actions/upload-artifact@v4
+      - uses: actions/upload-artifact@v7
         with:
           name: build-aarch64-musllinux
           path: ./wheelhouse/*.whl
@@ -91,14 +91,14 @@ jobs:
       CIBW_BUILD: 'pp310-*'
       CIBW_ENABLE: 'pypy pypy-eol'
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - name: Set up QEMU
-        uses: docker/setup-qemu-action@v3
+        uses: docker/setup-qemu-action@v4
         with:
           platforms: all
       - name: Build wheels
         uses: pypa/cibuildwheel@v3.2.1
-      - uses: actions/upload-artifact@v4
+      - uses: actions/upload-artifact@v7
         with:
           name: build-aarch64-pypy
           path: ./wheelhouse/*.whl
@@ -111,12 +111,12 @@ jobs:
       CIBW_ENABLE: 'pypy pypy-eol cpython-freethreading'
       CIBW_SKIP: 'pp38-* pp39-* pp311-* cp38-* cp39-* cp313t-*'
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - name: Build wheels
         uses: pypa/cibuildwheel@v3.2.1
         env:
           CIBW_ARCHS_MACOS: x86_64 arm64
-      - uses: actions/upload-artifact@v4
+      - uses: actions/upload-artifact@v7
         with:
           name: build-macos
           path: ./wheelhouse/*.whl
@@ -129,10 +129,10 @@ jobs:
       CIBW_ENABLE: 'pypy pypy-eol cpython-freethreading'
       CIBW_SKIP: 'pp38-* pp39-* pp311-* cp38-* cp39-* cp313t-*'
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - name: Build wheels
         uses: pypa/cibuildwheel@v3.2.1
-      - uses: actions/upload-artifact@v4
+      - uses: actions/upload-artifact@v7
         with:
           name: build-windows
           path: ./wheelhouse/*.whl
@@ -150,9 +150,9 @@ jobs:
     runs-on: ubuntu-latest
     if: ${{ inputs.publish_type != 'build' }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - name: Set up Python (3.12)
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: 3.12
       - name: Install Dependencies
@@ -164,7 +164,7 @@ jobs:
           rm -rf dist 
           python setup.py sdist
       - name: Retrieve wheels
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           pattern: build-*
           merge-multiple: true


### PR DESCRIPTION
## Summary
- Bumps GitHub Actions off Node 20 ahead of the Sept 16, 2026 removal
- Replaces `hoverkraft-tech/compose-action` with direct `docker compose` since its latest release still targets Node 20
- Refreshes the ClickHouse test matrix to match the currently supported versions