### PR TITLE
add opt-in server-side bind parameters to sqlalchemy dialect

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## UNRELEASED
 
+### Improvements
+- SQLAlchemy: opt-in server-side bind parameters via `create_engine(url, server_side_params=True)`. The dialect then emits ClickHouse native `{name:Type}` / `{name:Array(Type)}` placeholders instead of client-side string interpolation. Off by default. Closes [#735](https://github.com/ClickHouse/clickhouse-connect/issues/735).
+
 ### Bug Fixes
 - Strip `--` line comments that have no following space when classifying queries, so a DDL with a leading `--sql`-style comment is routed as a command instead of raising `StreamFailureError`. Closes [#499](https://github.com/ClickHouse/clickhouse-connect/issues/499).
 

--- a/clickhouse_connect/cc_sqlalchemy/dialect.py
+++ b/clickhouse_connect/cc_sqlalchemy/dialect.py
@@ -61,6 +61,11 @@ class ClickHouseDialect(DefaultDialect):
         ),
     ]
 
+    def __init__(self, server_side_params: bool = False, **kwargs):
+        # Set before super().__init__() so ChIdentifierPreparer can read it when built.
+        self.server_side_params = server_side_params
+        super().__init__(**kwargs)
+
     # SQA 1 compatibility
 
     @classmethod

--- a/clickhouse_connect/cc_sqlalchemy/inspector.py
+++ b/clickhouse_connect/cc_sqlalchemy/inspector.py
@@ -4,7 +4,7 @@ from collections.abc import Collection
 from typing import Any
 
 import sqlalchemy.schema as sa_schema
-from sqlalchemy import text
+from sqlalchemy import String, bindparam, text
 from sqlalchemy.engine.reflection import Inspector
 from sqlalchemy.exc import NoResultFound
 
@@ -27,7 +27,9 @@ def _database_name(connection, schema: str | None) -> str:
 def get_table_metadata(connection, table_name, schema=None):
     database = _database_name(connection, schema)
     result_set = connection.execute(
-        text("SELECT engine, engine_full, comment FROM system.tables WHERE database = :database AND name = :table_name"),
+        text("SELECT engine, engine_full, comment FROM system.tables WHERE database = :database AND name = :table_name").bindparams(
+            bindparam("database", type_=String()), bindparam("table_name", type_=String())
+        ),
         {"database": database, "table_name": table_name},
     )
     row = next(result_set, None)

--- a/clickhouse_connect/cc_sqlalchemy/sql/compiler.py
+++ b/clickhouse_connect/cc_sqlalchemy/sql/compiler.py
@@ -1,9 +1,15 @@
+import re
+
 from sqlalchemy.exc import CompileError
 from sqlalchemy.sql import elements, sqltypes
 from sqlalchemy.sql.compiler import SQLCompiler
+from sqlalchemy.util import memoized_property
 
 from clickhouse_connect.cc_sqlalchemy.datatypes.base import ChSqlaType
 from clickhouse_connect.cc_sqlalchemy.sql import format_table
+
+# The driver's external_bind_re only recognizes \w+ placeholder names.
+_bind_name_re = re.compile(r"\w+\Z")
 
 
 def _find_outermost_marker(text, markers):
@@ -40,12 +46,8 @@ def _find_outermost_marker(text, markers):
     return -1
 
 
-def _resolve_ch_type_name(sqla_type):
-    """Resolve a SQLAlchemy type instance to a ClickHouse type name string.
-
-    Handles both native ChSqlaType instances which carry their ClickHouse name
-    directly and generic SQLAlchemy types by mapping to reasonable ClickHouse defaults.
-    """
+def _ch_type_name(sqla_type):
+    """Map a SQLAlchemy type to a ClickHouse type name, or None if unmapped."""
     if isinstance(sqla_type, ChSqlaType):
         return sqla_type.name
     # Order matters so we need to check subtypes before parent types
@@ -69,10 +71,93 @@ def _resolve_ch_type_name(sqla_type):
         return "Date"
     if isinstance(sqla_type, sqltypes.String):
         return "String"
-    return "String"
+    return None
+
+
+def _resolve_ch_type_name(sqla_type):
+    """ClickHouse type name for a VALUES column, falling back to String."""
+    return _ch_type_name(sqla_type) or "String"
+
+
+def _resolve_ch_bind_type(sqla_type):
+    """ClickHouse type name for a server-side bind, raising on unmapped types."""
+    if isinstance(sqla_type, sqltypes.TupleType):
+        return f"Tuple({', '.join(_resolve_ch_bind_type(t) for t in sqla_type.types)})"
+    name = _ch_type_name(sqla_type)
+    if name is None:
+        raise CompileError(f"server_side_params needs an explicit type for every bind; none resolved for {sqla_type!r}.")
+    return name
 
 
 class ChStatementCompiler(SQLCompiler):
+    # SQLAlchemy 1.4 does not pass bindparam_type to bindparam_string, so stash it here.
+    _ch_bind_type = None
+
+    @property
+    def _server_side_params(self):
+        return getattr(self.dialect, "server_side_params", False)
+
+    @property
+    def _ch_array_binds(self):
+        return self.__dict__.setdefault("_ch_array_bind_names", set())
+
+    @memoized_property
+    def _bind_processors(self):
+        """Bind processors with array-bound params dropped; the driver formats those."""
+        processors = SQLCompiler._bind_processors.fget(self)
+        if self._ch_array_binds:
+            return {k: v for k, v in processors.items() if k not in self._ch_array_binds}
+        return processors
+
+    def _ch_check_bind_name(self, name):
+        if not _bind_name_re.match(name):
+            raise CompileError(
+                f"server_side_params cannot bind parameter {name!r}: ClickHouse server-side "
+                "parameter names must match [A-Za-z0-9_]. Rename the bind parameter."
+            )
+
+    def visit_bindparam(self, bindparam, **kw):
+        if not self._server_side_params:
+            return super().visit_bindparam(bindparam, **kw)
+        if bindparam.expanding and not kw.get("literal_binds") and not bindparam.literal_execute:
+            return self._ch_expanding_bindparam(bindparam, **kw)
+        prev = self._ch_bind_type
+        self._ch_bind_type = bindparam.type
+        try:
+            return super().visit_bindparam(bindparam, **kw)
+        finally:
+            self._ch_bind_type = prev
+
+    def _ch_has_bind_processor(self, sqla_type):
+        if isinstance(sqla_type, sqltypes.TupleType):
+            return any(self._ch_has_bind_processor(t) for t in sqla_type.types)
+        return sqla_type._cached_bind_processor(self.dialect) is not None
+
+    def _ch_expanding_bindparam(self, bindparam, **kw):
+        """Render an IN-family bind as a single {name:Array(Type)} placeholder."""
+        # Array binds skip per-element processors, so a type that needs one can't be bound.
+        if self._ch_has_bind_processor(bindparam.type):
+            raise CompileError(f"server_side_params cannot bind an IN list of {bindparam.type!r}: it needs a bind processor.")
+        # Drop the param from post-compile expansion so its list reaches the driver intact.
+        super().visit_bindparam(bindparam, **kw)
+        self.post_compile_params = self.post_compile_params.difference([bindparam])
+        name = self._truncate_bindparam(bindparam)
+        actual = self.escaped_bind_names.get(name, name) if self.escaped_bind_names else name
+        self._ch_check_bind_name(actual)
+        self._ch_array_binds.add(actual)
+        return "{" + actual + ":Array(" + _resolve_ch_bind_type(bindparam.type) + ")}"
+
+    def bindparam_string(self, name, **kw):
+        base = super().bindparam_string(name, **kw)
+        if not self._server_side_params or kw.get("post_compile") or kw.get("expanding"):
+            return base
+        actual = self.escaped_bind_names.get(name, name) if self.escaped_bind_names else name
+        self._ch_check_bind_name(actual)
+        ch_type = kw.get("bindparam_type") or self._ch_bind_type
+        if ch_type is None:
+            raise CompileError(f"server_side_params requires a typed bind parameter, but none was available for {name!r}.")
+        return "{" + actual + ":" + _resolve_ch_bind_type(ch_type) + "}"
+
     def _raise_on_escape(self, binary, operator_name: str):
         if binary.modifiers.get("escape") is not None:
             raise CompileError(f"ClickHouse does not support the ESCAPE clause on {operator_name}")

--- a/clickhouse_connect/cc_sqlalchemy/sql/preparer.py
+++ b/clickhouse_connect/cc_sqlalchemy/sql/preparer.py
@@ -6,5 +6,10 @@ from clickhouse_connect.driver.binding import quote_identifier
 class ChIdentifierPreparer(IdentifierPreparer):
     quote_identifier = staticmethod(quote_identifier)
 
+    def __init__(self, dialect, **kwargs):
+        super().__init__(dialect, **kwargs)
+        if getattr(dialect, "server_side_params", False):
+            self._double_percents = False
+
     def _requires_quotes(self, _value):
         return True

--- a/tests/integration_tests/test_sqlalchemy/test_server_side_params.py
+++ b/tests/integration_tests/test_sqlalchemy/test_server_side_params.py
@@ -1,0 +1,110 @@
+"""End-to-end tests for the opt-in server_side_params mode (issue #735)."""
+
+from collections.abc import Iterator
+
+from pytest import fixture
+from sqlalchemy import MetaData, Table, insert, inspect, select, text, tuple_
+from sqlalchemy.engine import Engine, create_engine
+
+from tests.integration_tests.conftest import TestConfig
+from tests.integration_tests.test_sqlalchemy.conftest import verify_tables_ready
+
+TABLE = "server_side_params_test"
+
+
+@fixture(scope="module", name="server_side_engine")
+def server_side_engine_fixture(test_config: TestConfig) -> Iterator[Engine]:
+    conn_str = (
+        f"clickhousedb://{test_config.username}:{test_config.password}@{test_config.host}:"
+        f"{test_config.port}/{test_config.test_database}?ca_cert=certifi"
+    )
+    if test_config.cloud:
+        conn_str += "&select_sequential_consistency=1"
+    engine = create_engine(conn_str, server_side_params=True)
+    yield engine
+    engine.dispose()
+
+
+@fixture(scope="module", autouse=True, name="ssp_table")
+def ssp_table_fixture(test_engine: Engine, server_side_engine: Engine, test_db: str):
+    with test_engine.begin() as conn:
+        conn.execute(text(f"DROP TABLE IF EXISTS {test_db}.{TABLE}"))
+        conn.execute(
+            text(
+                f"""
+            CREATE TABLE {test_db}.{TABLE} (
+                id UInt32,
+                name String
+            ) ENGINE MergeTree() ORDER BY id
+        """
+            )
+        )
+        conn.execute(text(f"INSERT INTO {test_db}.{TABLE} (id, name) VALUES (13, 'user_1'), (79, 'user_2'), (5, 'O''Brien')"))
+        verify_tables_ready(conn, {f"{test_db}.{TABLE}": 3})
+
+    # Autoload through the server-side engine to also cover reflection in this mode.
+    md = MetaData(schema=test_db)
+    tbl = Table(TABLE, md, autoload_with=server_side_engine)
+    yield tbl
+    with test_engine.begin() as conn:
+        conn.execute(text(f"DROP TABLE IF EXISTS {test_db}.{TABLE}"))
+
+
+def _ids(engine, stmt):
+    with engine.connect() as conn:
+        return sorted(row[0] for row in conn.execute(stmt))
+
+
+def test_scalar_where(server_side_engine: Engine, ssp_table: Table):
+    stmt = select(ssp_table.c.id).where(ssp_table.c.name == "user_1")
+    assert _ids(server_side_engine, stmt) == [13]
+
+
+def test_scalar_matches_client_side(server_side_engine: Engine, test_engine: Engine, ssp_table: Table):
+    stmt = select(ssp_table.c.id).where(ssp_table.c.id > 5).where(ssp_table.c.id < 79)
+    assert _ids(server_side_engine, stmt) == _ids(test_engine, stmt)
+
+
+def test_in_clause(server_side_engine: Engine, ssp_table: Table):
+    stmt = select(ssp_table.c.id).where(ssp_table.c.id.in_([13, 5, 999]))
+    assert _ids(server_side_engine, stmt) == [5, 13]
+
+
+def test_not_in_clause(server_side_engine: Engine, ssp_table: Table):
+    stmt = select(ssp_table.c.id).where(ssp_table.c.id.notin_([13, 79]))
+    assert _ids(server_side_engine, stmt) == [5]
+
+
+def test_empty_in_clause(server_side_engine: Engine, ssp_table: Table):
+    stmt = select(ssp_table.c.id).where(ssp_table.c.id.in_([]))
+    assert _ids(server_side_engine, stmt) == []
+
+
+def test_tuple_in_clause(server_side_engine: Engine, ssp_table: Table):
+    stmt = select(ssp_table.c.id).where(tuple_(ssp_table.c.id, ssp_table.c.name).in_([(13, "user_1"), (79, "nope")]))
+    assert _ids(server_side_engine, stmt) == [13]
+
+
+def test_string_value_with_quote(server_side_engine: Engine, ssp_table: Table):
+    stmt = select(ssp_table.c.id).where(ssp_table.c.name == "O'Brien")
+    assert _ids(server_side_engine, stmt) == [5]
+
+
+def test_limit_offset(server_side_engine: Engine, ssp_table: Table):
+    stmt = select(ssp_table.c.id).order_by(ssp_table.c.id).limit(1).offset(1)
+    assert _ids(server_side_engine, stmt) == [13]
+
+
+def test_insert_then_select(server_side_engine: Engine, ssp_table: Table):
+    with server_side_engine.begin() as conn:
+        conn.execute(insert(ssp_table).values(id=21, name="user_3"))
+    stmt = select(ssp_table.c.name).where(ssp_table.c.id == 21)
+    with server_side_engine.connect() as conn:
+        assert [row[0] for row in conn.execute(stmt)] == ["user_3"]
+
+
+def test_reflection_has_table(server_side_engine: Engine, test_db: str):
+    with server_side_engine.connect() as conn:
+        inspector = inspect(conn)
+        assert inspector.has_table(TABLE, schema=test_db)
+        assert {c["name"] for c in inspector.get_columns(TABLE, schema=test_db)} == {"id", "name"}

--- a/tests/unit_tests/test_sqlalchemy/test_server_side_params.py
+++ b/tests/unit_tests/test_sqlalchemy/test_server_side_params.py
@@ -1,0 +1,115 @@
+"""Compile-time tests for the opt-in server_side_params mode (issue #735)."""
+
+import pytest
+from sqlalchemy import Integer, String, bindparam, column, select, table, text, tuple_
+from sqlalchemy.exc import CompileError
+
+from clickhouse_connect import dbapi
+from clickhouse_connect.cc_sqlalchemy.dialect import ClickHouseDialect
+
+events = table("events", column("id", Integer), column("name", String))
+
+
+def _compile(element, server_side=True):
+    dialect = ClickHouseDialect(dbapi=dbapi, server_side_params=server_side)
+    return element.compile(dialect=dialect)
+
+
+def _sql(element, server_side=True):
+    return str(_compile(element, server_side))
+
+
+def test_scalar_binds_render_server_side():
+    sql = _sql(select(events.c.id).where(events.c.name == "user_1").where(events.c.id > 13))
+    assert "{name_1:String}" in sql
+    assert "{id_1:Int32}" in sql
+    assert "%(" not in sql
+
+
+def test_between_renders_two_scalar_binds():
+    sql = _sql(select(events.c.id).where(events.c.id.between(13, 79)))
+    assert "BETWEEN {id_1:Int32} AND {id_2:Int32}" in sql
+
+
+def test_in_renders_single_array_placeholder():
+    sql = _sql(select(events.c.id).where(events.c.id.in_([13, 79, 5])))
+    assert "IN {id_1:Array(Int32)}" in sql
+    assert "POSTCOMPILE" not in sql
+    assert "IN ({id_1" not in sql
+
+
+def test_not_in_renders_array_placeholder():
+    sql = _sql(select(events.c.id).where(events.c.id.notin_([13, 79])))
+    assert "{id_1:Array(Int32)}" in sql
+    assert "POSTCOMPILE" not in sql
+
+
+def test_tuple_in_renders_array_of_tuple():
+    sql = _sql(select(events.c.id).where(tuple_(events.c.id, events.c.name).in_([(13, "u1"), (79, "u2")])))
+    assert "{param_1:Array(Tuple(Int32, String))}" in sql
+    assert "POSTCOMPILE" not in sql
+
+
+def test_mixed_scalar_and_in_has_no_pyformat():
+    sql = _sql(select(events.c.id).where(events.c.name == "u2").where(events.c.id.in_([13, 79])))
+    assert "{name_1:String}" in sql
+    assert "{id_1:Array(Int32)}" in sql
+    assert "%(" not in sql
+
+
+def test_modulo_renders_single_percent():
+    sql = _sql(select(events.c.id).where(events.c.id % 5 == 0))
+    assert "%%" not in sql
+    assert " % " in sql
+
+
+def test_limit_offset_render_server_side():
+    sql = _sql(select(events.c.id).limit(10).offset(5))
+    assert "{param_1:Int32}" in sql
+    assert "{param_2:Int32}" in sql
+
+
+def test_param_dict_keys_match_bind_names():
+    compiled = _compile(select(events.c.id).where(events.c.name == "user_1").where(events.c.id > 13))
+    assert set(compiled.params) == {"name_1", "id_1"}
+
+
+def test_flag_off_keeps_pyformat():
+    sql = _sql(select(events.c.id).where(events.c.id == 13), server_side=False)
+    assert "%(id_1)s" in sql
+    assert "{id_1:" not in sql
+
+
+def test_double_percents_disabled_only_when_enabled():
+    assert ClickHouseDialect(dbapi=dbapi, server_side_params=True).identifier_preparer._double_percents is False
+    assert ClickHouseDialect(dbapi=dbapi).identifier_preparer._double_percents is True
+
+
+def test_untyped_bind_raises():
+    with pytest.raises(CompileError):
+        _sql(select(events.c.id).where(text("id = :x")).params(x=13))
+
+
+def test_non_word_bind_name_raises():
+    with pytest.raises(CompileError):
+        _sql(select(events.c.id).where(events.c.id == bindparam("a-b", value=13, type_=Integer())))
+
+
+def test_in_list_with_bind_processor_raises():
+    from datetime import timedelta
+
+    from clickhouse_connect.cc_sqlalchemy.datatypes.sqltypes import Time
+
+    durations = table("durations", column("dur", Time()), column("id", Integer))
+    with pytest.raises(CompileError):
+        _sql(select(durations.c.id).where(durations.c.dur.in_([timedelta(seconds=5)])))
+
+
+def test_literal_binds_keep_single_percent():
+    sql_literal = str(
+        select(events.c.id)
+        .where(events.c.name == "pre%fix")
+        .compile(dialect=ClickHouseDialect(dbapi=dbapi, server_side_params=True), compile_kwargs={"literal_binds": True})
+    )
+    assert "'pre%fix'" in sql_literal
+    assert "%%" not in sql_literal


### PR DESCRIPTION
## Summary

Adds `create_engine(url, server_side_params=True)`. When enabled, the dialect emits ClickHouse native `{name:Type}` placeholders and `{name:Array(Type)}`/`{name:Array(Tuple(...))}` for `IN`, `NOT IN`, and composite `tuple_().in_()` instead of interpolating values into SQL client-side, so values are bound by the server. The parameter is False by default so existing behavior is unchanged.

## How it works
- `bindparam_string` renders scalars as `{name:Type}`. `visit_bindparam` renders the `IN` family as a single `Array` placeholder, reusing the existing `bind_query` external-bind path.
- `_double_percents` is disabled in this mode so the modulo operator and  literal % aren't doubled

## Notes
- Every bind must resolve to an explicit type. An untyped bind e.g. raw `text(":x")` will raise `CompileError` rather than guessing.
- In server-side mode, a `Time`/`Time64` value cannot be used as a bind parameter because it relies on a SQLAlchemy bind processor that server-side binding can't apply.
- This PR does not by itself fix the `DateTime64` sub-second precision issue mentioned in #735. That issue is tracked separately #739. Once a fix for that merges, server-side binds inherit it via the `DateTime64(...)` hint.

Closes #735

## Checklist
Delete items not relevant to your PR:
- [X] Unit and integration tests covering the common scenarios were added
- [X] A human-readable description of the changes was provided to include in CHANGELOG