### PR TITLE
reduce cloud tests to single python version

### DIFF
--- a/.github/workflows/on_push.yml
+++ b/.github/workflows/on_push.yml
@@ -233,26 +233,17 @@ jobs:
 
   cloud-tests:
     runs-on: ubuntu-latest
-    name: Cloud Tests Py=${{ matrix.python-version }}
+    name: Cloud Tests Py=3.12
     needs: check-secret
     if: needs.check-secret.outputs.has_secrets == 'true'
-
-    strategy:
-      matrix:
-        python-version:
-          - '3.10'
-          - '3.11'
-          - '3.12'
-          - '3.13'
-          - '3.14'
 
     steps:
       - name: Checkout
         uses: actions/checkout@v6
-      - name: Set up Python ${{ matrix.python-version }}
+      - name: Set up Python 3.12
         uses: actions/setup-python@v6
         with:
-          python-version: ${{ matrix.python-version }}
+          python-version: '3.12'
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip


### PR DESCRIPTION
Five simultaneous cloud tests against different Python versions seems overkill and has been causing some connection issues when a lot of merges/PRs run through CI at the same time. The non-cloud matrix runs every Python version against each supported server version so I think this is defensible.