### PR TITLE
route ping through proxy

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## UNRELEASED
 
 ### Bug Fixes
+- Async client: `ping()` now routes through the configured proxy, matching `_raw_request`. Previously the proxy was omitted, so `ping()` falsely returned `False` on networks where the server was only reachable via the proxy. Closes [#757](https://github.com/ClickHouse/clickhouse-connect/issues/757).
 - Fix `query("SHOW ROW POLICIES")`/`query("SHOW POLICIES")` by routing these non-tabular statements without appending `FORMAT Native`. Empty row-policy `SHOW` command results now return `""` instead of `QuerySummary`. Closes [#761](https://github.com/ClickHouse/clickhouse-connect/issues/761).
 - Async client: retry stale keep-alive resets surfaced by aiohttp as `ClientOSError` or `ClientConnectionResetError`, fixing large async inserts on killed pooled connections. Closes [#763](https://github.com/ClickHouse/clickhouse-connect/issues/763).
 - Async client: do not retry aiohttp timeout, connector, or fingerprint errors as these can indicate the request was already delivered or a config issue, not a stale connection.

--- a/clickhouse_connect/driver/asyncclient.py
+++ b/clickhouse_connect/driver/asyncclient.py
@@ -1008,6 +1008,8 @@ class AsyncClient(Client):
             url = f"{self.url}/ping"
             timeout = aiohttp.ClientTimeout(total=3.0)
             get_kwargs: dict[str, Any] = {"timeout": timeout}
+            if self._proxy_url:
+                get_kwargs["proxy"] = self._proxy_url
             if self.server_host_name:
                 get_kwargs["headers"] = {"Host": self.server_host_name}
                 if self._ssl_context is not None:

--- a/tests/integration_tests/test_proxy.py
+++ b/tests/integration_tests/test_proxy.py
@@ -19,6 +19,7 @@ def test_proxies(client_factory, call, test_config: TestConfig):
             http_proxy=test_config.proxy_address,
         )
         assert "2" in call(client.command, "SELECT version()")
+        assert call(client.ping) is True
 
         try:
             os.environ["HTTP_PROXY"] = f"http://{test_config.proxy_address}"
@@ -35,6 +36,7 @@ def test_proxies(client_factory, call, test_config: TestConfig):
                 # Async client uses aiohttp
                 assert hasattr(client, "_proxy_url") and client._proxy_url is not None
             assert "2" in call(client.command, "SELECT version()")
+            assert call(client.ping) is True
 
             os.environ["no_proxy"] = f"{test_config.host}:{test_config.port}"
             client = client_factory(
@@ -51,6 +53,7 @@ def test_proxies(client_factory, call, test_config: TestConfig):
                 # Async client uses aiohttp
                 assert not hasattr(client, "_proxy_url") or client._proxy_url is None
             assert "2" in call(client.command, "SELECT version()")
+            assert call(client.ping) is True
         finally:
             os.environ.pop("HTTP_PROXY", None)
             os.environ.pop("no_proxy", None)
@@ -65,6 +68,7 @@ def test_proxies(client_factory, call, test_config: TestConfig):
             https_proxy=test_config.proxy_address,
         )
         assert "2" in call(client.command, "SELECT version()")
+        assert call(client.ping) is True
 
         try:
             os.environ["HTTPS_PROXY"] = f"{test_config.proxy_address}"
@@ -82,5 +86,6 @@ def test_proxies(client_factory, call, test_config: TestConfig):
                 # Async client uses aiohttp
                 assert hasattr(client, "_proxy_url") and client._proxy_url is not None
             assert "2" in call(client.command, "SELECT version()")
+            assert call(client.ping) is True
         finally:
             os.environ.pop("HTTPS_PROXY", None)


### PR DESCRIPTION
## Summary
Follow up to copilot's comment/finding in #756, this PR Routes `ping()` through a configured proxy if present.

Closes #757

## Checklist
Delete items not relevant to your PR:
- [X] A human-readable description of the changes was provided to include in CHANGELOG