### PR TITLE
docs: document concurrent client usage

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,3 +91,14 @@ Then create a client with `clickhouse_connect.get_async_client()`. See the
 
 The documentation for ClickHouse Connect has moved to
 [ClickHouse Docs](https://clickhouse.com/docs/integrations/python)
+
+### Concurrency and Session Ownership
+
+Do not share a session-bound client across concurrent threads or request handlers. Each client should be owned by one thread, one request, or one coroutine at a time, especially when using temporary tables, session settings, or an explicit session_id.
+
+Recommended patterns:
+- Threaded apps: create one client per thread.
+- Web handlers: create one client per request and close it in finally.
+- asyncio apps: use async with await clickhouse_connect.get_async_client(...).
+
+See [examples/concurrency_examples.py](./examples/concurrency_examples.py) for runnable examples.

--- a/examples/concurrency_examples.py
+++ b/examples/concurrency_examples.py
@@ -1,0 +1,67 @@
+#!/usr/bin/env python3 -u
+
+"""
+Runnable examples: thread-local, request-local, and async client ownership.
+Adjust SYNC_CLIENT_CONFIG / ASYNC_CLIENT_CONFIG for your server.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import threading
+
+import clickhouse_connect
+
+SYNC_CLIENT_CONFIG = {"host": "localhost", "port": 8123, "user": "default", "password": ""}
+ASYNC_CLIENT_CONFIG = {"host": "localhost", "port": 8123, "user": "default", "password": ""}
+
+_thread_status = threading.local()
+
+
+def get_thread_client():
+    client = getattr(_thread_status, "client", None)
+    if client is None:
+        client = clickhouse_connect.get_client(**SYNC_CLIENT_CONFIG)
+        _thread_status.client = client
+    return client
+
+
+def close_thread_client():
+    client = getattr(_thread_status, "client", None)
+    if client is not None:
+        client.close()
+        del _thread_status.client
+
+
+def thread_worker(job_id: int):
+    client = get_thread_client()
+    try:
+        result = client.query("SELECT 1")
+        print("thread", job_id, result.result_rows[0][0])
+    finally:
+        close_thread_client()
+
+
+def handle_request(request_id: int):
+    client = clickhouse_connect.get_client(**SYNC_CLIENT_CONFIG)
+    try:
+        result = client.query("SELECT 1")
+        return result.result_rows[0][0]
+    finally:
+        client.close()
+
+
+async def handle_async_request(request_id: int):
+    async with await clickhouse_connect.get_async_client(**ASYNC_CLIENT_CONFIG) as client:
+        result = await client.query("SELECT 1")
+        return result.result_rows[0][0]
+
+
+async def run_async_batch():
+    results = await asyncio.gather(*(handle_async_request(i) for i in range(4)))
+    print("async results", results)
+
+if __name__ == "__main__":
+    thread_worker(1)
+    print("request result:", handle_request(1))
+    asyncio.run(run_async_batch())


### PR DESCRIPTION
## Summary

Document how clickhouse-connect clients should be used in concurrent applications. Sharing a session-bound client across multiple threads or concurrent request handlers can raise concurrent query or session locking errors, so this PR recommends per-thread or request-local client ownership and points asyncio users to the async client.

## What changed

- Added a README section explaining why a session-bound client should not be shared concurrently.
- Added a runnable example at `examples/concurrency_examples.py`.
- Included three patterns:
  - thread-local client ownership
  - request-local client ownership
  - asyncio usage with `get_async_client()`
- Recommended closing clients explicitly when they are no longer needed.

## Why

Sharing session state such as temporary tables, session settings, or a session_id across concurrent queries can cause conflicts and confusing production failures. The new docs call out safe ownership patterns more clearly.

## Verification

- Ran the example successfully in a virtual environment.
- Confirmed the script works against a local ClickHouse server.

## Notes

This is a docs-only change. No runtime behavior was modified.