### PR TITLE
Make safe for free threaded declaration

### DIFF
--- a/.github/workflows/on_push.yml
+++ b/.github/workflows/on_push.yml
@@ -123,7 +123,15 @@ jobs:
       - name: Install pip
         run:  python -m pip install --upgrade pip
       - name: Install Test Dependencies
-        run: pip install -r tests/test_requirements.txt
+        # polars ships no free-threaded wheels and its sdist needs a long Rust nightly
+        # build, so it is excluded on 3.14t and its tests skip
+        run: |
+          if [ "${{ matrix.python-version }}" = "3.14t" ]; then
+            grep -v '^polars' tests/test_requirements.txt > /tmp/test_requirements.txt
+            pip install -r /tmp/test_requirements.txt
+          else
+            pip install -r tests/test_requirements.txt
+          fi
       - name: Build cython extensions
         run: python setup.py build_ext --inplace
       - name: "Add distribution info"  #  This lets SQLAlchemy find entry points

--- a/.github/workflows/on_push.yml
+++ b/.github/workflows/on_push.yml
@@ -86,22 +86,22 @@ jobs:
           - '3.14'
         clickhouse-version:
           - '25.8' # LTS
-          - '26.2' # Stable
           - '26.3' # LTS
           - '26.4' # Stable
+          - '26.5' # Stable
         use-c:
           - '1'
         include:
           - python-version: '3.10'
-            clickhouse-version: '25.8'
+            clickhouse-version: '26.3'
             use-c: '0'
           - python-version: '3.14'
-            clickhouse-version: '26.4'
+            clickhouse-version: '26.3'
             use-c: '0'
           # Free-threaded build (experimental). PYTHON_GIL=0 keeps the GIL off when
           # dependencies that have not declared free-threading compatibility are imported.
           - python-version: '3.14t'
-            clickhouse-version: '26.4'
+            clickhouse-version: '26.3'
             use-c: '1'
             python-gil: '0'
 

--- a/.github/workflows/on_push.yml
+++ b/.github/workflows/on_push.yml
@@ -98,7 +98,15 @@ jobs:
           - python-version: '3.14'
             clickhouse-version: '26.4'
             use-c: '0'
+          # Free-threaded build (experimental). PYTHON_GIL=0 keeps the GIL off when
+          # dependencies that have not declared free-threading compatibility are imported.
+          - python-version: '3.14t'
+            clickhouse-version: '26.4'
+            use-c: '1'
+            python-gil: '0'
 
+    # The free-threaded job is non-blocking while support is experimental
+    continue-on-error: ${{ matrix.python-version == '3.14t' }}
     name: Local Tests Py=${{ matrix.python-version }} CH=${{ matrix.clickhouse-version }} C=${{ matrix.use-c }}
     steps:
       - name: Checkout
@@ -130,6 +138,8 @@ jobs:
           CLICKHOUSE_CONNECT_TEST_DOCKER: 'False'
           CLICKHOUSE_CONNECT_TEST_FUZZ: 50
           SQLALCHEMY_SILENCE_UBER_WARNING: 1
+          # Empty for non-free-threaded entries, CPython ignores an empty value
+          PYTHON_GIL: ${{ matrix.python-gil }}
         run: pytest -n 4 tests
       - name: Stop ClickHouse
         if: ${{ always() && hashFiles('docker-compose.yml') != '' }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## UNRELEASED
 
+### Improvements
+- The Cython extension modules now declare free-threading compatibility, so importing clickhouse-connect on a free-threaded Python build such as 3.14t no longer silently re-enables the GIL. As part of this change, `ResponseBuffer.read_uint64` no longer uses a module level scratch buffer for its big-endian byte swap, which was the one piece of shared mutable state in the C modules. Building from source now requires Cython 3.1 or later. The CI test matrix now runs the full suite on free-threaded Python 3.14t as a non-blocking job. Free-threading support remains experimental.
+
 ## 1.3.0, 2026-06-11
 
 ### Improvements

--- a/clickhouse_connect/driverc/buffer.pyx
+++ b/clickhouse_connect/driverc/buffer.pyx
@@ -1,3 +1,4 @@
+# cython: freethreading_compatible = True
 import sys
 from typing import Iterable, Any, Optional
 
@@ -22,10 +23,17 @@ cdef char * errors = 'strict'
 cdef char * utf8 = 'utf8'
 cdef dict array_templates = {}
 cdef bint must_swap = sys.byteorder == 'big'
-cdef array.array swapper = array.array('Q', [0])
 
 for c in 'bBuhHiIlLqQfd':
     array_templates[c] = array.array(c, [])
+
+
+cdef inline unsigned long long _bswap_uint64(unsigned long long v):
+    """Byte-swap a 64-bit unsigned integer for big-endian systems."""
+    return (((v & 0xFF) << 56) | (((v >> 8) & 0xFF) << 48) |
+            (((v >> 16) & 0xFF) << 40) | (((v >> 24) & 0xFF) << 32) |
+            (((v >> 32) & 0xFF) << 24) | (((v >> 40) & 0xFF) << 16) |
+            (((v >> 48) & 0xFF) << 8) | ((v >> 56) & 0xFF))
 
 
 cdef class ResponseBuffer:
@@ -279,11 +287,11 @@ cdef class ResponseBuffer:
     @cython.wraparound(False)
     def read_uint64(self) -> int:
         cdef ull_wrapper* x
+        cdef unsigned long long tmp
         cdef char* b = self.read_bytes_c(8)
         if must_swap:
-            memcpy(swapper.data.as_voidptr, b, 8)
-            swapper.byteswap()
-            return swapper[0]
+            memcpy(&tmp, b, 8)
+            return _bswap_uint64(tmp)
         x = <ull_wrapper *> b
         return x.int_value
 

--- a/clickhouse_connect/driverc/dataconv.pyx
+++ b/clickhouse_connect/driverc/dataconv.pyx
@@ -1,3 +1,4 @@
+# cython: freethreading_compatible = True
 import struct
 from typing import Sequence, Optional
 

--- a/clickhouse_connect/driverc/npconv.pyx
+++ b/clickhouse_connect/driverc/npconv.pyx
@@ -1,3 +1,4 @@
+# cython: freethreading_compatible = True
 import cython
 
 import numpy as np

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,5 @@
 [build-system]
-requires = ["setuptools", "cython>=3.0.11,<4"]
+requires = ["setuptools", "cython>=3.1,<4"]
 
 build-backend = "setuptools.build_meta"
 

--- a/tests/test_requirements.txt
+++ b/tests/test_requirements.txt
@@ -4,7 +4,7 @@ certifi
 aiohttp>=3.9.0
 sqlalchemy>=2.0,<3.0
 alembic>=1.16
-cython==3.0.11
+cython==3.2.5
 pyarrow
 pytest
 pytest-asyncio

--- a/tests/unit_tests/test_freethreading.py
+++ b/tests/unit_tests/test_freethreading.py
@@ -1,0 +1,31 @@
+import os
+import subprocess
+import sys
+import sysconfig
+
+import pytest
+
+pytest.importorskip("clickhouse_connect.driverc.buffer")
+
+CHECK_SCRIPT = """
+import sys
+import warnings
+
+warnings.filterwarnings("error", category=RuntimeWarning)
+import clickhouse_connect.driverc.buffer
+import clickhouse_connect.driverc.dataconv
+import clickhouse_connect.driverc.npconv
+
+sys.exit(0 if not sys._is_gil_enabled() else 1)
+"""
+
+
+@pytest.mark.skipif(
+    sysconfig.get_config_var("Py_GIL_DISABLED") != 1,
+    reason="requires a free-threaded Python build",
+)
+def test_c_modules_keep_gil_disabled():
+    # Strip PYTHON_GIL so the check reflects the module declarations, not a CI override
+    env = {k: v for k, v in os.environ.items() if k != "PYTHON_GIL"}
+    result = subprocess.run([sys.executable, "-c", CHECK_SCRIPT], capture_output=True, text=True, check=False, env=env)
+    assert result.returncode == 0, result.stderr


### PR DESCRIPTION
## Summary

The published cp314t wheels install and work, but importing the package silently re-enabled the GIL. CPython turns the GIL back on when it loads any extension module that does not set the `Py_mod_gil` slot, and none of the three Cython modules in `clickhouse_connect/driverc` declared it. This PR audits those modules for free-threading safety, fixes the one real safety issue found, and declares compatibility so the GIL stays off.

## Changes

- Add the `freethreading_compatible = True` directive to `buffer.pyx`, `dataconv.pyx`, and `npconv.pyx`.
- Remove the module level scratch array used by `ResponseBuffer.read_uint64` for its big-endian byte swap. Two threads in that path could race on the shared buffer and read each other's values. It now copies into a local and swaps with an inline helper identical to the one `dataconv.pyx` already uses. This was the only shared mutable state in the C modules. The branch only executes on big-endian hosts, which we do not publish wheels for anyway, and the replacement is functionally equivalent for source builds on that hardware.
- Bump the build requirement to `cython>=3.1`, which the directive requires, and bump the test requirements pin to `cython 3.2.5` so CI in place builds keep working.
- Exclude polars from the test dependencies on the 3.14t job. `polars` only ships abi3 wheels as of today, which pip rejects on free-threaded builds, so installing it triggers a full Rust source build of the polars engine on the runner. The polars tests already skip when the package is not installed. The exclusion can be removed once polars publishes free-threaded wheels. `zstandard` and `lz4` also lack cp314t wheels but their C source builds are quick and the resulting modules declare free-threading compatibility, so they can stay.
- Add a unit test that imports the three C modules in a subprocess with `RuntimeWarning`s escalated to errors and asserts the GIL stays disabled. It runs only on free-threaded builds and catches any future module that misses the directive.

## Audit

`dataconv` and `npconv` have no module level mutable state. All module globals are written once at import and read only afterward, and every read function builds freshly allocated thread private containers. The write functions mutate caller supplied `bytearrays` that the driver creates per output block. The buffer's per object state is mutable but matches the existing contract that individual objects are not thread safe, and the driver creates one buffer per HTTP response and never shares one across concurrent threads.

## Testing

All testing ran on CPython 3.14.0 free-threaded, macOS arm64, built with Cython 3.2.x, against a live ClickHouse server, with the GIL verified off throughout. Everything passed.

- Import check. GIL confirmed disabled before and after importing all three modules, no `RuntimeWarning`, and the C ResponseBuffer confirmed active rather than the pure Python fallback.
- Mixed type concurrent reads. 16 threads with per thread clients, 50 iterations each, covering `String`, `FixedString`, `Nullable`, `DateTime` with and without timezone, `DateTime64`, `Date`, `Date32`, `UUID`, `IPv4`, `IPv6`, `Array`, `Map`, `LowCardinality`, `Int64` and the `UInt64` and `LEB128` paths. Every cell verified against deterministic expected values, 80,000 rows per run, run twice, zero mismatches.
- Shared client. The same workload through a single client with `autogenerate_session_id=False` across 16 threads, zero mismatches.
- Concurrent inserts. 8 threads inserting mixed type batches, 8,000 rows round tripped and verified, exercising the `write_str_col` and `write_native_col` paths.
- Streaming. 6 threads each consuming `query_rows_stream` over 200,000 rows, 1.2 million rows verified.
- numpy path. Concurrent `query_np` calls, 2.4 million rows verified.
- Pure Python baseline. The same harness with `CLICKHOUSE_CONNECT_USE_C=0` and the GIL off, identical results to the C path.
- Test suites. Full unit suite 743 passed and integration suite 593 passed with 16 environmental skips under 3.14t.

No segfaults, hangs, exceptions or data mismatches in any scenario.

## Notes

- Free-threading support remains experimental. This change removes the silent GIL re-enable but does not promise thread safety beyond the documented contracts.
- Users already on 3.14t have been getting GIL semantics by accident. After this change they get true no-GIL execution. PYTHON_GIL=1 restores the old behavior if needed.
- The big-endian branch cannot be exercised in CI since the matrix has no big-endian hardware. That was equally true before this change, and the swap logic is byte for byte the helper `dataconv` has shipped for years.
- SQLAlchemy users on 3.14t will still see the GIL re-enabled by SQLAlchemy's own cyextension modules. That is outside this package's control.

## Checklist
Delete items not relevant to your PR:
- [X] Unit and integration tests covering the common scenarios were added
- [X] A human-readable description of the changes was provided to include in CHANGELOG