### PR TITLE
fix uuid and ip address bind parameters rendering unquoted inside containers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 
 ### Bug Fixes
 - Large query parameter payloads are now automatically sent as form data in the request body instead of the URL query string. Server-side bind parameters were urlencoded into the request URL, so a large `IN` list or a high-dimensional vector embedding could produce a URL that HTTP intermediaries such as nginx, AWS ALB, and CloudFront reject with HTTP 414. The client now routes parameters to the POST body once their encoded length passes a threshold, which keeps the URL small. Setting `form_encode_query_params=True` still forces form encoding for all queries. Queries using binary parameter binds are never promoted automatically and only use form encoding when the flag is set. This does not change the server's per-value size limit, which is governed by `http_max_field_value_size`. Applies to both sync and async clients. Closes [#740](https://github.com/ClickHouse/clickhouse-connect/issues/740).
+- `uuid.UUID`, `IPv4Address`, and `IPv6Address` values nested inside `Array`, `Tuple`, or `Map` server-side bind parameters are now quoted, matching client-side parameter formatting. Previously they rendered unquoted, so an `IN` list of UUIDs bound to `{name:Array(String)}` (as produced by SQLAlchemy `Column.in_` with `server_side_params=True`) was rejected by the server with `Code: 26 ... cannot be parsed as Array(String)`. Closes [#791](https://github.com/ClickHouse/clickhouse-connect/issues/791).
 
 ## 1.2.0, 2026-06-08
 

--- a/clickhouse_connect/driver/binding.py
+++ b/clickhouse_connect/driver/binding.py
@@ -316,4 +316,8 @@ def format_bind_value(value: Any, server_tz: tzinfo = timezone.utc, top_level: b
         return f"{{{', '.join(pairs)}}}"
     if isinstance(value, Enum):
         return recurse(value.value)
+    if isinstance(value, (uuid.UUID, ipaddress.IPv4Address, ipaddress.IPv6Address)):
+        if top_level:
+            return str(value)
+        return f"'{value}'"
     return str(value)

--- a/tests/unit_tests/test_driver/test_params.py
+++ b/tests/unit_tests/test_driver/test_params.py
@@ -1,3 +1,5 @@
+import ipaddress
+import uuid
 import zoneinfo
 from datetime import date, datetime, timezone
 
@@ -46,6 +48,16 @@ def test_finalize():
         (b"\x00\xf8'", r"\x00\xf8\x27"),
         ([b"AB"], r"['\x41\x42']"),
         ((b"AB", "x"), r"('\x41\x42', 'x')"),
+        (uuid.UUID("019e1780-3b41-7673-a645-17f9b60fe8ec"), "019e1780-3b41-7673-a645-17f9b60fe8ec"),
+        (
+            [uuid.UUID("019e1780-3b41-7673-a645-17f9b60fe8ec"), uuid.UUID("019e1780-3b41-7673-a645-17f9b60fe8ed")],
+            "['019e1780-3b41-7673-a645-17f9b60fe8ec', '019e1780-3b41-7673-a645-17f9b60fe8ed']",
+        ),
+        ((uuid.UUID("019e1780-3b41-7673-a645-17f9b60fe8ec"), "user_1"), "('019e1780-3b41-7673-a645-17f9b60fe8ec', 'user_1')"),
+        (ipaddress.IPv4Address("10.13.79.1"), "10.13.79.1"),
+        ([ipaddress.IPv4Address("10.13.79.1")], "['10.13.79.1']"),
+        (ipaddress.IPv6Address("2001:db8::79"), "2001:db8::79"),
+        ([ipaddress.IPv6Address("2001:db8::79")], "['2001:db8::79']"),
     ],
 )
 def test_format_bind_value(value, expected):


### PR DESCRIPTION
## Summary
`format_bind_value` now quotes `uuid.UUID`, `IPv4Address`, and `IPv6Address` at nested level, matching `format_query_value`, so Array/Tuple/Map literals bound to server-side params (e.g. SQLAlchemy Column.in_ of UUIDs) are valid.

Closes #791 

## Checklist
- [x] Unit and integration tests covering the common scenarios were added
- [x] A human-readable description of the changes was provided to include in CHANGELOG
