### PR TITLE
don't require space for line comments

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## UNRELEASED
 
+### Bug Fixes
+- Strip `--` line comments that have no following space when classifying queries, so a DDL with a leading `--sql`-style comment is routed as a command instead of raising `StreamFailureError`. Closes [#499](https://github.com/ClickHouse/clickhouse-connect/issues/499).
+
 ## 1.1.1, 2026-05-27
 
 ### Bug Fixes

--- a/clickhouse_connect/driver/query.py
+++ b/clickhouse_connect/driver/query.py
@@ -403,7 +403,7 @@ class QueryResult(Closable):
             self._block_gen = None
 
 
-comment_re = re.compile(r"(\".*?\"|\'.*?\')|(/\*.*?\*/|(--\s)[^\n]*$)", re.MULTILINE | re.DOTALL)
+comment_re = re.compile(r"(\".*?\"|\'.*?\')|(/\*.*?\*/|(--)[^\n]*$)", re.MULTILINE | re.DOTALL)
 
 
 def remove_sql_comments(sql: str) -> str:

--- a/tests/unit_tests/test_driver/test_parser.py
+++ b/tests/unit_tests/test_driver/test_parser.py
@@ -60,3 +60,15 @@ LIMIT
 -- 6dcd92a04feb50f14bbcf07c661680ba
 """
     assert remove_sql_comments(sql) == "SELECT \n* FROM benchmark_results  WHERE result = 'True'\n\nLIMIT\n\n2\n\n"
+
+
+def test_remove_comments_no_space_after_dashes():
+    # leading `--sql` comment at start of input
+    assert remove_sql_comments("--sql\nSELECT 1") == "\nSELECT 1"
+    # mid-query comment with no space after the dashes
+    assert remove_sql_comments("SELECT 1--1") == "SELECT 1"
+    # comment running to end of input with no trailing newline
+    assert remove_sql_comments("SELECT 1 --done") == "SELECT 1 "
+    # `--` inside quoted strings is preserved
+    assert remove_sql_comments("SELECT 'a--b'") == "SELECT 'a--b'"
+    assert remove_sql_comments('SELECT "a--b"') == 'SELECT "a--b"'

--- a/tests/unit_tests/test_driver/test_query.py
+++ b/tests/unit_tests/test_driver/test_query.py
@@ -94,6 +94,19 @@ def test_non_row_policy_show_empty_body_uses_query_summary(query):
     assert returns_empty_string_on_empty_body(query) is False
 
 
+@pytest.mark.parametrize(
+    "query",
+    [
+        "--sql\nCREATE OR REPLACE TABLE x (a String) ENGINE=MergeTree ORDER BY tuple()",
+        "--anything\nDROP TABLE x",
+        "--sql\n  ALTER TABLE x ADD COLUMN y UInt32",
+        "/*sql*/CREATE TABLE x (a String) ENGINE=Memory",
+    ],
+)
+def test_leading_no_space_comment_is_command(query):
+    assert QueryContext(query).is_command is True
+
+
 def test_active_tz_utc_defaults_to_naive():
     ctx = QueryContext(query_tz=zoneinfo.ZoneInfo("UTC"))
     assert ctx.tz_mode == "naive_utc"


### PR DESCRIPTION
## Summary

`client.query()` raised `StreamFailureError` on a `CREATE ... ON CLUSTER` DDL when the query began with a `--sql` magic comment with no space after the dashes.

The comment-stripping regex used for query classification required whitespace after `--`, so `--sql` wasn't stripped, `is_command` returned False, and the DDL was sent through the Native query path instead of being routed as a command.

The fix strips `--` line comments regardless of a following space, matching ClickHouse's lexer.

Closes #499

## Checklist
Delete items not relevant to your PR:
- [X] Unit and integration tests covering the common scenarios were added
- [X] A human-readable description of the changes was provided to include in CHANGELOG