### PR TITLE
Joe/739 datetime64 parameter values silently truncated to seconds precision without  64 suffix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 - SQLAlchemy: opt-in server-side bind parameters via `create_engine(url, server_side_params=True)`. The dialect then emits ClickHouse native `{name:Type}` / `{name:Array(Type)}` placeholders instead of client-side string interpolation. Off by default. Closes [#735](https://github.com/ClickHouse/clickhouse-connect/issues/735).
 
 ### Bug Fixes
+- A `datetime` bound to a server-side `{name:DateTime64(...)}` placeholder now keeps its sub-second precision instead of being truncated to seconds. The declared parameter type drives this, so no `_64` name suffix or manual `DT64Param` wrapper is needed, and it applies through `Array` and `Tuple` hints. Plain `DateTime` binds are unchanged. Closes [#739](https://github.com/ClickHouse/clickhouse-connect/issues/739).
 - Strip `--` line comments that have no following space when classifying queries, so a DDL with a leading `--sql`-style comment is routed as a command instead of raising `StreamFailureError`. Closes [#499](https://github.com/ClickHouse/clickhouse-connect/issues/499).
 
 ## 1.1.1, 2026-05-27

--- a/clickhouse_connect/driver/binding.py
+++ b/clickhouse_connect/driver/binding.py
@@ -105,7 +105,7 @@ def _extract_tz_from_type(type_str: str) -> tzinfo | None:
 
 
 def _promote_datetime64(type_str: str, value):
-    """Wrap values bound a DateTime64 hint in DT64Param to preserve precision"""
+    """Wrap values bound to a DateTime64 hint in DT64Param to preserve precision."""
     if value is None or "datetime64" not in type_str.lower():
         return value
     try:

--- a/clickhouse_connect/driver/binding.py
+++ b/clickhouse_connect/driver/binding.py
@@ -68,22 +68,24 @@ def finalize_query(query: str, parameters: Sequence | dict[str, Any] | None, ser
     return query % tuple(format_query_value(v, server_tz) for v in parameters)
 
 
+def _unwrap_outer(type_str: str) -> tuple[str, tuple]:
+    """Strip LowCardinality/Nullable wrappers and return (base_name, args)"""
+    base = type_str.strip()
+    if base[:15].lower() == "lowcardinality(":
+        base = base[15:-1]
+    if base[:9].lower() == "nullable(":
+        base = base[9:-1]
+    base_name, values, _ = parse_callable(base)
+    return base_name, values
+
+
 def _extract_tz_from_type(type_str: str) -> tzinfo | None:
-    """Extract timezone from a ClickHouse type hint like DateTime64(6, 'UTC').
-
-    Handles LowCardinality/Nullable wrappers and container types
-    (Array, Tuple, Map). Returns None if no timezone is found or parsing fails.
-    """
+    """Resolve the timezone named in a ClickHouse type hint like DateTime64(6, 'UTC'),
+    unwrapping LowCardinality/Nullable and recursing into Array/Tuple/Map. Returns None
+    if there is no timezone or parsing fails."""
     try:
-        base = type_str.strip()
-        if base.startswith("LowCardinality"):
-            base = base[15:-1]
-        if base.startswith("Nullable"):
-            base = base[9:-1]
-
-        base_name, values, _ = parse_callable(base)
-
-        if base_name in ("DateTime", "DateTime64"):
+        base_name, values = _unwrap_outer(type_str)
+        if base_name.lower() in ("datetime", "datetime64"):
             for v in values:
                 if isinstance(v, str) and v.startswith("'") and v.endswith("'"):
                     try:
@@ -102,6 +104,25 @@ def _extract_tz_from_type(type_str: str) -> tzinfo | None:
         return None
     except Exception:
         return None
+
+
+def _promote_datetime64(type_str: str, value):
+    """Wrap values bound a DateTime64 hint in DT64Param to preserve precision"""
+    if value is None or "datetime64" not in type_str.lower():
+        return value
+    try:
+        base_name, values = _unwrap_outer(type_str)
+        base_name = base_name.lower()
+        if base_name == "datetime64":
+            return DT64Param(value) if isinstance(value, datetime) else value
+        if base_name == "array" and values and isinstance(value, (list, tuple)):
+            inner = str(values[0])
+            return type(value)(_promote_datetime64(inner, x) for x in value)
+        if base_name == "tuple" and isinstance(value, tuple) and len(values) == len(value):
+            return tuple(_promote_datetime64(str(t), x) for t, x in zip(values, value))
+        return value
+    except Exception:
+        return value
 
 
 def bind_query(
@@ -147,6 +168,7 @@ def bind_query(
                     hint_tz = _extract_tz_from_type(type_str)
                     if hint_tz is not None:
                         tz = hint_tz
+                    v = _promote_datetime64(type_str, v)
                 bound_params[f"param_{k}"] = format_bind_value(v, tz)
     else:
         query, bound_params = finalize_query(query, parameters, server_tz), {}

--- a/clickhouse_connect/driver/binding.py
+++ b/clickhouse_connect/driver/binding.py
@@ -80,9 +80,7 @@ def _unwrap_outer(type_str: str) -> tuple[str, tuple]:
 
 
 def _extract_tz_from_type(type_str: str) -> tzinfo | None:
-    """Resolve the timezone named in a ClickHouse type hint like DateTime64(6, 'UTC'),
-    unwrapping LowCardinality/Nullable and recursing into Array/Tuple/Map. Returns None
-    if there is no timezone or parsing fails."""
+    """Resolve the timezone named in a ClickHouse type hint."""
     try:
         base_name, values = _unwrap_outer(type_str)
         if base_name.lower() in ("datetime", "datetime64"):

--- a/tests/integration_tests/test_params.py
+++ b/tests/integration_tests/test_params.py
@@ -90,3 +90,10 @@ def test_datetime_64_params(param_client: Client, call):
     dt_params = [DT64Param(v) for v in dt_values]
     result = call(param_client.query, "SELECT %s as string, toDateTime64(%s,6) as dateTime", parameters=dt_params).first_row
     assert result == ("2023-06-01 07:40:02.250306", dt_values[1])
+
+    result = call(param_client.query, "SELECT {d0:DateTime64(6)}, {d1:DateTime64(9)}", parameters={"d0": dt_values[0], "d1": dt_values[1]}).first_row
+    assert result[0] == dt_values[0]
+    assert result[1] == dt_values[1]
+
+    result = call(param_client.query, "SELECT {a1:Array(DateTime64(6))}", parameters={"a1": dt_values}).first_row
+    assert result[0] == dt_values

--- a/tests/integration_tests/test_params.py
+++ b/tests/integration_tests/test_params.py
@@ -91,7 +91,9 @@ def test_datetime_64_params(param_client: Client, call):
     result = call(param_client.query, "SELECT %s as string, toDateTime64(%s,6) as dateTime", parameters=dt_params).first_row
     assert result == ("2023-06-01 07:40:02.250306", dt_values[1])
 
-    result = call(param_client.query, "SELECT {d0:DateTime64(6)}, {d1:DateTime64(9)}", parameters={"d0": dt_values[0], "d1": dt_values[1]}).first_row
+    result = call(
+        param_client.query, "SELECT {d0:DateTime64(6)}, {d1:DateTime64(9)}", parameters={"d0": dt_values[0], "d1": dt_values[1]}
+    ).first_row
     assert result[0] == dt_values[0]
     assert result[1] == dt_values[1]
 

--- a/tests/unit_tests/test_driver/test_params.py
+++ b/tests/unit_tests/test_driver/test_params.py
@@ -4,7 +4,7 @@ from datetime import date, datetime, timezone
 import pytest
 
 from clickhouse_connect.driver import tzutil
-from clickhouse_connect.driver.binding import _extract_tz_from_type, bind_query, finalize_query, format_bind_value
+from clickhouse_connect.driver.binding import DT64Param, _extract_tz_from_type, bind_query, finalize_query, format_bind_value
 
 
 def test_finalize():
@@ -50,7 +50,7 @@ class TestBindQueryTimezoneHint:
     def test_datetime64_utc_hint(self):
         query = "SELECT * FROM t WHERE dt >= {dt:DateTime64(6, 'UTC')}"
         _, params = bind_query(query, {"dt": self.dt_utc}, server_tz=self.berlin_tz)
-        assert params["param_dt"] == "2025-01-01 12:00:00"
+        assert params["param_dt"] == "2025-01-01 12:00:00.000000"
 
     def test_datetime_utc_hint(self):
         query = "SELECT * FROM t WHERE dt >= {dt:DateTime('UTC')}"
@@ -65,12 +65,12 @@ class TestBindQueryTimezoneHint:
     def test_no_hint_tz_falls_back_to_server_tz(self):
         query = "SELECT * FROM t WHERE dt >= {dt:DateTime64(6)}"
         _, params = bind_query(query, {"dt": self.dt_utc}, server_tz=self.berlin_tz)
-        assert params["param_dt"] == "2025-01-01 13:00:00"
+        assert params["param_dt"] == "2025-01-01 13:00:00.000000"
 
     def test_nullable_wrapper(self):
         query = "SELECT * FROM t WHERE dt >= {dt:Nullable(DateTime64(6, 'UTC'))}"
         _, params = bind_query(query, {"dt": self.dt_utc}, server_tz=self.berlin_tz)
-        assert params["param_dt"] == "2025-01-01 12:00:00"
+        assert params["param_dt"] == "2025-01-01 12:00:00.000000"
 
     def test_lowcardinality_nullable_wrapper(self):
         query = "SELECT * FROM t WHERE dt >= {dt:LowCardinality(Nullable(DateTime('UTC')))}"
@@ -108,3 +108,77 @@ class TestBindQueryTimezoneHint:
         query = "SELECT * FROM t WHERE dt >= {dt:NotAType!!!}"
         _, params = bind_query(query, {"dt": self.dt_utc}, server_tz=self.berlin_tz)
         assert params["param_dt"] == "2025-01-01 13:00:00"
+
+
+class TestBindQueryDateTime64Precision:
+    """A DateTime64 type hint preserves sub-second precision without a _64 suffix or DT64Param."""
+
+    utc = timezone.utc
+    dt = datetime(2025, 1, 1, 12, 0, 0, 250306, tzinfo=timezone.utc)
+
+    def test_scalar(self):
+        query = "SELECT {dt:DateTime64(6)}"
+        _, params = bind_query(query, {"dt": self.dt}, server_tz=self.utc)
+        assert params["param_dt"] == "2025-01-01 12:00:00.250306"
+
+    def test_plain_datetime_truncates(self):
+        query = "SELECT {dt:DateTime}"
+        _, params = bind_query(query, {"dt": self.dt}, server_tz=self.utc)
+        assert params["param_dt"] == "2025-01-01 12:00:00"
+
+    def test_lowercase_spelling(self):
+        query = "SELECT {dt:Datetime64(6)}"
+        _, params = bind_query(query, {"dt": self.dt}, server_tz=self.utc)
+        assert params["param_dt"] == "2025-01-01 12:00:00.250306"
+
+    def test_nullable_wrapper(self):
+        query = "SELECT {dt:Nullable(DateTime64(9))}"
+        _, params = bind_query(query, {"dt": self.dt}, server_tz=self.utc)
+        assert params["param_dt"] == "2025-01-01 12:00:00.250306"
+
+    def test_lowcardinality_nullable_wrapper(self):
+        query = "SELECT {dt:LowCardinality(Nullable(DateTime64(6)))}"
+        _, params = bind_query(query, {"dt": self.dt}, server_tz=self.utc)
+        assert params["param_dt"] == "2025-01-01 12:00:00.250306"
+
+    def test_none_nullable(self):
+        query = "SELECT {dt:Nullable(DateTime64(6))}"
+        _, params = bind_query(query, {"dt": None}, server_tz=self.utc)
+        assert params["param_dt"] == "\\N"
+
+    def test_array(self):
+        query = "SELECT {dts:Array(DateTime64(6))}"
+        dts = [self.dt, self.dt.replace(microsecond=777722)]
+        _, params = bind_query(query, {"dts": dts}, server_tz=self.utc)
+        assert params["param_dts"] == "['2025-01-01 12:00:00.250306', '2025-01-01 12:00:00.777722']"
+
+    def test_tuple(self):
+        query = "SELECT {val:Tuple(DateTime64(6), String)}"
+        _, params = bind_query(query, {"val": (self.dt, "user_1")}, server_tz=self.utc)
+        assert params["param_val"] == "('2025-01-01 12:00:00.250306', 'user_1')"
+
+    def test_array_of_tuple(self):
+        query = "SELECT {vals:Array(Tuple(DateTime64(6), String))}"
+        _, params = bind_query(query, {"vals": [(self.dt, "user_1")]}, server_tz=self.utc)
+        assert params["param_vals"] == "[('2025-01-01 12:00:00.250306', 'user_1')]"
+
+    def test_tz_hint_with_precision(self):
+        berlin = zoneinfo.ZoneInfo("Europe/Berlin")
+        query = "SELECT {dt:DateTime64(6, 'Europe/Berlin')}"
+        _, params = bind_query(query, {"dt": self.dt}, server_tz=self.utc)
+        assert params["param_dt"] == self.dt.astimezone(berlin).strftime("%Y-%m-%d %H:%M:%S.%f")
+
+    def test_lowercase_tz_hint_preserved(self):
+        query = "SELECT {dt:Datetime64(6, 'UTC')}"
+        _, params = bind_query(query, {"dt": self.dt}, server_tz=zoneinfo.ZoneInfo("Europe/Berlin"))
+        assert params["param_dt"] == "2025-01-01 12:00:00.250306"
+
+    def test_already_dt64param_not_double_wrapped(self):
+        query = "SELECT {dt:DateTime64(6)}"
+        _, params = bind_query(query, {"dt": DT64Param(self.dt)}, server_tz=self.utc)
+        assert params["param_dt"] == "2025-01-01 12:00:00.250306"
+
+    def test_malformed_hint_does_not_crash(self):
+        query = "SELECT {dt:DateTime64(((}"
+        _, params = bind_query(query, {"dt": self.dt}, server_tz=self.utc)
+        assert "param_dt" in params


### PR DESCRIPTION
## Summary
- A datetime with sub-second precision bound to a server-side `{name:DateTime64(...)}` placeholder was silently truncated to seconds, returning wrong results. The PR fixes it to now keep full precision.
- `bind_query` already parses the placeholder's declared type for timezone resolution and now it also uses a `DateTime64` hint to promote the value into the existing `DT64Param`.
- Promotion recurses through `Array` and `Tuple` incl. `Array(Tuple(DateTime64, ...)))` so the SQLAlchemy server-side bind path inherits correct precision for IN-lists and composite binds.
- Type-name matching is now case-insensitive, which also fixes a latent bug where a lowercase `Datetime64(..., 'TZ')` hint dropped its timezone.

Closes #739

## Checklist
Delete items not relevant to your PR:
- [X] Unit and integration tests covering the common scenarios were added
- [X] A human-readable description of the changes was provided to include in CHANGELOG