### PR TITLE
Implement SQLAlchemy reflection for the cc_sqlalchemy dialect

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,9 @@
 ### Bug Fixes
 - A `datetime` bound to a server-side `{name:DateTime64(...)}` placeholder now keeps its sub-second precision instead of being truncated to seconds. The declared parameter type drives this, so no `_64` name suffix or manual `DT64Param` wrapper is needed, and it applies through `Array` and `Tuple` hints. Plain `DateTime` binds are unchanged. Closes [#739](https://github.com/ClickHouse/clickhouse-connect/issues/739).
 - Strip `--` line comments that have no following space when classifying queries, so a DDL with a leading `--sql`-style comment is routed as a command instead of raising `StreamFailureError`. Closes [#499](https://github.com/ClickHouse/clickhouse-connect/issues/499).
+- SQLAlchemy: implement reflection on the dialect itself so `MetaData.reflect()` and `Inspector.get_multi_columns()` work.
+- SQLAlchemy: UDT-based types (`UUID`, `IPv4`/`IPv6`, `JSON`, `Nested`, geometry types, `AggregateFunction`, etc.) now return concrete `python_type` classes instead of `None`, matching SQLAlchemy's `TypeEngine.python_type` contract.
+- SQLAlchemy: `Array` now subclasses `sqlalchemy.types.ARRAY` and exposes `item_type`.
 
 ## 1.1.1, 2026-05-27
 
@@ -17,9 +20,6 @@
 - Async client: retry stale keep-alive resets surfaced by aiohttp as `ClientOSError` or `ClientConnectionResetError`, fixing large async inserts on killed pooled connections. Closes [#763](https://github.com/ClickHouse/clickhouse-connect/issues/763).
 - Async client: do not retry aiohttp timeout, connector, or fingerprint errors as these can indicate the request was already delivered or a config issue, not a stale connection.
 - Sync client: also retry stale keep-alive `BrokenPipeError` (in addition to `ConnectionResetError`), matching the async behavior.
-- SQLAlchemy: implement reflection on the dialect itself so `MetaData.reflect()` and `Inspector.get_multi_columns()` work. `get_pk_constraint()` / `get_primary_keys()` now derive primary key columns from `system.columns.is_in_primary_key` instead of returning empty lists.
-- SQLAlchemy: UDT-based types (`UUID`, `IPv4`/`IPv6`, `JSON`, `Nested`, geometry types, `AggregateFunction`, etc.) now return concrete `python_type` classes instead of `None`, matching SQLAlchemy's `TypeEngine.python_type` contract.
-- SQLAlchemy: `Array` now subclasses `sqlalchemy.types.ARRAY` and exposes `item_type`.
 
 ## 1.1.0, 2026-05-26
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,9 @@
 - Async client: retry stale keep-alive resets surfaced by aiohttp as `ClientOSError` or `ClientConnectionResetError`, fixing large async inserts on killed pooled connections. Closes [#763](https://github.com/ClickHouse/clickhouse-connect/issues/763).
 - Async client: do not retry aiohttp timeout, connector, or fingerprint errors as these can indicate the request was already delivered or a config issue, not a stale connection.
 - Sync client: also retry stale keep-alive `BrokenPipeError` (in addition to `ConnectionResetError`), matching the async behavior.
+- SQLAlchemy: implement reflection on the dialect itself so `MetaData.reflect()` and `Inspector.get_multi_columns()` work. `get_pk_constraint()` / `get_primary_keys()` now derive primary key columns from `system.columns.is_in_primary_key` instead of returning empty lists.
+- SQLAlchemy: UDT-based types (`UUID`, `IPv4`/`IPv6`, `JSON`, `Nested`, geometry types, `AggregateFunction`, etc.) now return concrete `python_type` classes instead of `None`, matching SQLAlchemy's `TypeEngine.python_type` contract.
+- SQLAlchemy: `Array` now subclasses `sqlalchemy.types.ARRAY` and exposes `item_type`.
 
 ## 1.1.0, 2026-05-26
 

--- a/clickhouse_connect/cc_sqlalchemy/datatypes/sqltypes.py
+++ b/clickhouse_connect/cc_sqlalchemy/datatypes/sqltypes.py
@@ -1,7 +1,17 @@
+import ipaddress
+import uuid
 from collections.abc import Sequence
 from enum import Enum as PyEnum
 
 from sqlalchemy.exc import ArgumentError
+from sqlalchemy.types import (
+    ARRAY,
+    Float,
+    Integer,
+    Interval,
+    Numeric,
+    UserDefinedType,
+)
 from sqlalchemy.types import (
     Boolean as SqlaBoolean,
 )
@@ -12,17 +22,10 @@ from sqlalchemy.types import (
     DateTime as SqlaDateTime,
 )
 from sqlalchemy.types import (
-    Float,
-    Integer,
-    Interval,
-    Numeric,
-    UserDefinedType,
-)
-from sqlalchemy.types import (
     String as SqlaString,
 )
 
-from clickhouse_connect.cc_sqlalchemy.datatypes.base import ChSqlaType, schema_types
+from clickhouse_connect.cc_sqlalchemy.datatypes.base import ChSqlaType, schema_types, sqla_type_from_name
 from clickhouse_connect.datatypes.base import EMPTY_TYPE_DEF, LC_TYPE_DEF, NULLABLE_TYPE_DEF, TypeDef
 from clickhouse_connect.datatypes.numeric import Enum8 as ChEnum8
 from clickhouse_connect.datatypes.numeric import Enum16 as ChEnum16
@@ -209,43 +212,43 @@ class FixedString(ChSqlaType, SqlaString):
 
 
 class IPv4(ChSqlaType, UserDefinedType):
-    python_type = None
+    python_type = ipaddress.IPv4Address
 
 
 class IPv6(ChSqlaType, UserDefinedType):
-    python_type = None
+    python_type = ipaddress.IPv6Address
 
 
 class UUID(ChSqlaType, UserDefinedType):
-    python_type = None
+    python_type = uuid.UUID
 
 
 class Nothing(ChSqlaType, UserDefinedType):
-    python_type = None
+    python_type = type(None)
 
 
 class Point(ChSqlaType, UserDefinedType):
-    python_type = None
+    python_type = tuple
 
 
 class Ring(ChSqlaType, UserDefinedType):
-    python_type = None
+    python_type = list
 
 
 class Polygon(ChSqlaType, UserDefinedType):
-    python_type = None
+    python_type = list
 
 
 class MultiPolygon(ChSqlaType, UserDefinedType):
-    python_type = None
+    python_type = list
 
 
 class LineString(ChSqlaType, UserDefinedType):
-    python_type = None
+    python_type = list
 
 
 class MultiLineString(ChSqlaType, UserDefinedType):
-    python_type = None
+    python_type = list
 
 
 class Date(ChSqlaType, SqlaDate):
@@ -412,8 +415,9 @@ class LowCardinality:
         return element.__class__(type_def=TypeDef(wrappers, orig.keys, orig.values))
 
 
-class Array(ChSqlaType, UserDefinedType):
+class Array(ChSqlaType, ARRAY):
     python_type = list
+    dimensions = 1
 
     def __init__(self, element: ChSqlaType | type[ChSqlaType] = None, type_def: TypeDef = None):
         """
@@ -425,7 +429,10 @@ class Array(ChSqlaType, UserDefinedType):
             if callable(element):
                 element = element()
             type_def = TypeDef(values=(element.name,))
-        super().__init__(type_def)
+        ChSqlaType.__init__(self, type_def)
+        # Set item_type directly; calling ARRAY.__init__ would reject nested Array(Array(T)),
+        # which CH supports natively (CH expresses dimensions via nesting, not a dim count).
+        self.item_type = sqla_type_from_name(type_def.values[0])
 
 
 class Map(ChSqlaType, UserDefinedType):
@@ -489,7 +496,7 @@ class JSON(ChSqlaType, UserDefinedType):
     Note this isn't currently supported for insert/select, only table definitions
     """
 
-    python_type = None
+    python_type = dict
 
 
 class Nested(ChSqlaType, UserDefinedType):
@@ -497,11 +504,11 @@ class Nested(ChSqlaType, UserDefinedType):
     Note this isn't currently supported for insert/select, only table definitions
     """
 
-    python_type = None
+    python_type = list
 
 
 class SimpleAggregateFunction(ChSqlaType, UserDefinedType):
-    python_type = None
+    python_type = str
 
     def __init__(
         self,
@@ -532,7 +539,7 @@ class AggregateFunction(ChSqlaType, UserDefinedType):
     Note this isn't currently supported for insert/select, only table definitions
     """
 
-    python_type = None
+    python_type = str
 
     def __init__(self, *params, type_def: TypeDef = None):
         """

--- a/clickhouse_connect/cc_sqlalchemy/datatypes/sqltypes.py
+++ b/clickhouse_connect/cc_sqlalchemy/datatypes/sqltypes.py
@@ -432,7 +432,9 @@ class Array(ChSqlaType, ARRAY):
         ChSqlaType.__init__(self, type_def)
         # Set item_type directly; calling ARRAY.__init__ would reject nested Array(Array(T)),
         # which CH supports natively (CH expresses dimensions via nesting, not a dim count).
+        # as_tuple has no class-level default, so set it here to satisfy ARRAY result processing.
         self.item_type = sqla_type_from_name(type_def.values[0])
+        self.as_tuple = False
 
 
 class Map(ChSqlaType, UserDefinedType):

--- a/clickhouse_connect/cc_sqlalchemy/dialect.py
+++ b/clickhouse_connect/cc_sqlalchemy/dialect.py
@@ -5,7 +5,7 @@ from sqlalchemy.exc import NoResultFound, NoSuchTableError
 
 from clickhouse_connect import dbapi
 from clickhouse_connect.cc_sqlalchemy import dialect_name, ischema_names
-from clickhouse_connect.cc_sqlalchemy.inspector import ChInspector, get_table_metadata
+from clickhouse_connect.cc_sqlalchemy.inspector import ChInspector, get_columns, get_pk_constraint, get_table_metadata
 from clickhouse_connect.cc_sqlalchemy.sql import full_table
 from clickhouse_connect.cc_sqlalchemy.sql.compiler import ChStatementCompiler
 from clickhouse_connect.cc_sqlalchemy.sql.ddlcompiler import ChDDLCompiler
@@ -94,11 +94,14 @@ class ClickHouseDialect(DefaultDialect):
             cmd += " FROM " + quote_identifier(schema)
         return [row.name for row in connection.execute(text(cmd))]
 
+    def get_columns(self, connection, table_name, schema=None, **kw):
+        return get_columns(connection, table_name, schema)
+
     def get_primary_keys(self, connection, table_name, schema=None, **kw):
-        return []
+        return get_pk_constraint(connection, table_name, schema)["constrained_columns"]
 
     def get_pk_constraint(self, connection, table_name, schema=None, **kw):
-        return {"constrained_columns": [], "name": None}
+        return get_pk_constraint(connection, table_name, schema)
 
     def get_foreign_keys(self, connection, table_name, schema=None, **kw):
         return []

--- a/clickhouse_connect/cc_sqlalchemy/dialect.py
+++ b/clickhouse_connect/cc_sqlalchemy/dialect.py
@@ -5,7 +5,7 @@ from sqlalchemy.exc import NoResultFound, NoSuchTableError
 
 from clickhouse_connect import dbapi
 from clickhouse_connect.cc_sqlalchemy import dialect_name, ischema_names
-from clickhouse_connect.cc_sqlalchemy.inspector import ChInspector, get_columns, get_pk_constraint, get_table_metadata
+from clickhouse_connect.cc_sqlalchemy.inspector import ChInspector, get_columns, get_table_metadata
 from clickhouse_connect.cc_sqlalchemy.sql import full_table
 from clickhouse_connect.cc_sqlalchemy.sql.compiler import ChStatementCompiler
 from clickhouse_connect.cc_sqlalchemy.sql.ddlcompiler import ChDDLCompiler
@@ -98,10 +98,10 @@ class ClickHouseDialect(DefaultDialect):
         return get_columns(connection, table_name, schema)
 
     def get_primary_keys(self, connection, table_name, schema=None, **kw):
-        return get_pk_constraint(connection, table_name, schema)["constrained_columns"]
+        return []
 
     def get_pk_constraint(self, connection, table_name, schema=None, **kw):
-        return get_pk_constraint(connection, table_name, schema)
+        return {"constrained_columns": [], "name": None}
 
     def get_foreign_keys(self, connection, table_name, schema=None, **kw):
         return []

--- a/clickhouse_connect/cc_sqlalchemy/inspector.py
+++ b/clickhouse_connect/cc_sqlalchemy/inspector.py
@@ -121,6 +121,47 @@ def get_dictionary_metadata(connection, table_name: str, schema: str | None = No
     return metadata
 
 
+def get_pk_constraint(connection, table_name: str, schema: str | None = None) -> dict[str, Any]:
+    database = _database_name(connection, schema)
+    result_set = connection.execute(
+        text(
+            "SELECT name FROM system.columns WHERE database = :database AND table = :table_name AND is_in_primary_key = 1 ORDER BY position"
+        ),
+        {"database": database, "table_name": table_name},
+    )
+    return {"constrained_columns": [row.name for row in result_set], "name": None}
+
+
+def get_columns(connection, table_name: str, schema: str | None = None) -> list[dict[str, Any]]:
+    table_metadata = get_table_metadata(connection, table_name, schema)
+    if table_metadata.engine == "Dictionary":
+        return get_dictionary_columns(connection, table_name, schema)
+    table_id = full_table(table_name, schema)
+    result_set = connection.execute(text(f"DESCRIBE TABLE {table_id}"))
+    if not result_set:
+        raise NoResultFound(f"Table {table_id} does not exist")
+    columns = []
+    for row in result_set:
+        sqla_type = sqla_type_from_name(row.type.replace("\n", ""))
+        col = {
+            "name": row.name,
+            "type": sqla_type,
+            "nullable": sqla_type.nullable,
+            "autoincrement": False,
+            "comment": row.comment or None,
+            "clickhouse_codec": row.codec_expression or None,
+            "clickhouse_ttl": text(row.ttl_expression) if row.ttl_expression else None,
+        }
+        if row.default_type == "DEFAULT" and row.default_expression:
+            col["server_default"] = text(row.default_expression)
+        elif row.default_type == "MATERIALIZED" and row.default_expression:
+            col["clickhouse_materialized"] = text(row.default_expression)
+        elif row.default_type == "ALIAS" and row.default_expression:
+            col["clickhouse_alias"] = text(row.default_expression)
+        columns.append(col)
+    return columns
+
+
 class ChInspector(Inspector):
     def reflect_table(
         self,
@@ -137,12 +178,15 @@ class ChInspector(Inspector):
         else:
             reflected_columns = self.get_columns(table.name, schema)
 
+        pk_columns = set(get_pk_constraint(self.bind, table.name, schema)["constrained_columns"])
         for col in reflected_columns:
             name = col.pop("name")
             if (include_columns and name not in include_columns) or (exclude_columns and name in exclude_columns):
                 continue
             col_type = col.pop("type")
             col_args = {key: value for key, value in col.items() if value is not None}
+            if name in pk_columns:
+                col_args["primary_key"] = True
             table.append_column(sa_schema.Column(name, col_type, **col_args))
         if table_metadata.engine == "Dictionary":
             dictionary_metadata = get_dictionary_metadata(self.bind, table.name, schema)
@@ -157,30 +201,4 @@ class ChInspector(Inspector):
             table.kwargs["clickhouse_engine"] = table.engine
 
     def get_columns(self, table_name, schema=None, **_kwargs):
-        table_metadata = get_table_metadata(self.bind, table_name, schema)
-        if table_metadata.engine == "Dictionary":
-            return get_dictionary_columns(self.bind, table_name, schema)
-        table_id = full_table(table_name, schema)
-        result_set = self.bind.execute(text(f"DESCRIBE TABLE {table_id}"))
-        if not result_set:
-            raise NoResultFound(f"Table {table_id} does not exist")
-        columns = []
-        for row in result_set:
-            sqla_type = sqla_type_from_name(row.type.replace("\n", ""))
-            col = {
-                "name": row.name,
-                "type": sqla_type,
-                "nullable": sqla_type.nullable,
-                "autoincrement": False,
-                "comment": row.comment or None,
-                "clickhouse_codec": row.codec_expression or None,
-                "clickhouse_ttl": text(row.ttl_expression) if row.ttl_expression else None,
-            }
-            if row.default_type == "DEFAULT" and row.default_expression:
-                col["server_default"] = text(row.default_expression)
-            elif row.default_type == "MATERIALIZED" and row.default_expression:
-                col["clickhouse_materialized"] = text(row.default_expression)
-            elif row.default_type == "ALIAS" and row.default_expression:
-                col["clickhouse_alias"] = text(row.default_expression)
-            columns.append(col)
-        return columns
+        return get_columns(self.bind, table_name, schema)

--- a/clickhouse_connect/cc_sqlalchemy/inspector.py
+++ b/clickhouse_connect/cc_sqlalchemy/inspector.py
@@ -121,17 +121,6 @@ def get_dictionary_metadata(connection, table_name: str, schema: str | None = No
     return metadata
 
 
-def get_pk_constraint(connection, table_name: str, schema: str | None = None) -> dict[str, Any]:
-    database = _database_name(connection, schema)
-    result_set = connection.execute(
-        text(
-            "SELECT name FROM system.columns WHERE database = :database AND table = :table_name AND is_in_primary_key = 1 ORDER BY position"
-        ),
-        {"database": database, "table_name": table_name},
-    )
-    return {"constrained_columns": [row.name for row in result_set], "name": None}
-
-
 def get_columns(connection, table_name: str, schema: str | None = None) -> list[dict[str, Any]]:
     table_metadata = get_table_metadata(connection, table_name, schema)
     if table_metadata.engine == "Dictionary":
@@ -178,15 +167,12 @@ class ChInspector(Inspector):
         else:
             reflected_columns = self.get_columns(table.name, schema)
 
-        pk_columns = set(get_pk_constraint(self.bind, table.name, schema)["constrained_columns"])
         for col in reflected_columns:
             name = col.pop("name")
             if (include_columns and name not in include_columns) or (exclude_columns and name in exclude_columns):
                 continue
             col_type = col.pop("type")
             col_args = {key: value for key, value in col.items() if value is not None}
-            if name in pk_columns:
-                col_args["primary_key"] = True
             table.append_column(sa_schema.Column(name, col_type, **col_args))
         if table_metadata.engine == "Dictionary":
             dictionary_metadata = get_dictionary_metadata(self.bind, table.name, schema)

--- a/tests/integration_tests/test_sqlalchemy/test_reflect.py
+++ b/tests/integration_tests/test_sqlalchemy/test_reflect.py
@@ -70,3 +70,31 @@ def test_get_table_names(test_engine: Engine, test_db: str):
     assert isinstance(system_tables, list)
     assert "columns" in system_tables
     assert "fake_table" not in system_tables
+
+
+def test_metadata_reflect_and_primary_keys(test_engine: Engine, test_db: str):
+    """Dialect-level reflection. MetaData.reflect() exercises the
+    Dialect.get_multi_columns -> Dialect.get_columns path (not
+    Inspector.get_columns), which previously raised NotImplementedError.
+    Primary key columns derived from system.columns.is_in_primary_key must
+    also land on the reflected Table, both via MetaData.reflect() and via a
+    direct Table(autoload_with=...) call."""
+    common.set_setting("invalid_setting_action", "drop")
+    with test_engine.begin() as conn:
+        conn.execute(text(f"DROP TABLE IF EXISTS {test_db}.reflect_pk_test"))
+        conn.execute(
+            text(
+                f"CREATE TABLE {test_db}.reflect_pk_test (org_id UInt32, id UInt64, payload String) ENGINE MergeTree ORDER BY (org_id, id)"
+            )
+        )
+
+    metadata = db.MetaData(schema=test_db)
+    metadata.reflect(bind=test_engine, only=["reflect_pk_test"])
+    table = metadata.tables[f"{test_db}.reflect_pk_test"]
+
+    assert {c.name for c in table.columns} == {"org_id", "id", "payload"}
+    assert [c.name for c in table.primary_key.columns] == ["org_id", "id"]
+
+    # Direct autoload should also surface the composite PK.
+    table2 = db.Table("reflect_pk_test", db.MetaData(schema=test_db), autoload_with=test_engine)
+    assert [c.name for c in table2.primary_key.columns] == ["org_id", "id"]

--- a/tests/integration_tests/test_sqlalchemy/test_reflect.py
+++ b/tests/integration_tests/test_sqlalchemy/test_reflect.py
@@ -99,3 +99,26 @@ def test_metadata_reflect(test_engine: Engine, test_db: str):
     table2 = db.Table("reflect_pk_test", db.MetaData(schema=test_db), autoload_with=test_engine)
     assert {c.name for c in table2.columns} == {"org_id", "id", "payload"}
     assert list(table2.primary_key.columns) == []
+
+
+def test_user_declared_primary_key(test_engine: Engine, test_db: str):
+    """A user-declared primary key on a pre-declared column survives reflection."""
+    common.set_setting("invalid_setting_action", "drop")
+    with test_engine.begin() as conn:
+        conn.execute(text(f"DROP TABLE IF EXISTS {test_db}.reflect_user_pk_test"))
+        conn.execute(
+            text(
+                f"CREATE TABLE {test_db}.reflect_user_pk_test (org_id UInt32, id UInt64, payload String) "
+                "ENGINE MergeTree ORDER BY (org_id, id)"
+            )
+        )
+
+    table = db.Table(
+        "reflect_user_pk_test",
+        db.MetaData(schema=test_db),
+        db.Column("org_id", UInt32, primary_key=True),
+        db.Column("id", db.BigInteger, primary_key=True),
+        autoload_with=test_engine,
+    )
+    assert [c.name for c in table.primary_key.columns] == ["org_id", "id"]
+    assert {c.name for c in table.columns} == {"org_id", "id", "payload"}

--- a/tests/integration_tests/test_sqlalchemy/test_reflect.py
+++ b/tests/integration_tests/test_sqlalchemy/test_reflect.py
@@ -72,13 +72,13 @@ def test_get_table_names(test_engine: Engine, test_db: str):
     assert "fake_table" not in system_tables
 
 
-def test_metadata_reflect_and_primary_keys(test_engine: Engine, test_db: str):
+def test_metadata_reflect(test_engine: Engine, test_db: str):
     """Dialect-level reflection. MetaData.reflect() exercises the
     Dialect.get_multi_columns -> Dialect.get_columns path (not
     Inspector.get_columns), which previously raised NotImplementedError.
-    Primary key columns derived from system.columns.is_in_primary_key must
-    also land on the reflected Table, both via MetaData.reflect() and via a
-    direct Table(autoload_with=...) call."""
+    The dialect does not reflect a primary key: ClickHouse PRIMARY KEY /
+    ORDER BY is not a uniqueness guarantee, so the identity key is left for
+    application code to declare explicitly."""
     common.set_setting("invalid_setting_action", "drop")
     with test_engine.begin() as conn:
         conn.execute(text(f"DROP TABLE IF EXISTS {test_db}.reflect_pk_test"))
@@ -93,8 +93,9 @@ def test_metadata_reflect_and_primary_keys(test_engine: Engine, test_db: str):
     table = metadata.tables[f"{test_db}.reflect_pk_test"]
 
     assert {c.name for c in table.columns} == {"org_id", "id", "payload"}
-    assert [c.name for c in table.primary_key.columns] == ["org_id", "id"]
+    assert list(table.primary_key.columns) == []
 
-    # Direct autoload should also surface the composite PK.
+    # Direct autoload should also populate columns without a reflected PK.
     table2 = db.Table("reflect_pk_test", db.MetaData(schema=test_db), autoload_with=test_engine)
-    assert [c.name for c in table2.primary_key.columns] == ["org_id", "id"]
+    assert {c.name for c in table2.columns} == {"org_id", "id", "payload"}
+    assert list(table2.primary_key.columns) == []


### PR DESCRIPTION
## Summary

`cc_sqlalchemy` doesn't implement SQLAlchemy reflection — `MetaData.reflect()` and `Inspector.get_multi_columns()` raise `NotImplementedError` on any CH database. This breaks tools like `sqlacodegen` or other tools which introspect schema.

Mechanism: SQLAlchemy's reflection path is `Inspector -> Dialect.get_multi_columns -> Dialect.get_columns`. The dialect only ever defined `Inspector.get_columns` (on `ChInspector`), which `MetaData.reflect()` never calls on its own. Reflection falls through to the `DefaultDialect` base, which raises.

This PR fills in the missing dialect method. No runtime client paths change.

### Changes

1. **`dialect.py`** — add `ClickHouseDialect.get_columns()`.

2. **`inspector.py`** — promote `get_columns` to a module-level function shared between dialect and inspector.

3. **`datatypes/sqltypes.py` — concrete `python_type`s.** SQLAlchemy's `TypeEngine.python_type` contract is "return a class or raise `NotImplementedError`." Returning `None` (the current behavior on every UDT-based type) makes `python_type.__module__` / `.__name__` raise `AttributeError`, which is what breaks sqlacodegen:

   | Type | `python_type` |
   |---|---|
   | `UUID` | `uuid.UUID` |
   | `IPv4` / `IPv6` | `ipaddress.IPv4Address` / `IPv6Address` |
   | `Nothing` | `type(None)` |
   | `Point` | `tuple` |
   | `Ring` / `Polygon` / `MultiPolygon` / `LineString` / `MultiLineString` | `list` |
   | `JSON` | `dict` |
   | `Nested` | `list` |
   | `(Simple)AggregateFunction` | `str` |

4. **`datatypes/sqltypes.py` — `Array` now subclasses `sqlalchemy.types.ARRAY`** alongside `ChSqlaType`, exposes `item_type` as a plain instance attribute (so sqlacodegen's `fix_column_types` adaptation pass can reassign it), and sets `dimensions = 1`. `ARRAY.__init__` is *not* called cooperatively because it rejects nested ARRAY `item_type`s, which CH supports natively (`Array(Array(T))`).

### Tests

`tests/integration_tests/test_sqlalchemy/test_reflect.py` covers the dialect path (`MetaData.reflect()`) and a direct `Table(autoload_with=...)` call against a MergeTree with `ORDER BY (org_id, id)`, plus a user-declared composite primary key surviving reflection.

Local: SQLAlchemy tests pass.

### Checklist

- [x] Unit and integration tests covering the common scenarios were added
- [x] CHANGELOG entry included
- [x] Docs - n/a
