### PR TITLE
Add support for refreshable JWT access tokens

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Improvements
 - SQLAlchemy: opt-in server-side bind parameters via `create_engine(url, server_side_params=True)`. The dialect then emits ClickHouse native `{name:Type}` / `{name:Array(Type)}` placeholders instead of client-side string interpolation. Off by default. Closes [#735](https://github.com/ClickHouse/clickhouse-connect/issues/735).
+- Added a `token_provider` client option (sync and async). It accepts a callable returning an access token string; the callable is invoked once for the initial token and again to fetch a fresh token whenever the server rejects the current one (authentication failure), retrying the request once. Mutually exclusive with `access_token` and `username`/`password`.
 
 ### Bug Fixes
 - A `datetime` bound to a server-side `{name:DateTime64(...)}` placeholder now keeps its sub-second precision instead of being truncated to seconds. The declared parameter type drives this, so no `_64` name suffix or manual `DT64Param` wrapper is needed, and it applies through `Array` and `Tuple` hints. Plain `DateTime` binds are unchanged. Closes [#739](https://github.com/ClickHouse/clickhouse-connect/issues/739).

--- a/clickhouse_connect/driver/__init__.py
+++ b/clickhouse_connect/driver/__init__.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+from collections.abc import Awaitable, Callable
 from inspect import signature
 from typing import TYPE_CHECKING, Any
 from urllib.parse import parse_qs, urlparse
@@ -75,10 +76,14 @@ def _parse_connection_params(
     return host, username, password, port, database, interface
 
 
-def _validate_access_token(access_token: str | None, username: str | None, password: str) -> None:
-    """Validate that access_token and username/password are not both provided."""
-    if access_token and (username or password != ""):
-        raise ProgrammingError("Cannot use both access_token and username/password")
+def _validate_access_token(
+    access_token: str | None, token_provider: Callable[[], str] | None, username: str | None, password: str
+) -> None:
+    """Validate that token-based and username/password auth are not mixed."""
+    if (access_token or token_provider) and (username or password):
+        raise ProgrammingError("Cannot use both token authentication and username/password")
+    if access_token and token_provider:
+        raise ProgrammingError("Cannot use both access_token and token_provider")
 
 
 def create_client(
@@ -87,6 +92,7 @@ def create_client(
     username: str | None = None,
     password: str = "",
     access_token: str | None = None,
+    token_provider: Callable[[], str] | None = None,
     database: str = "__default__",
     interface: str | None = None,
     port: int = 0,
@@ -106,6 +112,9 @@ def create_client(
       Should not be set if `access_token` is used.
     :param access_token: JWT access token (ClickHouse Cloud feature).
       Should not be set if `username`/`password` are used.
+    :param token_provider: A callable returning a JWT access token (ClickHouse Cloud feature). Called for the initial token and
+      again to refresh it whenever the server rejects the current one.
+      Should not be set if `access_token` or `username`/`password` are used.
     :param database:  The default database for the connection. If not set, ClickHouse Connect will use the
      default database for username.
     :param interface: Must be http or https.  Defaults to http, or to https if port is set to 8443 or 443
@@ -162,7 +171,7 @@ def create_client(
     host, username, password, port, database, interface = _parse_connection_params(
         host, username, password, port, database, interface, secure, dsn, kwargs
     )
-    _validate_access_token(access_token, username, password)
+    _validate_access_token(access_token, token_provider, username, password)
 
     settings = settings or {}
     if interface.startswith("http"):
@@ -178,7 +187,10 @@ def create_client(
                     if name.startswith("ch_"):
                         name = name[3:]
                     settings[name] = value
-        return HttpClient(interface, host, port, username, password, database, access_token, settings=settings, **kwargs)
+        return HttpClient(
+            interface, host, port, username, password, database, access_token,
+            token_provider=token_provider, settings=settings, **kwargs,
+        )
     raise ProgrammingError(f"Unrecognized client type {interface}")
 
 
@@ -188,6 +200,7 @@ async def create_async_client(
     username: str | None = None,
     password: str = "",
     access_token: str | None = None,
+    token_provider: Callable[[], str | Awaitable[str]] | None = None,
     database: str = "__default__",
     interface: str | None = None,
     port: int = 0,
@@ -212,6 +225,8 @@ async def create_async_client(
     :param username: The ClickHouse username. If not set, the default ClickHouse user will be used.
     :param password: The password for username.
     :param access_token: JWT access token.
+    :param token_provider: A callable returning a JWT access token. Called for the initial token and
+      again to refresh it whenever the server rejects the current one.
     :param database:  The default database for the connection. If not set, ClickHouse Connect will use the
      default database for username.
     :param interface: Must be http or https.  Defaults to http, or to https if port is set to 8443 or 443
@@ -280,7 +295,7 @@ async def create_async_client(
     host, username, password, port, database, interface = _parse_connection_params(
         host, username, password, port, database, interface, secure, dsn, kwargs
     )
-    _validate_access_token(access_token, username, password)
+    _validate_access_token(access_token, token_provider, username, password)
 
     settings = settings or {}
     if generic_args:
@@ -307,6 +322,7 @@ async def create_async_client(
         password=password,
         database=database,
         access_token=access_token,
+        token_provider=token_provider,
         settings=settings,
         connector_limit=connector_limit,
         connector_limit_per_host=connector_limit_per_host,

--- a/clickhouse_connect/driver/__init__.py
+++ b/clickhouse_connect/driver/__init__.py
@@ -226,7 +226,8 @@ async def create_async_client(
     :param password: The password for username.
     :param access_token: JWT access token.
     :param token_provider: A callable returning a JWT access token. Called for the initial token and
-      again to refresh it whenever the server rejects the current one.
+      again to refresh it whenever the server rejects the current one. Because multiple in-flight requests
+      may each trigger a refresh concurrently, the callable must be safe to invoke in parallel.
     :param database:  The default database for the connection. If not set, ClickHouse Connect will use the
      default database for username.
     :param interface: Must be http or https.  Defaults to http, or to https if port is set to 8443 or 443

--- a/clickhouse_connect/driver/__init__.py
+++ b/clickhouse_connect/driver/__init__.py
@@ -76,9 +76,7 @@ def _parse_connection_params(
     return host, username, password, port, database, interface
 
 
-def _validate_access_token(
-    access_token: str | None, token_provider: Callable[[], str] | None, username: str | None, password: str
-) -> None:
+def _validate_access_token(access_token: str | None, token_provider: Callable[[], str] | None, username: str | None, password: str) -> None:
     """Validate that token-based and username/password auth are not mixed."""
     if (access_token or token_provider) and (username or password):
         raise ProgrammingError("Cannot use both token authentication and username/password")
@@ -187,9 +185,23 @@ def create_client(
                     if name.startswith("ch_"):
                         name = name[3:]
                     settings[name] = value
+        # token auth may also arrive via generic_args (DB-API connect_args); pop both so neither is passed twice
+        generic_access = kwargs.pop("access_token", None)
+        generic_token = kwargs.pop("token_provider", None)
+        access_token = access_token or generic_access
+        token_provider = token_provider or generic_token
+        _validate_access_token(access_token, token_provider, username, password)
         return HttpClient(
-            interface, host, port, username, password, database, access_token,
-            token_provider=token_provider, settings=settings, **kwargs,
+            interface,
+            host,
+            port,
+            username,
+            password,
+            database,
+            access_token,
+            token_provider=token_provider,
+            settings=settings,
+            **kwargs,
         )
     raise ProgrammingError(f"Unrecognized client type {interface}")
 
@@ -314,6 +326,13 @@ async def create_async_client(
 
     if "autogenerate_session_id" not in kwargs:
         kwargs["autogenerate_session_id"] = False
+
+    # token auth may also arrive via generic_args (DB-API connect_args); pop both so neither is passed twice
+    generic_access = kwargs.pop("access_token", None)
+    generic_token = kwargs.pop("token_provider", None)
+    access_token = access_token or generic_access
+    token_provider = token_provider or generic_token
+    _validate_access_token(access_token, token_provider, username, password)
 
     client = _AsyncClient(
         interface=interface,

--- a/clickhouse_connect/driver/asyncclient.py
+++ b/clickhouse_connect/driver/asyncclient.py
@@ -2035,6 +2035,8 @@ class AsyncClient(Client):
                         response.close()
                         continue
                 if self._token_provider and not auth_retried and response.headers.get(ex_header) == auth_failed_ex_code:
+                    if retry_body is None and not (data is None or isinstance(data, (bytes, bytearray, str, dict))):
+                        await self._error_handler(response)  # non-replayable body, surface the auth error instead of retrying
                     auth_retried = True
                     self.set_access_token(await self._resolve_token())
                     req_headers["Authorization"] = self.headers["Authorization"]

--- a/clickhouse_connect/driver/asyncclient.py
+++ b/clickhouse_connect/driver/asyncclient.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import asyncio
 import gzip
+import inspect
 import io
 import json
 import logging
@@ -60,6 +61,7 @@ from clickhouse_connect.driver.transform import NativeTransform
 logger = logging.getLogger(__name__)
 columns_only_re = re.compile(r"LIMIT 0\s*$", re.IGNORECASE)
 ex_header = "X-ClickHouse-Exception-Code"
+auth_failed_ex_code = "516"  # ClickHouse AUTHENTICATION_FAILED
 ex_tag_header = "X-ClickHouse-Exception-Tag"
 
 if "br" in available_compression:
@@ -197,6 +199,7 @@ class AsyncClient(Client):
         password: str | None = None,
         database: str | None = None,
         access_token: str | None = None,
+        token_provider: Callable[[], str | Awaitable[str]] | None = None,
         compress: bool | str = True,
         connect_timeout: int = 10,
         send_receive_timeout: int = 300,
@@ -242,6 +245,8 @@ class AsyncClient(Client):
             if isinstance(verify, str) and verify.lower() == "proxy":
                 verify = True
                 tls_mode = tls_mode or "proxy"
+
+        self._token_provider = token_provider  # initial token is resolved in _initialize()
 
         # Priority: access_token > mutual TLS > basic auth
         if client_cert and (tls_mode is None or tls_mode == "mutual"):
@@ -381,6 +386,9 @@ class AsyncClient(Client):
 
         if self._initialized:
             return
+
+        if self._token_provider:
+            self.set_access_token(await self._resolve_token())
 
         try:
             tz_source = self._deferred_tz_source
@@ -532,6 +540,13 @@ class AsyncClient(Client):
 
     def get_client_setting(self, key) -> str | None:
         return self._client_settings.get(key)
+
+    async def _resolve_token(self) -> str:
+        # Run sync providers off the event loop; await async providers.
+        result = await asyncio.get_running_loop().run_in_executor(None, self._token_provider)
+        if inspect.isawaitable(result):
+            result = await result
+        return result
 
     def set_access_token(self, access_token: str):
         auth_header = self.headers.get("Authorization")
@@ -1950,6 +1965,7 @@ class AsyncClient(Client):
             req_headers["Host"] = self.server_host_name
         query_session = final_params.get("session_id")
         attempts = 0
+        auth_retried = False
 
         while True:
             attempts += 1
@@ -2018,6 +2034,15 @@ class AsyncClient(Client):
                         await asyncio.sleep(0.1 * attempts)
                         response.close()
                         continue
+                if self._token_provider and not auth_retried and response.headers.get(ex_header) == auth_failed_ex_code:
+                    auth_retried = True
+                    self.set_access_token(await self._resolve_token())
+                    req_headers["Authorization"] = self.headers["Authorization"]
+                    if retry_body is not None:
+                        data = await retry_body()
+                    logger.debug("Refreshing access token after authentication failure")
+                    response.close()
+                    continue
                 await self._error_handler(response)
 
             except aiohttp.ClientConnectionError as e:

--- a/clickhouse_connect/driver/asyncclient.py
+++ b/clickhouse_connect/driver/asyncclient.py
@@ -543,6 +543,8 @@ class AsyncClient(Client):
 
     async def _resolve_token(self) -> str:
         # Run sync providers off the event loop; await async providers.
+        # The provider may be called concurrently if multiple requests get a 516 at the same time;
+        # it must be safe to invoke in parallel (e.g. if it hits an IdP, consider rate limiting).
         result = await asyncio.get_running_loop().run_in_executor(None, self._token_provider)
         if inspect.isawaitable(result):
             result = await result

--- a/clickhouse_connect/driver/httpclient.py
+++ b/clickhouse_connect/driver/httpclient.py
@@ -44,6 +44,7 @@ from clickhouse_connect.driver.transform import NativeTransform
 logger = logging.getLogger(__name__)
 columns_only_re = re.compile(r"LIMIT 0\s*$", re.IGNORECASE)
 ex_header = "X-ClickHouse-Exception-Code"
+auth_failed_ex_code = "516"  # ClickHouse AUTHENTICATION_FAILED
 ex_tag_header = "X-ClickHouse-Exception-Tag"
 
 _REMOTE_CLOSE_ERRORS = (ConnectionResetError, BrokenPipeError)
@@ -79,6 +80,7 @@ class HttpClient(Client):
         password: str,
         database: str,
         access_token: str | None = None,
+        token_provider: Callable[[], str] | None = None,
         compress: bool | str = True,
         query_limit: int = 0,
         query_retries: int = 2,
@@ -150,6 +152,9 @@ class HttpClient(Client):
             else:
                 self.http = default_pool_manager()
 
+        self._token_provider = token_provider
+        if token_provider:
+            access_token = token_provider()
         if access_token:
             self.headers["Authorization"] = f"Bearer {access_token}"
         elif (not client_cert or tls_mode in ("strict", "proxy")) and username:
@@ -532,6 +537,7 @@ class HttpClient(Client):
             data = data.encode()
         headers = dict_copy(self.headers, headers)
         attempts = 0
+        auth_retried = False
         final_params = {}
         if server_wait:
             final_params["wait_end_of_query"] = "1"
@@ -606,6 +612,14 @@ class HttpClient(Client):
                 if attempts > retries:
                     self._error_handler(response, True)
                 logger.debug("Retrying requests with status code %d", response.status)
+            elif self._token_provider and not auth_retried and response.headers.get(ex_header) == auth_failed_ex_code:
+                auth_retried = True
+                self.set_access_token(self._token_provider())
+                headers["Authorization"] = self.headers["Authorization"]
+                if retry_body is not None:
+                    kwargs["body"] = retry_body()
+                response.close()
+                logger.debug("Refreshing access token after authentication failure")
             elif error_handler:
                 error_handler(response)
             else:

--- a/clickhouse_connect/driver/httpclient.py
+++ b/clickhouse_connect/driver/httpclient.py
@@ -613,6 +613,9 @@ class HttpClient(Client):
                     self._error_handler(response, True)
                 logger.debug("Retrying requests with status code %d", response.status)
             elif self._token_provider and not auth_retried and response.headers.get(ex_header) == auth_failed_ex_code:
+                body = kwargs.get("body")
+                if retry_body is None and not (body is None or isinstance(body, (bytes, bytearray, str))):
+                    self._error_handler(response)  # non-replayable body, surface the auth error instead of retrying
                 auth_retried = True
                 self.set_access_token(self._token_provider())
                 headers["Authorization"] = self.headers["Authorization"]

--- a/tests/integration_tests/test_jwt_auth.py
+++ b/tests/integration_tests/test_jwt_auth.py
@@ -146,6 +146,119 @@ async def test_jwt_auth_async_client_set_access_token_errors(test_config: TestCo
         client.set_access_token(access_token)
 
 
+def test_token_provider_sync_client(test_config: TestConfig):
+    if not test_config.cloud:
+        pytest.skip("Skipping JWT test in non-Cloud mode")
+
+    client = create_client(
+        host=test_config.host,
+        port=test_config.port,
+        token_provider=make_access_token,
+    )
+    result = client.query(query=CHECK_CLOUD_MODE_QUERY).result_set
+    assert result == [(True,)]
+
+
+@pytest.mark.asyncio
+async def test_token_provider_async_client(test_config: TestConfig):
+    if not test_config.cloud:
+        pytest.skip("Skipping JWT test in non-Cloud mode")
+
+    client = await create_async_client(
+        host=test_config.host,
+        port=test_config.port,
+        token_provider=make_access_token,
+    )
+    result = (await client.query(query=CHECK_CLOUD_MODE_QUERY)).result_set
+    assert result == [(True,)]
+
+
+@pytest.mark.asyncio
+async def test_token_provider_async_client_async_callable(test_config: TestConfig):
+    # The async client also accepts an async (awaitable) provider.
+    if not test_config.cloud:
+        pytest.skip("Skipping JWT test in non-Cloud mode")
+
+    provider = make_async_token_provider(make_access_token())
+    client = await create_async_client(
+        host=test_config.host,
+        port=test_config.port,
+        token_provider=provider,
+    )
+    assert provider.calls == 1  # async provider awaited once for the initial token
+    result = (await client.query(query=CHECK_CLOUD_MODE_QUERY)).result_set
+    assert result == [(True,)]
+
+
+def test_token_provider_sync_client_refresh(test_config: TestConfig):
+    if not test_config.cloud:
+        pytest.skip("Skipping JWT test in non-Cloud mode")
+
+    # The provider hands out a valid token for the initial connection and a
+    # second valid token for the refresh.
+    provider = make_token_provider(make_access_token(), make_access_token())
+    client = create_client(
+        host=test_config.host,
+        port=test_config.port,
+        token_provider=provider,
+    )
+    assert provider.calls == 1  # initial token only
+
+    # A real token can't be made to expire on demand, so simulate the server
+    # rejecting the current token by overwriting the auth header with a bad value.
+    client.set_access_token("invalid.jwt.token")
+    result = client.query(query=CHECK_CLOUD_MODE_QUERY).result_set
+    assert result == [(True,)]
+    assert provider.calls == 2  # provider re-invoked exactly once to refresh
+
+
+@pytest.mark.asyncio
+async def test_token_provider_async_client_refresh(test_config: TestConfig):
+    if not test_config.cloud:
+        pytest.skip("Skipping JWT test in non-Cloud mode")
+
+    provider = make_token_provider(make_access_token(), make_access_token())
+    client = await create_async_client(
+        host=test_config.host,
+        port=test_config.port,
+        token_provider=provider,
+    )
+    assert provider.calls == 1  # initial token only
+
+    # See the sync variant above for why the header is poisoned manually.
+    client.set_access_token("invalid.jwt.token")
+    result = (await client.query(query=CHECK_CLOUD_MODE_QUERY)).result_set
+    assert result == [(True,)]
+    assert provider.calls == 2  # provider re-invoked exactly once to refresh
+
+
+def test_token_provider_sync_client_config_errors():
+    provider = make_token_provider("foobar")
+    with pytest.raises(ProgrammingError):
+        create_client(username="bob", token_provider=provider)
+    with pytest.raises(ProgrammingError):
+        create_client(username="bob", password="secret", token_provider=provider)
+    with pytest.raises(ProgrammingError):
+        create_client(password="secret", token_provider=provider)
+    with pytest.raises(ProgrammingError):
+        create_client(access_token="foo", token_provider=provider)
+    assert provider.calls == 0  # validation runs before the provider is ever called
+
+
+@pytest.mark.asyncio
+async def test_token_provider_async_client_config_errors():
+    provider = make_token_provider("foobar")
+    with pytest.raises(ProgrammingError):
+        await create_async_client(username="bob", token_provider=provider)
+    with pytest.raises(ProgrammingError):
+        await create_async_client(username="bob", password="secret", token_provider=provider)
+    with pytest.raises(ProgrammingError):
+        await create_async_client(password="secret", token_provider=provider)
+    with pytest.raises(ProgrammingError):
+        await create_async_client(access_token="foo", token_provider=provider)
+    assert provider.calls == 0  # validation runs before the provider is ever called
+
+
 CHECK_CLOUD_MODE_QUERY = "SELECT value='1' FROM system.settings WHERE name='cloud_mode'"
 JWT_SECRET_ENV_KEY = "CLICKHOUSE_CONNECT_TEST_JWT_SECRET"
 
@@ -155,3 +268,47 @@ def make_access_token():
     if not secret:
         raise ValueError(f"{JWT_SECRET_ENV_KEY} environment variable is not set")
     return secret
+
+
+class _SequenceTokenProvider:
+    """A token_provider that returns predetermined tokens in sequence.
+
+    Each invocation returns the next token; once the sequence is exhausted the
+    last token is repeated. The ``calls`` attribute records how many times the
+    provider was invoked, so tests can assert that a refresh actually happened.
+    """
+
+    def __init__(self, tokens):
+        if not tokens:
+            raise ValueError("at least one token is required")
+        self._tokens = list(tokens)
+        self.calls = 0
+
+    def _next(self):
+        token = self._tokens[min(self.calls, len(self._tokens) - 1)]
+        self.calls += 1
+        return token
+
+    def __call__(self):
+        return self._next()
+
+
+class _AsyncSequenceTokenProvider(_SequenceTokenProvider):
+    """Awaitable counterpart of _SequenceTokenProvider for the async client."""
+
+    async def __call__(self):
+        return self._next()
+
+
+def make_token_provider(*tokens):
+    """Build a sync token_provider yielding the given tokens in order.
+
+    Mirrors make_access_token, but lets a test hand out a predetermined
+    sequence (e.g. an initial token followed by a refreshed one).
+    """
+    return _SequenceTokenProvider(tokens)
+
+
+def make_async_token_provider(*tokens):
+    """Async (awaitable) counterpart of make_token_provider."""
+    return _AsyncSequenceTokenProvider(tokens)

--- a/tests/unit_tests/test_driver/test_token_provider.py
+++ b/tests/unit_tests/test_driver/test_token_provider.py
@@ -1,0 +1,315 @@
+"""Unit tests for the token_provider auth mode (sync and async).
+
+These avoid a live server: validation runs before any connection, construction
+is exercised with a recording stand-in for the client, and the auth-refresh
+retry loop is driven against a fake transport on a client built via __new__.
+"""
+
+import asyncio
+from inspect import signature
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+import clickhouse_connect.driver as drv
+from clickhouse_connect import dbapi
+from clickhouse_connect.driver import create_async_client, create_client
+from clickhouse_connect.driver.asyncclient import AsyncClient
+from clickhouse_connect.driver.exceptions import DatabaseError, ProgrammingError
+from clickhouse_connect.driver.httpclient import HttpClient, auth_failed_ex_code
+
+
+class _TokenSequence:
+    """Callable token_provider returning preset tokens, recording call count."""
+
+    def __init__(self, *tokens):
+        self._tokens = list(tokens) or ["tok"]
+        self.calls = 0
+
+    def __call__(self):
+        token = self._tokens[min(self.calls, len(self._tokens) - 1)]
+        self.calls += 1
+        return token
+
+
+class TestTokenProviderValidation:
+    def test_rejects_token_provider_with_username(self):
+        with pytest.raises(ProgrammingError):
+            create_client(username="user_1", token_provider=lambda: "t")
+
+    def test_rejects_token_provider_with_password(self):
+        with pytest.raises(ProgrammingError):
+            create_client(password="secret", token_provider=lambda: "t")
+
+    def test_rejects_token_provider_with_access_token(self):
+        with pytest.raises(ProgrammingError):
+            create_client(access_token="t", token_provider=lambda: "t")
+
+    @pytest.mark.asyncio
+    async def test_async_rejects_token_provider_with_username(self):
+        with pytest.raises(ProgrammingError):
+            await create_async_client(username="user_1", token_provider=lambda: "t")
+
+    def test_rejects_generic_args_token_provider_with_username(self):
+        with pytest.raises(ProgrammingError):
+            create_client(interface="http", host="h", port=8123, username="user_1", generic_args={"token_provider": lambda: "t"})
+
+    def test_rejects_generic_args_token_provider_with_access_token(self):
+        with pytest.raises(ProgrammingError):
+            create_client(interface="http", host="h", port=8123, access_token="t", generic_args={"token_provider": lambda: "t"})
+
+    @pytest.mark.asyncio
+    async def test_async_rejects_generic_args_token_provider_with_username(self):
+        with pytest.raises(ProgrammingError):
+            await create_async_client(
+                interface="http", host="h", port=8123, username="user_1", generic_args={"token_provider": lambda: "t"}
+            )
+
+
+class _RecordingClient:
+    """Stand-in mirroring the leading client signature so generic_args routing works."""
+
+    def __init__(
+        self,
+        interface=None,
+        host=None,
+        port=None,
+        username=None,
+        password=None,
+        database=None,
+        access_token=None,
+        token_provider=None,
+        settings=None,
+        **kwargs,
+    ):
+        self.access_token = access_token
+        self.token_provider = token_provider
+        self.extra = kwargs
+        self.server_tz = None
+
+    def _add_integration_tag(self, name):
+        pass
+
+    async def _initialize(self):
+        pass
+
+
+class TestTokenProviderConstruction:
+    """token_provider must reach the client through every entry point without colliding."""
+
+    def test_direct_create_client(self):
+        fn = lambda: "tok"  # noqa: E731
+        with patch.object(drv, "HttpClient", _RecordingClient):
+            client = create_client(interface="http", host="h", port=8123, token_provider=fn)
+        assert client.token_provider is fn
+
+    def test_create_client_via_generic_args(self):
+        fn = lambda: "tok"  # noqa: E731
+        with patch.object(drv, "HttpClient", _RecordingClient):
+            client = create_client(interface="http", host="h", port=8123, generic_args={"token_provider": fn})
+        assert client.token_provider is fn
+        assert "token_provider" not in client.extra
+
+    def test_access_token_via_generic_args(self):
+        with patch.object(drv, "HttpClient", _RecordingClient):
+            client = create_client(interface="http", host="h", port=8123, generic_args={"access_token": "jwt"})
+        assert client.access_token == "jwt"
+        assert "access_token" not in client.extra
+
+    def test_dbapi_connect(self):
+        fn = lambda: "tok"  # noqa: E731
+        with patch.object(drv, "HttpClient", _RecordingClient):
+            conn = dbapi.connect(token_provider=fn, host="h", port=8123, interface="http")
+        assert conn.client.token_provider is fn
+
+    @pytest.mark.asyncio
+    async def test_create_async_client_via_generic_args(self):
+        fn = lambda: "tok"  # noqa: E731
+        with patch("clickhouse_connect.driver.asyncclient.AsyncClient", _RecordingClient):
+            client = await create_async_client(interface="http", host="h", port=8123, generic_args={"token_provider": fn})
+        assert client.token_provider is fn
+        assert "token_provider" not in client.extra
+
+    def test_explicit_and_generic_args_access_token_no_duplicate(self):
+        with patch.object(drv, "HttpClient", _RecordingClient):
+            client = create_client(interface="http", host="h", port=8123, access_token="a", generic_args={"access_token": "b"})
+        assert client.access_token == "a"  # explicit wins, no duplicate keyword
+        assert "access_token" not in client.extra
+
+    def test_explicit_and_generic_args_token_provider_no_duplicate(self):
+        explicit = lambda: "a"  # noqa: E731
+        with patch.object(drv, "HttpClient", _RecordingClient):
+            client = create_client(
+                interface="http", host="h", port=8123, token_provider=explicit, generic_args={"token_provider": lambda: "b"}
+            )
+        assert client.token_provider is explicit  # explicit wins, no duplicate keyword
+        assert "token_provider" not in client.extra
+
+    def test_token_provider_in_httpclient_signature(self):
+        # Guards the routing the construction tests depend on.
+        assert "token_provider" in signature(HttpClient).parameters
+
+
+def _fake_response(status, ex_code=None):
+    r = MagicMock()
+    r.status = status
+    r.headers = {} if ex_code is None else {"X-ClickHouse-Exception-Code": ex_code}
+    r.data = b""
+    r.close = MagicMock()
+    return r
+
+
+def _build_sync_client(provider):
+    client = HttpClient.__new__(HttpClient)
+    client._token_provider = provider
+    client.headers = {"Authorization": f"Bearer {provider()}"}  # initial token, mirrors __init__
+    client.url = "http://localhost:8123"
+    client.params = {}
+    client.timeout = None
+    client.http_retries = 1
+    client.server_host_name = None
+    client._autogenerate_query_id = False
+    client._send_progress = None
+    client._progress_interval = None
+    client._active_session = None
+    client.show_clickhouse_errors = True
+    return client
+
+
+def _wire_sync(client, responses):
+    sent_auth = []
+    seq = iter(responses)
+
+    def fake_request(method, url, **kwargs):
+        sent_auth.append(kwargs["headers"].get("Authorization"))
+        return next(seq)
+
+    client.http = MagicMock()
+    client.http.request = fake_request
+    return sent_auth
+
+
+class TestSyncAuthRetry:
+    def test_refresh_on_516_then_success(self):
+        provider = _TokenSequence("init", "refreshed")
+        client = _build_sync_client(provider)
+        sent_auth = _wire_sync(client, [_fake_response(500, auth_failed_ex_code), _fake_response(200)])
+        resp = client._raw_request(b"SELECT 1", {})
+        assert resp.status == 200
+        assert provider.calls == 2  # initial token plus one refresh
+        assert sent_auth == ["Bearer init", "Bearer refreshed"]
+
+    def test_at_most_one_refresh(self):
+        provider = _TokenSequence("init", "refreshed", "stillbad")
+        client = _build_sync_client(provider)
+        _wire_sync(client, [_fake_response(500, auth_failed_ex_code), _fake_response(500, auth_failed_ex_code)])
+        with pytest.raises(DatabaseError):
+            client._raw_request(b"SELECT 1", {})
+        assert provider.calls == 2  # refreshed once, second failure surfaced
+
+    def test_non_replayable_body_not_retried(self):
+        provider = _TokenSequence("init", "refreshed")
+        client = _build_sync_client(provider)
+        _wire_sync(client, [_fake_response(500, auth_failed_ex_code)])
+        gen = (b"row" for _ in range(1))
+        with pytest.raises(DatabaseError):
+            client._raw_request(gen, {})  # generator body, no retry_body
+        assert provider.calls == 1  # never refreshed
+        assert next(gen) == b"row"  # body untouched, not consumed by a retry
+
+    def test_replayable_body_with_retry_body_refreshes(self):
+        provider = _TokenSequence("init", "refreshed")
+        client = _build_sync_client(provider)
+        _wire_sync(client, [_fake_response(500, auth_failed_ex_code), _fake_response(200)])
+        gen = (b"row" for _ in range(1))
+        resp = client._raw_request(gen, {}, retry_body=lambda: (b"row" for _ in range(1)))
+        assert resp.status == 200
+        assert provider.calls == 2
+
+    def test_no_provider_surfaces_immediately(self):
+        client = _build_sync_client(_TokenSequence("init"))
+        client._token_provider = None
+        _wire_sync(client, [_fake_response(500, auth_failed_ex_code)])
+        with pytest.raises(DatabaseError):
+            client._raw_request(b"SELECT 1", {})
+
+
+def _fake_async_response(status, ex_code=None):
+    r = MagicMock()
+    r.status = status
+    r.headers = {} if ex_code is None else {"X-ClickHouse-Exception-Code": ex_code}
+
+    async def _read():
+        return b""
+
+    r.read = _read
+    r.close = MagicMock()
+    return r
+
+
+class _FakeLease:
+    def __init__(self, session):
+        self.session = session
+        self.inflight = 0
+
+    def acquire(self):
+        self.inflight += 1
+
+    def release(self):
+        self.inflight -= 1
+
+
+class _FakeSession:
+    def __init__(self, responses):
+        self._seq = iter(responses)
+        self.closed = False
+        self.headers = {}
+        self.sent_auth = []
+
+    async def request(self, **kwargs):
+        self.sent_auth.append(kwargs["headers"].get("Authorization"))
+        return next(self._seq)
+
+
+def _build_async_client(provider, responses):
+    client = AsyncClient.__new__(AsyncClient)
+    client._token_provider = provider
+    client.headers = {"Authorization": f"Bearer {provider()}"}
+    client.url = "http://localhost:8123"
+    client.server_host_name = None
+    client._client_settings = {}
+    client._send_progress = None
+    client._progress_interval = None
+    client._autogenerate_query_id = False
+    client._active_session = None
+    client._last_pool_reset = None
+    client.show_clickhouse_errors = True
+    client._session_lock = asyncio.Lock()
+    session = _FakeSession(responses)
+    client._session_lease = _FakeLease(session)
+    return client, session
+
+
+class TestAsyncAuthRetry:
+    @pytest.mark.asyncio
+    async def test_refresh_on_516_then_success(self):
+        provider = _TokenSequence("init", "refreshed")
+        client, session = _build_async_client(provider, [_fake_async_response(500, auth_failed_ex_code), _fake_async_response(200)])
+        resp = await client._raw_request(b"SELECT 1", {})
+        assert resp.status == 200
+        assert provider.calls == 2
+        assert session.sent_auth == ["Bearer init", "Bearer refreshed"]
+        assert client._session_lease.inflight == 1  # held for the caller until the body is consumed
+        resp._lease_release()
+        assert client._session_lease.inflight == 0  # released after the retry, no leak
+
+    @pytest.mark.asyncio
+    async def test_non_replayable_body_not_retried(self):
+        provider = _TokenSequence("init", "refreshed")
+        client, _ = _build_async_client(provider, [_fake_async_response(500, auth_failed_ex_code)])
+        gen = (b"row" for _ in range(1))
+        with pytest.raises(DatabaseError):
+            await client._raw_request(gen, {})
+        assert provider.calls == 1
+        assert next(gen) == b"row"
+        assert client._session_lease.inflight == 0  # lease released even on the surfaced error


### PR DESCRIPTION
Now the Client object only accepts a static string containing a token. However, sometimes (e.g. for longer-running programs) this may not be enough. Now, you have to externally check whether an auth failure happened (i.e. when a token expired) and feed a new token to the client. After this change, the client will try to use the `token_provider` callable if authentication failed. This happens at most once: if the new token also fails -- the error will be surfaced.

## Summary
Support a callable token provider with auto-refresh on auth failure

## Checklist
Delete items not relevant to your PR:
- [x] Unit and integration tests covering the common scenarios were added
- [x] A human-readable description of the changes was provided to include in CHANGELOG
- [ ] For significant changes, documentation in https://github.com/ClickHouse/clickhouse-docs was updated with further explanations or tutorials
