### PR TITLE
fix unescaped inner quotes in pre-quoted identifiers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## UNRELEASED
 
+### Bug Fixes
+- `quote_identifier` now re-escapes inputs that start and end with `` ` `` or `"` but contain unescaped inner occurrences of the same quote character, instead of passing them through unchanged. Validly pre-quoted identifiers like backslash or doubled-quote escaping still pass through untouched. Closes [#737](https://github.com/ClickHouse/clickhouse-connect/issues/737).
+
 ## 1.0.1, 2026-05-19
 
 ### Bug Fixes

--- a/clickhouse_connect/driver/binding.py
+++ b/clickhouse_connect/driver/binding.py
@@ -41,7 +41,7 @@ def quote_identifier(identifier: str) -> str:
 
 
 def _is_validly_quoted(identifier: str, quote: str) -> bool:
-    # Accepts backslash escaping (\` or \") and doubled-quote escaping (`` or "").
+    # Accepts backslash escapes (\X) and doubled-quote escapes (`` or "").
     i, end = 1, len(identifier) - 1
     while i < end:
         c = identifier[i]

--- a/clickhouse_connect/driver/binding.py
+++ b/clickhouse_connect/driver/binding.py
@@ -32,12 +32,31 @@ class DT64Param:
         return f"'{s}'"
 
 
-def quote_identifier(identifier: str):
-    first_char = identifier[0]
-    if first_char in ("`", '"') and identifier[-1] == first_char:
-        # Identifier is already quoted, assume that it's valid
-        return identifier
+def quote_identifier(identifier: str) -> str:
+    if len(identifier) >= 2:
+        quote = identifier[0]
+        if quote in ("`", '"') and identifier[-1] == quote and _is_validly_quoted(identifier, quote):
+            return identifier
     return f"`{escape_str(identifier)}`"
+
+
+def _is_validly_quoted(identifier: str, quote: str) -> bool:
+    # Accepts backslash escaping (\` or \") and doubled-quote escaping (`` or "").
+    i, end = 1, len(identifier) - 1
+    while i < end:
+        c = identifier[i]
+        if c == "\\":
+            if i + 1 >= end:
+                return False
+            i += 2
+        elif c == quote:
+            if i + 1 < end and identifier[i + 1] == quote:
+                i += 2
+            else:
+                return False
+        else:
+            i += 1
+    return True
 
 
 def finalize_query(query: str, parameters: Sequence | dict[str, Any] | None, server_tz: tzinfo | None = None) -> str:

--- a/tests/integration_tests/test_inserts.py
+++ b/tests/integration_tests/test_inserts.py
@@ -87,3 +87,16 @@ def test_numeric_conversion(param_client: Client, call, table_context: Callable)
         assert result[1][1] is None
         assert result[2][1] == 2
         assert result[2][2] == 5.32
+
+
+def test_insert_table_name_with_unescaped_inner_backtick(param_client: Client, call, test_table_engine: str):
+    # A table name wrapped in backticks but containing unescaped inner backticks must be re-escaped.
+    raw_table = "`quote`insert`"
+    quoted_table = "`\\`quote\\`insert\\``"
+    call(param_client.command, f"DROP TABLE IF EXISTS {quoted_table}")
+    try:
+        call(param_client.command, f"CREATE TABLE {quoted_table} (id UInt32) ENGINE {test_table_engine} ORDER BY id")
+        call(param_client.insert, raw_table, [[13]], column_names=["id"])
+        assert call(param_client.command, f"SELECT count() FROM {quoted_table}") == 1
+    finally:
+        call(param_client.command, f"DROP TABLE IF EXISTS {quoted_table}")

--- a/tests/unit_tests/test_driver/test_binding.py
+++ b/tests/unit_tests/test_driver/test_binding.py
@@ -1,0 +1,43 @@
+import pytest
+
+from clickhouse_connect.driver.binding import quote_identifier
+
+
+@pytest.mark.parametrize(
+    "identifier, expected",
+    [
+        ("foo", "`foo`"),
+        ("foo`bar", "`foo\\`bar`"),
+        ('foo"bar', '`foo"bar`'),
+        ("", "``"),
+    ],
+)
+def test_quote_identifier_raw(identifier, expected):
+    assert quote_identifier(identifier) == expected
+
+
+@pytest.mark.parametrize(
+    "identifier",
+    [
+        "`foo`",
+        '"foo"',
+        "`foo\\`bar`",
+        "`foo``bar`",
+        '"foo""bar"',
+    ],
+)
+def test_quote_identifier_valid_prequoted_passthrough(identifier):
+    assert quote_identifier(identifier) == identifier
+
+
+@pytest.mark.parametrize(
+    "identifier, expected",
+    [
+        ("`weird`name`", "`\\`weird\\`name\\``"),
+        ('"weird"name"', '`"weird"name"`'),
+        ("`foo\\`", "`\\`foo\\\\\\``"),
+        ("`", "`\\``"),
+    ],
+)
+def test_quote_identifier_invalid_prequoted_escaped_as_raw(identifier, expected):
+    assert quote_identifier(identifier) == expected


### PR DESCRIPTION
## Summary

`quote_identifier` previously short-circuited on any input that started and ended with ``` ` ``` or `"`, returning it unchanged even when inner occurrences of the same quote were unescaped. A validating helper now only passes through identifiers that are actually well formed like backslash or doubled-quote escaping. Malformed inputs are treated as raw and re-escaped.

Closes #737

## Checklist
Delete items not relevant to your PR:
- [X] Unit and integration tests covering the common scenarios were added
- [X] A human-readable description of the changes was provided to include in CHANGELOG