### PR TITLE
chore: add local mypy pre-commit hook mirroring CI

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -5,3 +5,13 @@ repos:
       - id: ruff
         args: [--fix]
       - id: ruff-format
+  - repo: local
+    hooks:
+      - id: mypy
+        name: mypy
+        # Mirrors the CI "Mypy check" step in .github/workflows/on_push.yml exactly: no extra
+        # args, no extra strictness. Uses the project venv's mypy so installed stubs match CI.
+        entry: mypy
+        language: system
+        pass_filenames: false
+        always_run: true

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -9,9 +9,7 @@ repos:
     hooks:
       - id: mypy
         name: mypy
-        # Mirrors the CI "Mypy check" step in .github/workflows/on_push.yml exactly: no extra
-        # args, no extra strictness. Uses the project venv's mypy so installed stubs match CI.
         entry: mypy
         language: system
         pass_filenames: false
-        always_run: true
+        files: \.py$

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -155,6 +155,14 @@ ruff format clickhouse_connect tests examples setup.py
 ruff check --fix clickhouse_connect tests examples setup.py
 ```
 
+The project also uses [mypy](https://mypy-lang.org/) for type checking:
+
+```bash
+mypy
+```
+
+If you ran `pre-commit install` during setup, both `ruff` and `mypy` run automatically on `git commit`.
+
 ### Git blame
 
 Bulk formatting commits are listed in `.git-blame-ignore-revs`. To configure git blame to skip them:


### PR DESCRIPTION
## Summary

Adds a local pre-commit hook that runs mypy (the same bare invocation as the CI "Mypy check" step in `on_push.yml`).
Also adds a one-line mention in `CONTRIBUTING.md`'s **Style Guide** section, mirroring the existing ruff instructions.
