### PR TITLE
propagate server_host_name to TLS SNI

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,11 @@
 
 ## UNRELEASED
 
+### Compatibility
+- Async client now requires `aiohttp>=3.9.0`. This is required to support TLS SNI override via `server_host_name`, because aiohttp added the per-request `server_hostname` option in 3.9.
+
 ### Bug Fixes
+- Async client: `server_host_name` now also overrides the TLS SNI / certificate hostname, matching the sync client. Previously the async path only applied it to the HTTP `Host` header, so connecting to host A while presenting SNI B (the 0.x `pool_mgr=urllib3.PoolManager(server_hostname=...)` pattern, useful for ClickHouse Cloud VPC endpoints reached via external DNS) was not expressible against the new aiohttp-based client. Both `_raw_request` and `ping()` now pass `ssl=self._ssl_context, server_hostname=self.server_host_name` per request when an SSL context is in use. Closes [#752](https://github.com/ClickHouse/clickhouse-connect/issues/752).
 - Drain the full `retries` budget on connection-error retries in `_raw_request` instead of only retrying once. Previously both the sync and async clients gated network-error retries on `attempts == 1`, so two consecutive `aiohttp.ServerDisconnectedError`s (or `ConnectionResetError`s on the sync path) surfaced as `OperationalError` even when `query_retries` would have allowed another attempt. Read paths now drain `query_retries`; insert/command paths still get one retry (`retries=0` callers). Sync `raw_query` and `raw_stream` (the foundation for `query_arrow` / `query_arrow_stream`) now also pass `query_retries` so they match their async counterparts. Adds a `0.1 * attempts` backoff between connection-error retries to match the 429/503/504 branch. Closes [#754](https://github.com/ClickHouse/clickhouse-connect/issues/754).
 - `quote_identifier` now re-escapes inputs that start and end with `` ` `` or `"` but contain unescaped inner occurrences of the same quote character, instead of passing them through unchanged. Validly pre-quoted identifiers like backslash or doubled-quote escaping still pass through untouched. Closes [#737](https://github.com/ClickHouse/clickhouse-connect/issues/737).
 

--- a/clickhouse_connect/driver/asyncclient.py
+++ b/clickhouse_connect/driver/asyncclient.py
@@ -983,7 +983,13 @@ class AsyncClient(Client):
         try:
             url = f"{self.url}/ping"
             timeout = aiohttp.ClientTimeout(total=3.0)
-            async with session.get(url, timeout=timeout) as response:
+            get_kwargs: dict[str, Any] = {"timeout": timeout}
+            if self.server_host_name:
+                get_kwargs["headers"] = {"Host": self.server_host_name}
+                if self._ssl_context is not None:
+                    get_kwargs["ssl"] = self._ssl_context
+                    get_kwargs["server_hostname"] = self.server_host_name
+            async with session.get(url, **get_kwargs) as response:
                 return 200 <= response.status < 300
         except (aiohttp.ClientError, asyncio.TimeoutError):
             logger.debug("ping failed", exc_info=True)
@@ -1945,6 +1951,9 @@ class AsyncClient(Client):
                 # Construct full URL (aiohttp doesn't have base_url)
                 url = f"{self.url}/"
                 request_kwargs = {"method": method, "url": url, "params": final_params, "headers": req_headers}
+                if self.server_host_name and self._ssl_context is not None:
+                    request_kwargs["ssl"] = self._ssl_context
+                    request_kwargs["server_hostname"] = self.server_host_name
                 if hasattr(self, "_proxy_url") and self._proxy_url:
                     request_kwargs["proxy"] = self._proxy_url
                 if files:

--- a/setup.py
+++ b/setup.py
@@ -74,7 +74,7 @@ def run_setup(try_c: bool = True):
             "orjson": ["orjson"],
             "tzlocal": ["tzlocal>=4.0"],
             "tzdata": ["tzdata"],
-            "async": ["aiohttp>=3.8.0"],
+            "async": ["aiohttp>=3.9.0"],
         },
         tests_require=["pytest"],
         entry_points={

--- a/tests/test_requirements.txt
+++ b/tests/test_requirements.txt
@@ -1,7 +1,7 @@
 urllib3>=1.26
 setuptools
 certifi
-aiohttp>=3.8.0
+aiohttp>=3.9.0
 sqlalchemy>=2.0,<3.0
 cython==3.0.11
 pyarrow


### PR DESCRIPTION
## Summary
- Async client `server_host_name` now also overrides TLS SNI, not just the HTTP `Host` header. Both `_raw_request` and `ping()` now pass aiohttp's per-request `server_hostname` with the SSL context when the user has configured an override and TLS is in use
- Bumps the `async` extra to `aiohttp>=3.9.0`, since the per-request `server_hostname` kwarg is new in aiohttp 3.9

Closes #752

## Checklist
Delete items not relevant to your PR:
- [X] Unit and integration tests covering the common scenarios were added
- [X] A human-readable description of the changes was provided to include in CHANGELOG