### PR TITLE
Add AI_POLICY.md

### DIFF
--- a/AI_POLICY.md
+++ b/AI_POLICY.md
@@ -1,0 +1,13 @@
+# ClickHouse AI Policy
+
+You can use AI for ClickHouse development. We welcome and embrace AI usage, as well as research and experiments with the frontier AI models and novel methods of AI applications for software engineering.
+
+You don't have to disclose your usage of AI. You can tell about it, share your experience, and show the methods, but it is not required. AI is a normal developer's tool, similar to an IDE, an OS, or a keyboard. We don't judge your work on the basis of the usage of AI, but we recommend taking efforts to filter out slop before sending a pull request; otherwise, it may negatively affect your reputation as an engineer.
+
+When sending generated code, you take the responsibility in the same way as for the code you have manually typed. Take efforts to read and review the code before sending - otherwise it is disrespectful to maintainers. Take efforts to understand the code base, with or without the help of AI. Low-effort pull requests that require high effort from maintainers will be closed. Do not use AI to automate your responses to maintainers.
+
+Prefer using AI for improving the code base, such as removing and simplifying code, improving the build speed, improving continuous integration tools and quality checks, reverting bad modifications, security research, and bug fixing. Keep in mind that using AI for implementing big features requires as much design consideration as without AI.
+
+When using AI, the same rules around intellectual property apply as with manually written code. Do not copy, reproduce, or include code belonging to others unless its license explicitly permits this use and all license requirements are met. You are responsible for ensuring that you have all required permissions for any submitted code, whether AI-generated or not.
+
+We will be happy to participate in research and experiments with AI models and their application methods on top of the ClickHouse code base. It could be: - benchmarks and comparisons of models, testing of models by solving identical tasks, AI reproducibility studies, performance of agentic loops, AI sandboxing, etc. ClickHouse provides an extremely comprehensive test suite to fulfill these studies, and it is one of the most actively developed open-source software in the world. If you want to share your research, you can send a letter to ai@clickhouse.com.


### PR DESCRIPTION
Adds the AI usage policy from the main ClickHouse repository: https://github.com/ClickHouse/ClickHouse/blob/master/AI_POLICY.md

This makes the policy consistent across ClickHouse client/driver repositories.