### PR TITLE
add mypy to CI with a per-module baseline for issue #692

### DIFF
--- a/.github/workflows/on_push.yml
+++ b/.github/workflows/on_push.yml
@@ -44,6 +44,22 @@ jobs:
       - name: Ruff lint check
         run: ruff check clickhouse_connect tests examples setup.py
 
+  typecheck:
+    runs-on: ubuntu-latest
+    name: Mypy
+    steps:
+      - uses: actions/checkout@v6
+      - name: Set up Python 3.12
+        uses: actions/setup-python@v6
+        with:
+          python-version: "3.12"
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install -r tests/test_requirements.txt
+      - name: Mypy check
+        run: mypy
+
   bare-import-test:
     runs-on: ubuntu-latest
     needs: lint

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,6 +31,80 @@ ignore = [
     "B905",
 ]
 
+[tool.mypy]
+files = ["clickhouse_connect"]
+python_version = "3.10"
+
+[[tool.mypy.overrides]]
+# Optional dependencies without type stubs and the compiled Cython modules.
+module = [
+    "brotli.*",
+    "lz4.*",
+    "orjson.*",
+    "pandas.*",
+    "pyarrow.*",
+    "tzlocal.*",
+    "ujson.*",
+    "clickhouse_connect.driverc.*",
+]
+ignore_missing_imports = true
+
+[[tool.mypy.overrides]]
+# Baseline of modules that do not yet pass type checking (issue #692).
+# Remove entries as modules are annotated and pass cleanly.
+module = [
+    "clickhouse_connect.cc_sqlalchemy.alembic.impl",
+    "clickhouse_connect.cc_sqlalchemy.alembic.utils",
+    "clickhouse_connect.cc_sqlalchemy.datatypes.base",
+    "clickhouse_connect.cc_sqlalchemy.datatypes.sqltypes",
+    "clickhouse_connect.cc_sqlalchemy.ddl.custom",
+    "clickhouse_connect.cc_sqlalchemy.ddl.tableengine",
+    "clickhouse_connect.cc_sqlalchemy.dialect",
+    "clickhouse_connect.cc_sqlalchemy.sql",
+    "clickhouse_connect.cc_sqlalchemy.sql.preparer",
+    "clickhouse_connect.datatypes.base",
+    "clickhouse_connect.datatypes.container",
+    "clickhouse_connect.datatypes.dynamic",
+    "clickhouse_connect.datatypes.format",
+    "clickhouse_connect.datatypes.network",
+    "clickhouse_connect.datatypes.numeric",
+    "clickhouse_connect.datatypes.registry",
+    "clickhouse_connect.datatypes.special",
+    "clickhouse_connect.datatypes.string",
+    "clickhouse_connect.datatypes.temporal",
+    "clickhouse_connect.datatypes.vector",
+    "clickhouse_connect.dbapi",
+    "clickhouse_connect.dbapi.connection",
+    "clickhouse_connect.dbapi.cursor",
+    "clickhouse_connect.driver",
+    "clickhouse_connect.driver.asyncclient",
+    "clickhouse_connect.driver.asyncqueue",
+    "clickhouse_connect.driver.binding",
+    "clickhouse_connect.driver.buffer",
+    "clickhouse_connect.driver.client",
+    "clickhouse_connect.driver.common",
+    "clickhouse_connect.driver.compression",
+    "clickhouse_connect.driver.context",
+    "clickhouse_connect.driver.dataconv",
+    "clickhouse_connect.driver.ddl",
+    "clickhouse_connect.driver.exceptions",
+    "clickhouse_connect.driver.httpclient",
+    "clickhouse_connect.driver.httputil",
+    "clickhouse_connect.driver.insert",
+    "clickhouse_connect.driver.npquery",
+    "clickhouse_connect.driver.parser",
+    "clickhouse_connect.driver.query",
+    "clickhouse_connect.driver.streaming",
+    "clickhouse_connect.driver.summary",
+    "clickhouse_connect.driver.transform",
+    "clickhouse_connect.driver.types",
+    "clickhouse_connect.driver.tzutil",
+    "clickhouse_connect.json_impl",
+    "clickhouse_connect.tools.datagen",
+    "clickhouse_connect.tools.testing",
+]
+ignore_errors = true
+
 [tool.pytest.ini_options]
 log_cli = true
 log_cli_level = "INFO"

--- a/tests/test_requirements.txt
+++ b/tests/test_requirements.txt
@@ -25,4 +25,5 @@ lz4>=4.4.5; python_version >= "3.14"
 pyjwt[crypto]==2.10.1
 pre-commit==4.3.0
 ruff==0.15.8
+mypy==2.1.0
  


### PR DESCRIPTION
## Summary
Sets up the type checking foundation for #692 so annotation work can proceed in small PRs.

- Adds mypy 2.1.0, pinned in tests/test_requirements.txt like ruff
- Adds a Mypy job to CI that runs alongside the Ruff job
- Adds `[tool.mypy]` config in `pyproject.toml` targeting Python 3.10
- Ignores missing imports for optional dependencies without stubs and for the compiled `driverc` modules
- Baselines the modules that do not yet pass with `ignore_errors` so CI is green from the start
- Contributors annotate a module, remove it from the baseline list, and CI enforces it stays clean
- `py.typed` gets restored in a final PR once the baseline list is empty