### PR TITLE
fix show row policy handing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## UNRELEASED
 
+### Bug Fixes
+- Fix `query("SHOW ROW POLICIES")`/`query("SHOW POLICIES")` by routing these non-tabular statements without appending `FORMAT Native`. Empty row-policy `SHOW` command results now return `""` instead of `QuerySummary`. Closes [#761](https://github.com/ClickHouse/clickhouse-connect/issues/761).
+
 ## 1.1.0, 2026-05-26
 
 ### Compatibility

--- a/clickhouse_connect/driver/asyncclient.py
+++ b/clickhouse_connect/driver/asyncclient.py
@@ -45,7 +45,14 @@ from clickhouse_connect.driver.external import ExternalData
 from clickhouse_connect.driver.insert import InsertContext
 from clickhouse_connect.driver.models import ColumnDef, SettingDef
 from clickhouse_connect.driver.options import check_arrow, check_numpy, check_pandas, check_polars
-from clickhouse_connect.driver.query import QueryContext, QueryResult, TzMode, TzSource, arrow_buffer
+from clickhouse_connect.driver.query import (
+    QueryContext,
+    QueryResult,
+    TzMode,
+    TzSource,
+    arrow_buffer,
+    returns_empty_string_on_empty_body,
+)
 from clickhouse_connect.driver.streaming import StreamingFileAdapter, StreamingInsertSource, StreamingResponseSource
 from clickhouse_connect.driver.summary import QuerySummary
 from clickhouse_connect.driver.transform import NativeTransform
@@ -951,6 +958,8 @@ class AsyncClient(Client):
             _release_lease(response)
 
         if not body:
+            if returns_empty_string_on_empty_body(cmd):
+                return ""
             return QuerySummary(summary)
 
         loop = asyncio.get_running_loop()

--- a/clickhouse_connect/driver/client.py
+++ b/clickhouse_connect/driver/client.py
@@ -921,7 +921,7 @@ class Client(ABC):
         :param external_data: ClickHouse "external data" to send with command/query
         :param transport_settings: Optional dictionary of transport level settings (HTTP headers, etc.)
         :return: Decoded response from ClickHouse as either a string, int, or sequence of strings, or QuerySummary
-        if no data returned
+        if no data returned. Explicitly handled read-style commands can return an empty string for empty results.
         """
 
     @abstractmethod

--- a/clickhouse_connect/driver/httpclient.py
+++ b/clickhouse_connect/driver/httpclient.py
@@ -37,7 +37,7 @@ from clickhouse_connect.driver.httputil import (
     get_response_data,
 )
 from clickhouse_connect.driver.insert import InsertContext
-from clickhouse_connect.driver.query import QueryContext, QueryResult, TzSource
+from clickhouse_connect.driver.query import QueryContext, QueryResult, TzSource, returns_empty_string_on_empty_body
 from clickhouse_connect.driver.summary import QuerySummary
 from clickhouse_connect.driver.transform import NativeTransform
 
@@ -478,6 +478,8 @@ class HttpClient(Client):
                 return result
             except UnicodeDecodeError:
                 return str(response.data)
+        if returns_empty_string_on_empty_body(cmd):
+            return ""
         return QuerySummary(self._summary(response))
 
     def _error_handler(self, response: HTTPResponse, retried: bool = False) -> None:

--- a/clickhouse_connect/driver/query.py
+++ b/clickhouse_connect/driver/query.py
@@ -34,6 +34,14 @@ limit_re = re.compile(r"\s+LIMIT($|\s)", re.IGNORECASE)
 select_re = re.compile(r"(^|\s)SELECT\s", re.IGNORECASE)
 insert_re = re.compile(r"(^|\s)INSERT\s*INTO", re.IGNORECASE)
 command_re = re.compile(r"(^\s*)(" + commands + r")\s", re.IGNORECASE)
+row_policy_show_re = re.compile(r"^\s*SHOW\s+(ROW\s+)?POLICIES\b", re.IGNORECASE)
+bare_row_policy_show_re = re.compile(r"^\s*SHOW\s+(ROW\s+)?POLICIES\s*$", re.IGNORECASE)
+
+
+def returns_empty_string_on_empty_body(cmd: str | bytes) -> bool:
+    if not isinstance(cmd, str):
+        return False
+    return row_policy_show_re.search(remove_sql_comments(cmd)) is not None
 
 
 class QueryContext(BaseQueryContext):
@@ -167,7 +175,7 @@ class QueryContext(BaseQueryContext):
 
     @property
     def is_command(self) -> bool:
-        return command_re.search(self.uncommented_query) is not None
+        return command_re.search(self.uncommented_query) is not None or bare_row_policy_show_re.search(self.uncommented_query) is not None
 
     def set_parameters(self, parameters: dict[str, Any]):
         self.parameters = parameters

--- a/tests/integration_tests/test_client.py
+++ b/tests/integration_tests/test_client.py
@@ -6,6 +6,7 @@ from time import sleep
 import pytest
 
 from clickhouse_connect import create_client, datatypes
+from clickhouse_connect.driver.binding import quote_identifier
 from clickhouse_connect.driver.client import Client
 from clickhouse_connect.driver.exceptions import DatabaseError
 from tests.integration_tests.conftest import TestConfig
@@ -253,6 +254,31 @@ def test_show_create(param_client, call):
     result = call(param_client.query, "SHOW CREATE TABLE system.tables")
     result.close()
     assert "statement" in result.column_names
+
+
+def test_show_row_policies(param_client, call, table_context: Callable, test_config: TestConfig):
+    if test_config.cloud:
+        pytest.skip("Skipping row policy test in cloud env")
+    if not param_client.min_version("20"):
+        pytest.skip(f"Not supported server version {param_client.server_version}")
+
+    for statement in ("SHOW ROW POLICIES", "SHOW POLICIES"):
+        result = call(param_client.query, statement)
+        assert result.result_rows == [[""]]
+        result.close()
+
+    policy = "test_show_row_policies_policy"
+    with table_context("test_show_row_policies", ["id UInt32"]) as table:
+        target = f"{quote_identifier(param_client.database)}.{table.table}"
+        call(param_client.command, f"DROP ROW POLICY IF EXISTS {policy} ON {target}")
+        try:
+            assert call(param_client.command, f"SHOW ROW POLICIES ON {target}") == ""
+            assert call(param_client.command, f"SHOW POLICIES ON {target}") == ""
+
+            call(param_client.command, f"CREATE ROW POLICY {policy} ON {target} USING id = 13 TO ALL")
+            assert policy in call(param_client.command, f"SHOW ROW POLICIES ON {target}")
+        finally:
+            call(param_client.command, f"DROP ROW POLICY IF EXISTS {policy} ON {target}")
 
 
 def test_empty_result(param_client, call):

--- a/tests/unit_tests/test_driver/test_query.py
+++ b/tests/unit_tests/test_driver/test_query.py
@@ -7,7 +7,7 @@ import pytest
 from clickhouse_connect.driver import tzutil
 from clickhouse_connect.driver.client import _strip_utc_timezone_from_arrow
 from clickhouse_connect.driver.exceptions import ProgrammingError
-from clickhouse_connect.driver.query import QueryContext
+from clickhouse_connect.driver.query import QueryContext, returns_empty_string_on_empty_body
 
 
 def test_copy_context():
@@ -33,6 +33,65 @@ def test_copy_context():
     assert context_copy.settings["max_execution_time"] == 120
     assert context_copy.settings["max_bytes_for_external_group_by"] == 25165824
     assert context_copy.final_query == "SELECT source_ip FROM table WHERE user_id = 'user_2'"
+
+
+@pytest.mark.parametrize(
+    "query",
+    [
+        "SHOW ROW POLICIES",
+        "SHOW POLICIES",
+        "show row policies",
+        "  SHOW   ROW   POLICIES  ",
+        "-- comment\nSHOW ROW POLICIES",
+    ],
+)
+def test_bare_row_policy_show_is_command(query):
+    assert QueryContext(query).is_command is True
+
+
+@pytest.mark.parametrize(
+    "query",
+    [
+        "SHOW ROW POLICIES ON db.table",
+        "SHOW ROW POLICIES policy_1",
+        "SHOW DATABASES",
+        "SHOW TABLES",
+        "SHOW USERS",
+        "SELECT 1",
+        "SHOW",
+    ],
+)
+def test_other_show_queries_are_not_commands(query):
+    assert QueryContext(query).is_command is False
+
+
+@pytest.mark.parametrize(
+    "query",
+    [
+        "SHOW ROW POLICIES",
+        "SHOW POLICIES",
+        "  SHOW ROW POLICIES ON db.table",
+        "-- comment\nSHOW POLICIES ON db.table",
+        "SHOW ROW POLICIES policy_1",
+    ],
+)
+def test_row_policy_show_empty_body_returns_empty_string(query):
+    assert returns_empty_string_on_empty_body(query) is True
+
+
+@pytest.mark.parametrize(
+    "query",
+    [
+        b"SHOW ROW POLICIES",
+        "INSERT INTO t FORMAT TSV",
+        "CREATE TABLE x (id UInt32) ENGINE Memory",
+        "ALTER TABLE x ADD COLUMN y UInt32",
+        "SELECT 1",
+        "SHOW DATABASES",
+    ],
+)
+def test_non_row_policy_show_empty_body_uses_query_summary(query):
+    assert returns_empty_string_on_empty_body(query) is False
 
 
 def test_active_tz_utc_defaults_to_naive():


### PR DESCRIPTION
## Summary
- Fixes `SHOW ROW POLICIES`/`SHOW POLICIES` handling in `query()` by routing the bare non-tabular statements through `command()` so the client does not append `FORMAT Native`.
- Updates sync and async `command()` handling so empty row-policy `SHOW` results return `""` instead of `QuerySummary`, while preserving existing `QuerySummary` behavior for DDL, inserts, and other empty command responses.

## Checklist
Delete items not relevant to your PR:
- [X] Unit and integration tests covering the common scenarios were added
- [X] A human-readable description of the changes was provided to include in CHANGELOG