### PR TITLE
decode dsn creds

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 - A `datetime` bound to a server-side `{name:DateTime64(...)}` placeholder now keeps its sub-second precision instead of being truncated to seconds. The declared parameter type drives this, so no `_64` name suffix or manual `DT64Param` wrapper is needed, and it applies through `Array` and `Tuple` hints. Plain `DateTime` binds are unchanged. Closes [#739](https://github.com/ClickHouse/clickhouse-connect/issues/739).
 - Strip `--` line comments that have no following space when classifying queries, so a DDL with a leading `--sql`-style comment is routed as a command instead of raising `StreamFailureError`. Closes [#499](https://github.com/ClickHouse/clickhouse-connect/issues/499).
 - `bytes`/`bytearray` query parameters now render as ClickHouse string literals (each byte as `\xHH`) instead of the Python repr, fixing inserts into `FixedString`/`String` columns through the SQLAlchemy dialect. Closes [#777](https://github.com/ClickHouse/clickhouse-connect/issues/777).
+- The `dsn` passed to `create_client`/`create_async_client` now percent-decodes the username, password, and database, so credentials containing reserved characters can be supplied URL-encoded (`pass%20word` becomes `pass word`). A literal `%` in a DSN must now be written as `%25`. A DSN with a username and no password now sends an empty password rather than the literal string `None`. Closes [#713](https://github.com/ClickHouse/clickhouse-connect/issues/713).
 
 ## 1.1.1, 2026-05-27
 

--- a/clickhouse_connect/driver/__init__.py
+++ b/clickhouse_connect/driver/__init__.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 from inspect import signature
 from typing import TYPE_CHECKING, Any
-from urllib.parse import parse_qs, urlparse
+from urllib.parse import parse_qs, unquote, urlparse
 
 import clickhouse_connect.driver.ctypes  # noqa: F401 -- side-effect import
 from clickhouse_connect.driver.client import Client
@@ -34,6 +34,11 @@ def default_port(interface: str, secure: bool) -> int:
     raise ValueError("Unrecognized ClickHouse interface")
 
 
+def _unquote(value: str | None) -> str | None:
+    """Percent-decode a DSN component, passing through None/empty."""
+    return unquote(value) if value else value
+
+
 def _parse_connection_params(
     host: str | None,
     username: str | None,
@@ -48,12 +53,12 @@ def _parse_connection_params(
     """Parse and normalize connection parameters including DSN parsing."""
     if dsn:
         parsed = urlparse(dsn)
-        username = username or parsed.username
-        password = password or parsed.password
+        username = username or _unquote(parsed.username)
+        password = password or _unquote(parsed.password) or ""
         host = host or parsed.hostname
         port = port or parsed.port
         if parsed.path and (not database or database == "__default__"):
-            database = parsed.path[1:].split("/")[0]
+            database = unquote(parsed.path[1:].split("/")[0])
         database = database or parsed.path
         for k, v in parse_qs(parsed.query).items():
             kwargs[k] = v[0]

--- a/tests/unit_tests/test_driver/test_dsn.py
+++ b/tests/unit_tests/test_driver/test_dsn.py
@@ -1,0 +1,41 @@
+from clickhouse_connect.driver import _parse_connection_params
+
+
+def parse(dsn, *, host=None, username=None, password="", port=0, database="__default__", interface=None, secure=False):
+    return _parse_connection_params(
+        host=host,
+        username=username,
+        password=password,
+        port=port,
+        database=database,
+        interface=interface,
+        secure=secure,
+        dsn=dsn,
+        kwargs={},
+    )
+
+
+def test_dsn_percent_decoded():
+    _, username, password, _, database, _ = parse("https://user%40name:pass%20word%21@host:8443/my%2Ddb")
+    assert username == "user@name"
+    assert password == "pass word!"
+    assert database == "my-db"
+
+
+def test_dsn_unencoded_unchanged():
+    _, username, password, _, database, _ = parse("http://username:password@host:8123/mydb")
+    assert (username, password, database) == ("username", "password", "mydb")
+
+
+def test_dsn_no_password():
+    # A missing DSN password normalizes to "" so Basic auth encodes "username:" not "username:None".
+    _, username, password, _, _, _ = parse("http://username@host:8123/mydb")
+    assert username == "username"
+    assert password == ""
+
+
+def test_explicit_params_override_dsn():
+    _, username, password, _, database, _ = parse(
+        "http://user%40name:pass%20word@host:8123/my%20db", username="u", password="p", database="d"
+    )
+    assert (username, password, database) == ("u", "p", "d")


### PR DESCRIPTION
## Summary
- Percent-decodes DSN username, password, and database values
- Supports URL-encoded reserved characters in credentials
- Normalizes missing DSN password to an empty string

Closes #713

## Checklist
Delete items not relevant to your PR:
- [X] Unit and integration tests covering the common scenarios were added
- [X] A human-readable description of the changes was provided to include in CHANGELOG