### PR TITLE
fix bytes query parameters rendering as python repr

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 ### Bug Fixes
 - A `datetime` bound to a server-side `{name:DateTime64(...)}` placeholder now keeps its sub-second precision instead of being truncated to seconds. The declared parameter type drives this, so no `_64` name suffix or manual `DT64Param` wrapper is needed, and it applies through `Array` and `Tuple` hints. Plain `DateTime` binds are unchanged. Closes [#739](https://github.com/ClickHouse/clickhouse-connect/issues/739).
 - Strip `--` line comments that have no following space when classifying queries, so a DDL with a leading `--sql`-style comment is routed as a command instead of raising `StreamFailureError`. Closes [#499](https://github.com/ClickHouse/clickhouse-connect/issues/499).
+- `bytes`/`bytearray` query parameters now render as ClickHouse string literals (each byte as `\xHH`) instead of the Python repr, fixing inserts into `FixedString`/`String` columns through the SQLAlchemy dialect. Closes [#777](https://github.com/ClickHouse/clickhouse-connect/issues/777).
 
 ## 1.1.1, 2026-05-27
 

--- a/clickhouse_connect/driver/binding.py
+++ b/clickhouse_connect/driver/binding.py
@@ -200,6 +200,10 @@ def escape_str(value: str):
     return "".join(f"{BS}{c}" if c in must_escape else c for c in value)
 
 
+def escape_bytes(value):
+    return "".join(f"{BS}x{b:02x}" for b in value)
+
+
 def format_query_value(value: Any, server_tz: tzinfo = timezone.utc):
     """
     Format Python values in a ClickHouse query
@@ -211,6 +215,8 @@ def format_query_value(value: Any, server_tz: tzinfo = timezone.utc):
         return "NULL"
     if isinstance(value, str):
         return format_str(value)
+    if isinstance(value, (bytes, bytearray)):
+        return f"'{escape_bytes(value)}'"
     if isinstance(value, DT64Param):
         return value.format(server_tz, False)
     if isinstance(value, datetime):
@@ -258,6 +264,10 @@ def format_bind_value(value: Any, server_tz: tzinfo = timezone.utc, top_level: b
             # At the top levels, strings must not be surrounded by quotes
             return escape_str(value)
         return format_str(value)
+    if isinstance(value, (bytes, bytearray)):
+        if top_level:
+            return escape_bytes(value)
+        return f"'{escape_bytes(value)}'"
     if isinstance(value, DT64Param):
         return value.format(server_tz, top_level)
     if isinstance(value, datetime):

--- a/tests/integration_tests/test_sqlalchemy/test_inserts.py
+++ b/tests/integration_tests/test_sqlalchemy/test_inserts.py
@@ -4,7 +4,7 @@ from sqlalchemy import MetaData, text
 from sqlalchemy.engine import Engine
 from sqlalchemy.orm import Session, declarative_base
 
-from clickhouse_connect.cc_sqlalchemy.datatypes.sqltypes import LowCardinality, String, UInt64
+from clickhouse_connect.cc_sqlalchemy.datatypes.sqltypes import FixedString, LowCardinality, String, UInt64
 from clickhouse_connect.cc_sqlalchemy.ddl.tableengine import engine_map
 from clickhouse_connect.driver import Client
 
@@ -74,6 +74,31 @@ def test_multiple_insert(test_engine: Engine, test_model):
     session.add(model_2)
     session.add(model_3)
     session.commit()
+
+
+def test_bytes_insert(test_engine: Engine, test_db: str, test_table_engine: str):
+    engine_cls = engine_map[test_table_engine]
+    Base = declarative_base(metadata=MetaData(schema=test_db))  # noqa: N806
+
+    class BytesModel(Base):
+        __tablename__ = "bytes_insert_model"
+        __table_args__ = (engine_cls(order_by=["id"]),)
+        id = db.Column(FixedString(12), primary_key=True)
+        data = db.Column(String)
+
+    with test_engine.begin() as conn:
+        conn.execute(text("DROP TABLE IF EXISTS bytes_insert_model"))
+        Base.metadata.create_all(test_engine)
+
+    fixed = b"j!lUA\xf8\x93q;ky\x00"  # 12 bytes: non-UTF8 and a null byte
+    session = Session(test_engine)
+    session.add(BytesModel(id=fixed, data=b"hello"))
+    session.commit()
+
+    with test_engine.begin() as conn:
+        row = conn.execute(text("SELECT id, data FROM bytes_insert_model")).one()
+    assert row[0] == fixed
+    assert row[1] == "hello"
 
 
 def test_bulk_insert(test_engine: Engine, test_model):

--- a/tests/unit_tests/test_driver/test_params.py
+++ b/tests/unit_tests/test_driver/test_params.py
@@ -4,7 +4,14 @@ from datetime import date, datetime, timezone
 import pytest
 
 from clickhouse_connect.driver import tzutil
-from clickhouse_connect.driver.binding import DT64Param, _extract_tz_from_type, bind_query, finalize_query, format_bind_value
+from clickhouse_connect.driver.binding import (
+    DT64Param,
+    _extract_tz_from_type,
+    bind_query,
+    finalize_query,
+    format_bind_value,
+    format_query_value,
+)
 
 
 def test_finalize():
@@ -35,10 +42,33 @@ def test_finalize():
         (date(2023, 6, 1), "2023-06-01"),
         (datetime(2023, 6, 1, 20, 4, 5), "2023-06-01 20:04:05"),
         ([date(2023, 6, 1), date(2023, 8, 5)], "['2023-06-01', '2023-08-05']"),
+        (b"AB", r"\x41\x42"),
+        (b"\x00\xf8'", r"\x00\xf8\x27"),
+        ([b"AB"], r"['\x41\x42']"),
+        ((b"AB", "x"), r"('\x41\x42', 'x')"),
     ],
 )
 def test_format_bind_value(value, expected):
     assert format_bind_value(value) == expected
+
+
+@pytest.mark.parametrize(
+    "value, expected",
+    [
+        (b"AB", r"'\x41\x42'"),
+        (bytearray(b"AB"), r"'\x41\x42'"),
+        (b"j!lUA\xf8\x93q;ky\x00", r"'\x6a\x21\x6c\x55\x41\xf8\x93\x71\x3b\x6b\x79\x00'"),
+        ([b"AB", b"\x00"], r"['\x41\x42', '\x00']"),
+        ((b"AB", 1), r"('\x41\x42', 1)"),
+    ],
+)
+def test_format_query_value_bytes(value, expected):
+    assert format_query_value(value) == expected
+
+
+def test_finalize_bytes():
+    query = finalize_query("INSERT INTO t (id) VALUES (%(id)s)", {"id": b"j!lUA\xf8\x93q;ky\x00"})
+    assert query == r"INSERT INTO t (id) VALUES ('\x6a\x21\x6c\x55\x41\xf8\x93\x71\x3b\x6b\x79\x00')"
 
 
 class TestBindQueryTimezoneHint:


### PR DESCRIPTION
## Summary
- Add a `bytes` and `bytearray` branch to `format_query_value` and `format_bind_value` in `binding.py`. Each byte is emitted as `\xHH`, so the literal stays ASCII-only and is safe for quotes and null bytes.
- Quote the literal at the query and nested level. Leave it unquoted at the server-side bind top level.
- The change sits at the shared SQL-text boundary, so it also covers SQLAlchemy literal binds and nested arrays, tuples, and maps. The native binary insert path is unchanged.
- Previously a `bytes` value fell through to `%s` substitution and rendered as its Python repr like `b'...'`, so inserting into `FixedString` or `String` columns through the SQLAlchemy dialect failed with ClickHouse `SYNTAX_ERROR code 62`.

Closes #777

## Checklist
Delete items not relevant to your PR:
- [X] Unit and integration tests covering the common scenarios were added
- [X] A human-readable description of the changes was provided to include in CHANGELOG