### PR TITLE
add chainable Select.ch_join() for join modifiers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## UNRELEASED
 
+### Improvements
+- SQLAlchemy: added a chainable `Select.ch_join()` so ClickHouse JOIN modifiers can be written in normal SQLAlchemy chaining style instead of nesting the `ch_join()` helper inside `select_from()`. It takes the strictness modifiers ALL, ANY, ASOF, SEMI, and ANTI, the GLOBAL distribution modifier, plus USING and CROSS, all as keyword arguments, and chains so multi-join queries stay readable. The existing `ch_join()` factory is unchanged. Closes [#827](https://github.com/ClickHouse/clickhouse-connect/issues/827).
+
 ## 1.4.1, 2026-06-30
 
 ### Bug Fixes

--- a/clickhouse_connect/cc_sqlalchemy/MIGRATING_FROM_CLICKHOUSE_SQLALCHEMY.md
+++ b/clickhouse_connect/cc_sqlalchemy/MIGRATING_FROM_CLICKHOUSE_SQLALCHEMY.md
@@ -29,7 +29,7 @@ create_engine("clickhousedb://user:pass@host:8123/db")  # short form alias
 | `clickhouse-sqlalchemy` import                                          | Action  | Replacement                                                                                                                                                                                                                                                                                                                                                                                                         |
 |-------------------------------------------------------------------------|---------|---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
 | `from clickhouse_sqlalchemy import Table`                               | Alias   | `from clickhouse_connect.cc_sqlalchemy import Table`. Pure alias for `sqlalchemy.Table`. The dialect picks up the engine via `construct_arguments`.                                                                                                                                                                                                                                                                 |
-| `from clickhouse_sqlalchemy import select as ch_select`                 | Rewrite | `from sqlalchemy import select`. Once `clickhouse_connect.cc_sqlalchemy` has been imported anywhere in the process, plain `select` has our chainables (`.final()`, `.sample()`, `.array_join()`, `.left_array_join()`, `.prewhere()`, `.limit_by()`) attached.                                                                                                                                                      |
+| `from clickhouse_sqlalchemy import select as ch_select`                 | Rewrite | `from sqlalchemy import select`. Once `clickhouse_connect.cc_sqlalchemy` has been imported anywhere in the process, plain `select` has our chainables (`.final()`, `.sample()`, `.array_join()`, `.left_array_join()`, `.prewhere()`, `.limit_by()`, `.ch_join()`) attached.                                                                                                                                                      |
 | `from clickhouse_sqlalchemy import get_declarative_base`                | Rewrite | Use standard SQLAlchemy declarative setup. For a version-generic form across SQLAlchemy 1.4 and 2.x: `from sqlalchemy.orm import declarative_base; Base = declarative_base()`.                                                                                                                                                                                                                                      |
 | `from clickhouse_sqlalchemy.orm.query import Query` (`ClickHouseQuery`) | Drop    | Remove `query_cls=ClickHouseQuery` from your `sessionmaker(...)` call. `clickhouse-sqlalchemy`'s Query subclass adds ClickHouse-specific behavior to `session.query(...)`. In `clickhouse-connect`, the ClickHouse select helpers are attached to `sqlalchemy.select` instead. Your own `query_cls=YourQuery` still works for legacy `session.query(...)` usage, but it is separate from the `select(...)` helpers. |
 | `from clickhouse_sqlalchemy import types`                               | Alias   | `from clickhouse_connect.cc_sqlalchemy import types`. Provides `types.DateTime`, `types.UInt32`, `types.LowCardinality`, etc.                                                                                                                                                                                                                                                                                       |
@@ -80,6 +80,17 @@ select(tbl).sample(0.1)
 
 select(tbl).prewhere(tbl.c.active == 1)
 select(tbl).limit_by([tbl.c.user_id], 5)
+
+# Chained ClickHouse joins. The left side is the prior join or the single FROM/select_from target.
+(
+    select(authors.c.name, publishers.c.name)
+    .select_from(books)
+    .ch_join(authors, authors.c.id == books.c.author_id, isouter=True, strictness="ANY")
+    .ch_join(publishers, publishers.c.id == books.c.publisher_id, isouter=True, strictness="ANY")
+)
+# Do not mix .ch_join() with SQLAlchemy's native .join() on the same statement. Use .ch_join() throughout.
+# When chaining, the tracked join root is the left side, so a select_from() placed after a .ch_join()
+# does not become the left of the next .ch_join().
 
 func.arrayMap(Lambda("x", column("x") * 2), tbl.c.nums)
 

--- a/clickhouse_connect/cc_sqlalchemy/sql/__init__.py
+++ b/clickhouse_connect/cc_sqlalchemy/sql/__init__.py
@@ -160,7 +160,7 @@ def limit_by(select_stmt: Select, by_clauses: Any, limit: int, offset: int | Non
 
 def _select_ch_join(
     self: Select,
-    right: FromClause,
+    right: Any,
     onclause: Any = None,
     *,
     isouter: bool = False,

--- a/clickhouse_connect/cc_sqlalchemy/sql/__init__.py
+++ b/clickhouse_connect/cc_sqlalchemy/sql/__init__.py
@@ -5,6 +5,7 @@ from sqlalchemy.sql.selectable import FromClause, Select
 
 from clickhouse_connect.cc_sqlalchemy.sql.clauses import ArrayJoin, LimitByClause, PreWhereClause
 from clickhouse_connect.cc_sqlalchemy.sql.clauses import array_join as _array_join_fromclause
+from clickhouse_connect.cc_sqlalchemy.sql.clauses import ch_join as _ch_join_fromclause
 from clickhouse_connect.driver.binding import quote_identifier
 
 # Non-rendering statement-hint dialect tag. Used only to force distinct
@@ -157,6 +158,64 @@ def limit_by(select_stmt: Select, by_clauses: Any, limit: int, offset: int | Non
     return new_stmt
 
 
+def _select_ch_join(
+    self: Select,
+    right: FromClause,
+    onclause: Any = None,
+    *,
+    isouter: bool = False,
+    full: bool = False,
+    cross: bool = False,
+    using: Any = None,
+    strictness: str | None = None,
+    distribution: str | None = None,
+) -> Select:
+    """Chainable ClickHouse JOIN. Resolves the left side from the prior join or the single FROM/select_from target."""
+    if not isinstance(self, Select):
+        raise TypeError("ch_join() expects a SQLAlchemy Select instance")
+
+    if getattr(self, "_setup_joins", ()):
+        raise ValueError(
+            "ch_join() cannot be combined with SQLAlchemy's native .join() on the same statement. "
+            "Use .ch_join() for all joins in the chain."
+        )
+
+    left = getattr(self, "_ch_join_root", None)
+    if left is None:
+        from_obj: tuple[FromClause, ...] = getattr(self, "_from_obj", ())
+        if len(from_obj) == 1:
+            left = from_obj[0]
+        elif not from_obj:
+            froms = self.get_final_froms()
+            if len(froms) == 1:
+                left = froms[0]
+        if left is None:
+            raise ValueError(
+                "ch_join() cannot determine the left side of the join. "
+                "Use the module-level ch_join(left, right, ...) with select_from() instead."
+            )
+
+    join = _ch_join_fromclause(
+        left,
+        right,
+        onclause,
+        isouter=isouter,
+        full=full,
+        cross=cross,
+        using=using,
+        strictness=strictness,
+        distribution=distribution,
+    )
+    new = self.select_from(join)
+    # The join subsumes the prior froms (left's tables are hidden), so collapse
+    # _from_obj to exactly (join,). Keeps the cache key equal to the
+    # select_from(ch_join(...)) factory form and stops deep chains from
+    # accumulating froms.
+    new._from_obj = (join,)  # type: ignore[attr-defined]
+    new._ch_join_root = join  # type: ignore[attr-defined]
+    return new
+
+
 def _select_prewhere(self: Select, whereclause: Any) -> Select:
     return prewhere(self, whereclause)
 
@@ -171,3 +230,4 @@ Select.array_join = _select_array_join  # type: ignore[attr-defined]
 Select.left_array_join = _select_left_array_join  # type: ignore[attr-defined]
 Select.prewhere = _select_prewhere  # type: ignore[attr-defined]
 Select.limit_by = _select_limit_by  # type: ignore[attr-defined]
+Select.ch_join = _select_ch_join  # type: ignore[attr-defined]

--- a/tests/unit_tests/test_sqlalchemy/test_ch_join_chainable.py
+++ b/tests/unit_tests/test_sqlalchemy/test_ch_join_chainable.py
@@ -1,0 +1,271 @@
+import pytest
+import sqlalchemy as db
+from sqlalchemy import select
+from sqlalchemy.dialects import registry
+from sqlalchemy.orm import declarative_base
+
+# Import sql module so Select.ch_join monkey-patch is installed.
+import clickhouse_connect.cc_sqlalchemy.sql  # noqa: F401
+from clickhouse_connect.cc_sqlalchemy import dialect_name
+from clickhouse_connect.cc_sqlalchemy.datatypes.sqltypes import String, UInt32
+from clickhouse_connect.cc_sqlalchemy.sql.clauses import ch_join
+
+dialect = registry.load(dialect_name)()
+metadata = db.MetaData()
+
+books = db.Table(
+    "books",
+    metadata,
+    db.Column("id", UInt32),
+    db.Column("author_id", UInt32),
+    db.Column("publisher_id", UInt32),
+)
+
+authors = db.Table(
+    "authors",
+    metadata,
+    db.Column("id", UInt32),
+    db.Column("name", String),
+)
+
+publishers = db.Table(
+    "publishers",
+    metadata,
+    db.Column("id", UInt32),
+    db.Column("name", String),
+)
+
+reviews = db.Table(
+    "reviews",
+    metadata,
+    db.Column("id", UInt32),
+    db.Column("book_id", UInt32),
+)
+
+
+def compile_sql(stmt):
+    return str(stmt.compile(dialect=dialect, compile_kwargs={"literal_binds": True}))
+
+
+@pytest.mark.parametrize(
+    "kwargs,expected",
+    [
+        ({"strictness": "ALL"}, "ALL INNER JOIN"),
+        ({"strictness": "ANY"}, "ANY INNER JOIN"),
+        ({"strictness": "ASOF"}, "ASOF INNER JOIN"),
+        ({"isouter": True, "strictness": "SEMI"}, "SEMI LEFT OUTER JOIN"),
+        ({"isouter": True, "strictness": "ANTI"}, "ANTI LEFT OUTER JOIN"),
+        ({"distribution": "GLOBAL"}, "GLOBAL INNER JOIN"),
+        ({"full": True, "strictness": "ALL"}, "ALL FULL OUTER JOIN"),
+    ],
+)
+def test_single_ch_join_modifiers(kwargs, expected):
+    stmt = select(books.c.id, authors.c.name).select_from(books).ch_join(authors, authors.c.id == books.c.author_id, **kwargs)
+    sql = compile_sql(stmt)
+    assert expected in sql
+
+
+def test_single_ch_join_cross():
+    stmt = select(books.c.id, authors.c.name).select_from(books).ch_join(authors, cross=True)
+    sql = compile_sql(stmt)
+    assert "CROSS JOIN" in sql
+    assert " ON " not in sql
+
+
+def test_single_ch_join_using():
+    stmt = select(books.c.id, authors.c.name).select_from(books).ch_join(authors, using=["id"])
+    sql = compile_sql(stmt)
+    assert "INNER JOIN" in sql
+    assert "USING (`id`)" in sql
+    assert " ON " not in sql
+
+
+def test_two_join_chain_renders_both_with_single_from():
+    stmt = (
+        select(authors.c.name, publishers.c.name)
+        .select_from(books)
+        .ch_join(authors, authors.c.id == books.c.author_id, isouter=True, strictness="ANY")
+        .ch_join(publishers, publishers.c.id == books.c.publisher_id, isouter=True, strictness="ANY")
+    )
+    sql = compile_sql(stmt)
+    assert sql.count("ANY LEFT OUTER JOIN") == 2
+    assert sql.count("FROM") == 1
+    assert "FROM `books` ANY LEFT OUTER JOIN" in sql
+
+
+def test_three_join_chain_renders_all_with_single_from():
+    stmt = (
+        select(authors.c.name, publishers.c.name, reviews.c.id)
+        .select_from(books)
+        .ch_join(authors, authors.c.id == books.c.author_id, strictness="ALL")
+        .ch_join(publishers, publishers.c.id == books.c.publisher_id, strictness="ALL")
+        .ch_join(reviews, reviews.c.book_id == books.c.id, strictness="ALL")
+    )
+    sql = compile_sql(stmt)
+    assert sql.count("ALL INNER JOIN") == 3
+    assert sql.count("FROM") == 1
+    assert "FROM `books` ALL INNER JOIN `authors`" in sql
+    assert "`publishers`" in sql
+    assert "`reviews`" in sql
+
+
+def test_ch_join_is_generative():
+    base = select(books.c.id, authors.c.name).select_from(books)
+    chained = base.ch_join(authors, authors.c.id == books.c.author_id, strictness="ALL")
+    assert base is not chained
+    base_sql = compile_sql(base)
+    chained_sql = compile_sql(chained)
+    assert "JOIN" not in base_sql
+    assert "ALL INNER JOIN" in chained_sql
+
+
+def test_ch_join_state_survives_where():
+    stmt = (
+        select(authors.c.name, publishers.c.name)
+        .select_from(books)
+        .ch_join(authors, authors.c.id == books.c.author_id, strictness="ANY")
+        .where(books.c.id > 13)
+        .ch_join(publishers, publishers.c.id == books.c.publisher_id, strictness="ALL")
+    )
+    sql = compile_sql(stmt)
+    assert "ANY INNER JOIN" in sql
+    assert "ALL INNER JOIN" in sql
+
+
+def test_ch_join_after_final():
+    stmt = select(books.c.id).select_from(books).final().ch_join(authors, authors.c.id == books.c.author_id, strictness="ALL")
+    sql = compile_sql(stmt)
+    assert "FINAL" in sql
+    assert "ALL INNER JOIN" in sql
+
+
+def test_final_after_ch_join():
+    # After a join the single FROM is the join itself, so final() needs an explicit
+    # target table to disambiguate, same as the existing module-level ch_join + final.
+    stmt = (
+        select(books.c.id, authors.c.name)
+        .select_from(books)
+        .ch_join(authors, authors.c.id == books.c.author_id, strictness="ALL")
+        .final(books)
+    )
+    sql = compile_sql(stmt)
+    assert "FINAL" in sql
+    assert "ALL INNER JOIN" in sql
+
+
+def test_ch_join_parity_with_module_factory():
+    chained = select(authors.c.name).select_from(books).ch_join(authors, authors.c.id == books.c.author_id, isouter=True, strictness="ANY")
+    j = ch_join(books, authors, authors.c.id == books.c.author_id, isouter=True, strictness="ANY")
+    explicit = select(authors.c.name).select_from(j)
+    assert compile_sql(chained) == compile_sql(explicit)
+
+
+def test_ch_join_single_from_no_select_from():
+    stmt = select(books.c.id).ch_join(authors, authors.c.id == books.c.author_id, strictness="ALL")
+    sql = compile_sql(stmt)
+    assert "ALL INNER JOIN" in sql
+    assert "FROM `books` ALL INNER JOIN" in sql
+
+
+def test_ch_join_ambiguous_left_raises():
+    stmt = select(authors.c.name, publishers.c.name).select_from(books).select_from(authors)
+    with pytest.raises(ValueError, match="cannot determine the left side"):
+        stmt.ch_join(publishers, publishers.c.id == books.c.publisher_id)
+
+
+def test_ch_join_invalid_strictness_raises():
+    stmt = select(books.c.id).select_from(books)
+    with pytest.raises(ValueError, match="Invalid strictness"):
+        stmt.ch_join(authors, authors.c.id == books.c.author_id, strictness="PARTIAL")
+
+
+def test_ch_join_mixed_with_native_join_raises():
+    stmt = select(books.c.id).select_from(books).join(authors, authors.c.id == books.c.author_id)
+    with pytest.raises(ValueError, match="native .join.. on the same statement"):
+        stmt.ch_join(publishers, publishers.c.id == books.c.publisher_id)
+
+
+Base = declarative_base()
+
+
+class AuthorEntity(Base):
+    __tablename__ = "author_entities"
+    id = db.Column(UInt32, primary_key=True)
+    name = db.Column(String)
+
+
+class BookEntity(Base):
+    __tablename__ = "book_entities"
+    id = db.Column(UInt32, primary_key=True)
+    author_id = db.Column(UInt32)
+
+
+def test_ch_join_orm_renders():
+    stmt = (
+        select(AuthorEntity.name, BookEntity.id)
+        .select_from(AuthorEntity)
+        .ch_join(BookEntity, BookEntity.author_id == AuthorEntity.id, isouter=True, strictness="ANY")
+    )
+    sql = compile_sql(stmt)
+    assert "ANY LEFT OUTER JOIN" in sql
+    assert "`book_entities`" in sql
+
+
+# Cache-key tests select only UInt32 columns. UInt32 inherits SQLAlchemy Integer
+# (cache_ok = True) so _generate_cache_key() returns a real, non-None key. A String
+# column (UserDefinedType, cache_ok unset) would suppress the key to None and make
+# these assertions vacuous, also emitting an SAWarning.
+
+
+def test_ch_join_cache_key_identical_chains_match():
+    a = select(books.c.id).select_from(books).ch_join(authors, authors.c.id == books.c.author_id, strictness="ALL")
+    b = select(books.c.id).select_from(books).ch_join(authors, authors.c.id == books.c.author_id, strictness="ALL")
+    key_a = a._generate_cache_key()
+    key_b = b._generate_cache_key()
+    assert key_a is not None
+    assert key_a == key_b
+
+
+def test_ch_join_cache_key_differs_on_strictness():
+    a = select(books.c.id).select_from(books).ch_join(authors, authors.c.id == books.c.author_id, strictness="ALL")
+    b = select(books.c.id).select_from(books).ch_join(authors, authors.c.id == books.c.author_id, strictness="ANY")
+    key_a = a._generate_cache_key()
+    key_b = b._generate_cache_key()
+    assert key_a is not None and key_b is not None
+    assert key_a != key_b
+
+
+def test_ch_join_cache_key_differs_on_right_table():
+    a = select(books.c.id).select_from(books).ch_join(authors, authors.c.id == books.c.author_id, strictness="ALL")
+    b = select(books.c.id).select_from(books).ch_join(publishers, publishers.c.id == books.c.publisher_id, strictness="ALL")
+    key_a = a._generate_cache_key()
+    key_b = b._generate_cache_key()
+    assert key_a is not None and key_b is not None
+    assert key_a != key_b
+
+
+def test_ch_join_cache_key_differs_on_distribution():
+    a = select(books.c.id).select_from(books).ch_join(authors, authors.c.id == books.c.author_id, strictness="ALL")
+    b = select(books.c.id).select_from(books).ch_join(authors, authors.c.id == books.c.author_id, strictness="ALL", distribution="GLOBAL")
+    key_a = a._generate_cache_key()
+    key_b = b._generate_cache_key()
+    assert key_a is not None and key_b is not None
+    assert key_a != key_b
+
+
+def test_ch_join_cache_key_chained_matches_nested_factory():
+    chained = select(books.c.id).select_from(books).ch_join(authors, authors.c.id == books.c.author_id, strictness="ANY")
+    nested = select(books.c.id).select_from(ch_join(books, authors, authors.c.id == books.c.author_id, strictness="ANY"))
+    key_chained = chained._generate_cache_key()
+    key_nested = nested._generate_cache_key()
+    assert key_chained is not None
+    assert key_chained == key_nested
+
+
+def test_ch_join_cache_key_bare_matches_explicit_select_from():
+    bare = select(books.c.id).ch_join(authors, authors.c.id == books.c.author_id, strictness="ANY")
+    explicit = select(books.c.id).select_from(books).ch_join(authors, authors.c.id == books.c.author_id, strictness="ANY")
+    key_bare = bare._generate_cache_key()
+    key_explicit = explicit._generate_cache_key()
+    assert key_bare is not None
+    assert key_bare == key_explicit

--- a/tests/unit_tests/test_sqlalchemy/test_ch_join_chainable.py
+++ b/tests/unit_tests/test_sqlalchemy/test_ch_join_chainable.py
@@ -181,7 +181,7 @@ def test_ch_join_invalid_strictness_raises():
 
 def test_ch_join_mixed_with_native_join_raises():
     stmt = select(books.c.id).select_from(books).join(authors, authors.c.id == books.c.author_id)
-    with pytest.raises(ValueError, match="native .join.. on the same statement"):
+    with pytest.raises(ValueError, match=r"native \.join\(\) on the same statement"):
         stmt.ch_join(publishers, publishers.c.id == books.c.publisher_id)
 
 


### PR DESCRIPTION
## Summary
This PR adds a chainable `.ch_join()` so ClickHouse join modifiers can be written in normal SQLAlchemy chaining style instead of nesting the `ch_join()` helper inside `select_from()`.

The method is

```python
.ch_join(target, onclause=None, *, isouter=False, full=False, cross=False, using=None, strictness=None, distribution=None)
```

It takes the same modifiers as the existing `ch_join()` factory and covers `ANY`, `ALL`, `ASOF`, `SEMI`, `ANTI`, `GLOBAL`, `USING`, and `CROSS`. Under the hood it resolves the left side from the prior join in the chain or the single `FROM`/`select_from` target, tracks the join so chains compose, and collapses the `FROM` list so the statement cache key matches the equivalent `select_from(ch_join(...))` form.

I did not override SQLAlchemy's native `.join()`. Its signature is closed and it defers join construction to compile time, so passing modifiers through it would mean patching SQLAlchemy internals and changing `.join()` behavior. `.ch_join()` avoids that and stays consistent with the existing `.array_join()`, `.final()`, `.sample()`, `.prewhere()`, and `.limit_by()` chainables. Because the two build joins differently, mixing `.ch_join()` with native `.join()` on the same statement raises a clear `ValueError` rather than silently producing mis-ordered SQL.

There are no breaking changes. The `ch_join()` factory, `ClickHouseJoin`, and the compiler are untouched. 

As a follow-up, these helpers currently attach by monkey-patching SQLAlchemy's `Select`. The more idiomatic approach is a dialect `Select` subclass with its own `select()` constructor, the same pattern `postgresql.insert()` and `clickhouse-sqlalchemy` use. That would let the modifiers ride on native `.join()` and make the helper methods visible to downstream type checkers. It is a larger change, so I will track as separate future work and is out of scope here.

Closes #827

## Checklist
Delete items not relevant to your PR:
- [X] Unit and integration tests covering the common scenarios were added
- [X] A human-readable description of the changes was provided to include in CHANGELOG
- [X] For significant changes, documentation in https://github.com/ClickHouse/clickhouse-docs was updated with further explanations or tutorials
