### PR TITLE
add windows arm64 wheel builds

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -125,10 +125,28 @@ jobs:
           name: build-windows
           path: ./wheelhouse/*.whl
 
+  build_windows_arm64_wheels:
+    name: Build ARM64 wheels on Windows
+    runs-on: windows-11-arm
+    env:
+      CIBW_ARCHS_WINDOWS: ARM64
+      CIBW_BUILD_VERBOSITY: 2
+      CIBW_ENABLE: 'cpython-freethreading'
+      CIBW_SKIP: 'cp38-* cp39-* cp313t-*'
+    steps:
+      - uses: actions/checkout@v6
+      - name: Build wheels
+        uses: pypa/cibuildwheel@v3.2.1
+      - uses: actions/upload-artifact@v7
+        with:
+          name: build-windows-arm64
+          path: ./wheelhouse/*.whl
+
   publish:
     needs:
       - build_macos_wheels
       - build_windows_wheels
+      - build_windows_arm64_wheels
       - build_x86_musllinux_wheels
       - build_x86_manylinux_wheels
       - build_aarch64_musllinux_wheels

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## UNRELEASED
 
+### Improvements
+- Build and publish Windows ARM64 `win_arm64` wheels for CPython 3.10 through 3.14, including the free-threaded 3.14 build. Closes [#785](https://github.com/ClickHouse/clickhouse-connect/issues/785).
+
 ## 1.2.0, 2026-06-08
 
 ### Improvements


### PR DESCRIPTION
## Summary
- Adds a Windows ARM64 wheel build to the release pipeline so Windows on Arm installs a binary wheel from PyPI instead of falling back to a source build.
- Builds natively on the windows-11-arm GitHub-hosted runner.
- Covers CPython 3.10 through 3.14, including the free-threaded 3.14 build. PyPy is excluded because there is no PyPy for `win_arm64`.

Closes #785

## Checklist
Delete items not relevant to your PR:
- [X] Unit and integration tests covering the common scenarios were added
- [X] A human-readable description of the changes was provided to include in CHANGELOG