### PR TITLE
Joe/763 async client does not retry due to miscategorized exceptions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 ### Bug Fixes
 - Async client: retry stale keep-alive resets surfaced by aiohttp as `ClientOSError` or `ClientConnectionResetError`, fixing large async inserts on killed pooled connections. Closes [#763](https://github.com/ClickHouse/clickhouse-connect/issues/763).
+- Async client: do not retry aiohttp timeout, connector, or fingerprint errors as these can indicate the request was already delivered or a config issue, not a stale connection.
+- Sync client: also retry stale keep-alive `BrokenPipeError` (in addition to `ConnectionResetError`), matching the async behavior.
 
 ## 1.1.0, 2026-05-26
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## UNRELEASED
 
+### Bug Fixes
+- Async client: retry stale keep-alive resets surfaced by aiohttp as `ClientOSError` or `ClientConnectionResetError`, fixing large async inserts on killed pooled connections. Closes [#763](https://github.com/ClickHouse/clickhouse-connect/issues/763).
+
 ## 1.1.0, 2026-05-26
 
 ### Compatibility

--- a/clickhouse_connect/driver/asyncclient.py
+++ b/clickhouse_connect/driver/asyncclient.py
@@ -149,7 +149,9 @@ _REMOTE_CLOSE_ERRORS = (ConnectionResetError, BrokenPipeError)
 
 
 def _is_retryable_async_connection_error(error: aiohttp.ClientConnectionError) -> bool:
-    if isinstance(error, aiohttp.ServerConnectionError):
+    if isinstance(error, (aiohttp.ServerTimeoutError, aiohttp.ClientConnectorError, aiohttp.ServerFingerprintMismatch)):
+        return False
+    if isinstance(error, aiohttp.ServerDisconnectedError):
         return True
     if isinstance(error, _REMOTE_CLOSE_ERRORS):
         return True
@@ -2025,6 +2027,7 @@ class AsyncClient(Client):
                             logger.debug("Retrying after connection error from remote host (attempt %s/%s)", attempts, max_attempts)
                             await asyncio.sleep(0.1 * attempts)
                             continue
+                logger.debug("Non-retryable aiohttp connection error type=%s", type(e).__name__)
                 raise OperationalError(f"Network Error: {msg}") from e
 
             except (aiohttp.ClientError, asyncio.TimeoutError) as e:

--- a/clickhouse_connect/driver/asyncclient.py
+++ b/clickhouse_connect/driver/asyncclient.py
@@ -145,6 +145,19 @@ def _release_lease(response: aiohttp.ClientResponse | None) -> None:
         release()
 
 
+_REMOTE_CLOSE_ERRORS = (ConnectionResetError, BrokenPipeError)
+
+
+def _is_retryable_async_connection_error(error: aiohttp.ClientConnectionError) -> bool:
+    if isinstance(error, aiohttp.ServerConnectionError):
+        return True
+    if isinstance(error, _REMOTE_CLOSE_ERRORS):
+        return True
+    if isinstance(error.__cause__, _REMOTE_CLOSE_ERRORS):
+        return True
+    return isinstance(error.__context__, _REMOTE_CLOSE_ERRORS)
+
+
 class AsyncClient(Client):
     valid_transport_settings = {
         "database",
@@ -1994,9 +2007,9 @@ class AsyncClient(Client):
                         continue
                 await self._error_handler(response)
 
-            except aiohttp.ServerConnectionError as e:
+            except aiohttp.ClientConnectionError as e:
                 msg = str(e)
-                if "Connection reset" in msg or "Remote end closed" in msg or "Cannot connect" in msg or "Server disconnected" in msg:
+                if _is_retryable_async_connection_error(e):
                     # Always allow at least one retry on a clean connection error so a single stale
                     # keep-alive socket doesn't surface to the caller, and additionally honor the
                     # retries budget when it is larger (e.g. query_retries for reads), so that

--- a/clickhouse_connect/driver/httpclient.py
+++ b/clickhouse_connect/driver/httpclient.py
@@ -46,6 +46,8 @@ columns_only_re = re.compile(r"LIMIT 0\s*$", re.IGNORECASE)
 ex_header = "X-ClickHouse-Exception-Code"
 ex_tag_header = "X-ClickHouse-Exception-Tag"
 
+_REMOTE_CLOSE_ERRORS = (ConnectionResetError, BrokenPipeError)
+
 
 class HttpClient(Client):
     params = {}
@@ -574,7 +576,8 @@ class HttpClient(Client):
                 # retries budget when it is larger (e.g. query_retries for reads), so that
                 # bursts of stale pooled connections can be drained before giving up.
                 max_attempts = max(2, retries + 1)
-                if isinstance(ex.__context__, ConnectionResetError) and attempts < max_attempts:
+                remote_close = isinstance(ex.__context__, _REMOTE_CLOSE_ERRORS) or isinstance(ex.__cause__, _REMOTE_CLOSE_ERRORS)
+                if remote_close and attempts < max_attempts:
                     # The server closed the connection, probably because the Keep Alive has expired.
                     # We should be safe to retry, as ClickHouse should not have processed anything on
                     # a connection that it killed.
@@ -588,6 +591,7 @@ class HttpClient(Client):
                         logger.debug("Retrying remotely closed connection (attempt %s/%s)", attempts, max_attempts)
                         time.sleep(0.1 * attempts)
                         continue
+                logger.debug("Non-retryable HTTP transport error type=%s", type(ex).__name__)
                 logger.warning("Unexpected Http Driver Exception")
                 err_url = f" ({self.url})" if self.show_clickhouse_errors else ""
                 raise OperationalError(f"Error {ex} executing HTTP request attempt {attempts}{err_url}") from ex

--- a/tests/integration_tests/test_error_handling.py
+++ b/tests/integration_tests/test_error_handling.py
@@ -1,4 +1,5 @@
 import logging
+from types import SimpleNamespace
 
 import aiohttp
 import pytest
@@ -20,6 +21,15 @@ def _client_connection_reset_error() -> aiohttp.ClientConnectionError:
     if error_class is None:
         pytest.skip("aiohttp.ClientConnectionResetError is not available")
     return error_class(104, "Connection reset by peer")
+
+
+def _client_connector_reset_error() -> aiohttp.ClientConnectorError:
+    error = aiohttp.ClientConnectorError(
+        SimpleNamespace(host="localhost", port=8123, ssl=True),
+        ConnectionResetError(104, "Connection reset by peer"),
+    )
+    error.__cause__ = error.os_error
+    return error
 
 
 def test_wrong_port_error_message(client_factory, test_config: TestConfig):
@@ -175,15 +185,40 @@ async def test_async_retry_on_remote_close_client_connection_error(test_native_a
     assert result.result_rows[0][0] == 13
 
 
+@pytest.mark.parametrize(
+    "error_factory",
+    [
+        pytest.param(
+            lambda: aiohttp.ClientConnectionError("generic connection failure"),
+            id="generic_connection_error",
+        ),
+        pytest.param(
+            lambda: aiohttp.SocketTimeoutError("Timeout on reading data from socket"),
+            id="socket_timeout",
+        ),
+        pytest.param(
+            lambda: aiohttp.ConnectionTimeoutError("Connection timeout to host http://localhost:8123/"),
+            id="connection_timeout",
+        ),
+        pytest.param(
+            _client_connector_reset_error,
+            id="connector_reset_error",
+        ),
+        pytest.param(
+            lambda: aiohttp.ServerFingerprintMismatch(b"expected", b"got", "localhost", 8123),
+            id="fingerprint_mismatch",
+        ),
+    ],
+)
 @pytest.mark.asyncio
-async def test_async_client_connection_error_without_remote_close_is_not_retried(test_native_async_client, mocker):
-    """Does not retry generic aiohttp connection errors."""
+async def test_async_non_remote_close_connection_errors_are_not_retried(test_native_async_client, mocker, error_factory):
+    """Does not retry unsafe or non-stale aiohttp connection errors."""
     attempts = 0
 
     async def failing_request(*args, **kwargs):
         nonlocal attempts
         attempts += 1
-        raise aiohttp.ClientConnectionError("generic connection failure")
+        raise error_factory()
 
     mocker.patch.object(test_native_async_client._session, "request", side_effect=failing_request)
 
@@ -191,8 +226,37 @@ async def test_async_client_connection_error_without_remote_close_is_not_retried
         await test_native_async_client.query("SELECT 13")
 
     assert attempts == 1
-    assert "generic connection failure" in str(excinfo.value)
     assert isinstance(excinfo.value.__cause__, aiohttp.ClientConnectionError)
+
+
+@pytest.mark.parametrize(
+    "remote_close_error",
+    [
+        pytest.param(lambda: ConnectionResetError("Connection reset by peer"), id="connection_reset"),
+        pytest.param(lambda: BrokenPipeError("Broken pipe"), id="broken_pipe"),
+    ],
+)
+def test_sync_retry_on_remote_close_error(test_client, mocker, remote_close_error):
+    """urllib3 surfaces stale keep-alive RST/EPIPE as ProtocolError with the OS error chained via __context__."""
+    real_request = test_client.http.request
+    attempts = 0
+
+    def flaky_request(method, url, **kwargs):
+        nonlocal attempts
+        attempts += 1
+        if attempts == 1:
+            try:
+                raise remote_close_error()
+            except (ConnectionResetError, BrokenPipeError):
+                raise urllib3.exceptions.ProtocolError("Connection aborted.")  # noqa: B904
+        return real_request(method, url, **kwargs)
+
+    mocker.patch.object(test_client.http, "request", side_effect=flaky_request)
+
+    result = test_client.query("SELECT 13")
+
+    assert attempts == 2
+    assert result.result_rows[0][0] == 13
 
 
 @pytest.mark.parametrize("disconnect_count", [1, 2])

--- a/tests/integration_tests/test_error_handling.py
+++ b/tests/integration_tests/test_error_handling.py
@@ -9,6 +9,19 @@ from clickhouse_connect.driver.options import pd
 from tests.integration_tests.conftest import TestConfig
 
 
+def _client_os_error_from(cause: ConnectionError) -> aiohttp.ClientOSError:
+    error = aiohttp.ClientOSError(cause.errno, cause.strerror)
+    error.__cause__ = cause
+    return error
+
+
+def _client_connection_reset_error() -> aiohttp.ClientConnectionError:
+    error_class = getattr(aiohttp, "ClientConnectionResetError", None)
+    if error_class is None:
+        pytest.skip("aiohttp.ClientConnectionResetError is not available")
+    return error_class(104, "Connection reset by peer")
+
+
 def test_wrong_port_error_message(client_factory, test_config: TestConfig):
     """
     Test that connecting to the wrong port properly propagates
@@ -124,6 +137,64 @@ async def test_async_server_disconnected_raises_after_retry(test_native_async_cl
     assert isinstance(excinfo.value.__cause__, aiohttp.ServerDisconnectedError)
 
 
+@pytest.mark.parametrize(
+    "disconnect_factory",
+    [
+        pytest.param(
+            lambda: _client_os_error_from(ConnectionResetError(104, "Connection reset by peer")),
+            id="client_os_error_reset_cause",
+        ),
+        pytest.param(
+            lambda: _client_os_error_from(BrokenPipeError(32, "Broken pipe")),
+            id="client_os_error_broken_pipe_cause",
+        ),
+        pytest.param(
+            _client_connection_reset_error,
+            id="client_connection_reset_error",
+        ),
+    ],
+)
+@pytest.mark.asyncio
+async def test_async_retry_on_remote_close_client_connection_error(test_native_async_client, mocker, disconnect_factory):
+    """Retries aiohttp remote-close connection errors when the body can be replayed."""
+    real_request = test_native_async_client._session.request
+    attempts = 0
+
+    async def flaky_request(*args, **kwargs):
+        nonlocal attempts
+        attempts += 1
+        if attempts == 1:
+            raise disconnect_factory()
+        return await real_request(*args, **kwargs)
+
+    mocker.patch.object(test_native_async_client._session, "request", side_effect=flaky_request)
+
+    result = await test_native_async_client.query("SELECT 13")
+
+    assert attempts == 2
+    assert result.result_rows[0][0] == 13
+
+
+@pytest.mark.asyncio
+async def test_async_client_connection_error_without_remote_close_is_not_retried(test_native_async_client, mocker):
+    """Does not retry generic aiohttp connection errors."""
+    attempts = 0
+
+    async def failing_request(*args, **kwargs):
+        nonlocal attempts
+        attempts += 1
+        raise aiohttp.ClientConnectionError("generic connection failure")
+
+    mocker.patch.object(test_native_async_client._session, "request", side_effect=failing_request)
+
+    with pytest.raises(OperationalError) as excinfo:
+        await test_native_async_client.query("SELECT 13")
+
+    assert attempts == 1
+    assert "generic connection failure" in str(excinfo.value)
+    assert isinstance(excinfo.value.__cause__, aiohttp.ClientConnectionError)
+
+
 @pytest.mark.parametrize("disconnect_count", [1, 2])
 def test_sync_retry_on_connection_reset(test_client, mocker, disconnect_count):
     """
@@ -208,7 +279,7 @@ def _install_one_shot_reset_mock(client, client_mode, mocker):
                 if attempts[0] == 1:
                     async for _ in data:
                         pass
-                    raise aiohttp.ServerDisconnectedError("Connection reset by peer")
+                    raise _client_os_error_from(ConnectionResetError(104, "Connection reset by peer"))
             return await real_request(*args, **kwargs)
 
         mocker.patch.object(client._session, "request", side_effect=flaky_request)


### PR DESCRIPTION
## Summary
- Retry async stale keep-alive resets surfaced as `ClientOSError` or `ClientConnectionResetError`, fixing large async inserts on killed pooled connections.
- Tighten async retry classification so timeout, connector, and fingerprint errors are not retried.
- Align sync remote-close retries with async by handling `BrokenPipeError` and chained causes.

Closes #763

## Checklist
Delete items not relevant to your PR:
- [X] Unit and integration tests covering the common scenarios were added
- [X] A human-readable description of the changes was provided to include in CHANGELOG