### PR TITLE
fix cc_sqlalchemy Alembic renderers corrupting non-ClickHouse autogen…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## UNRELEASED
 
+### Bug Fixes
+- SQLAlchemy: importing the ClickHouse Alembic integration no longer changes Alembic autogenerate output for other database dialects. The ClickHouse renderers for `CreateTableOp`, `AddColumnOp`, and `DropTableOp` were registered as process-wide replacements with no dialect guard, because Alembic renderers have no per-dialect dispatch. Any non-ClickHouse autogenerate run in the same process then used the ClickHouse renderers, which dropped the `nullable` argument from columns whose nullability was not set explicitly and injected `cc_sqlalchemy` imports. The renderers now fall back to Alembic's built-in rendering for non-ClickHouse dialects. Closes [#832](https://github.com/ClickHouse/clickhouse-connect/issues/832).
+
 ## 1.4.0, 2026-06-29
 
 ### Bug Fixes

--- a/clickhouse_connect/cc_sqlalchemy/alembic/adapter.py
+++ b/clickhouse_connect/cc_sqlalchemy/alembic/adapter.py
@@ -106,15 +106,18 @@ def render_clickhouse_column(column, autogen_context: AutogenContext) -> str:
 
 
 # Alembic renderers have no dialect qualifier, so replace=True overrides rendering
-# process-wide. Capture each built-in renderer and delegate to it for non-ClickHouse
-# dialects so autogenerate stays correct for other databases (#832).
-_default_render_create_table = render.renderers._registry[(ops.CreateTableOp, "default")]
+# process-wide. Capture each built-in renderer before replacing it and delegate to it for
+# non-ClickHouse dialects so autogenerate stays correct for other databases (#832). Held on
+# the module so importlib.reload does not re-capture one of our own renderers and recurse.
+_DEFAULT_RENDERERS = globals().get("_DEFAULT_RENDERERS") or {
+    op: render.renderers.dispatch(op) for op in (ops.CreateTableOp, ops.AddColumnOp, ops.DropTableOp)
+}
 
 
 @render.renderers.dispatch_for(ops.CreateTableOp, replace=True)
 def render_create_table(autogen_context: AutogenContext, op: ops.CreateTableOp) -> str:
     if not _is_clickhouse_autogen(autogen_context):
-        return _default_render_create_table(autogen_context, op)
+        return _DEFAULT_RENDERERS[ops.CreateTableOp](autogen_context, op)
     table = op.to_table()
 
     args = [column for column in [render_clickhouse_column(column, autogen_context) for column in table.columns] if column] + sorted(
@@ -151,13 +154,10 @@ def render_create_table(autogen_context: AutogenContext, op: ops.CreateTableOp) 
     return rendered
 
 
-_default_render_add_column = render.renderers._registry[(ops.AddColumnOp, "default")]
-
-
 @render.renderers.dispatch_for(ops.AddColumnOp, replace=True)
 def render_add_column(autogen_context: AutogenContext, op: ops.AddColumnOp) -> str:
     if not _is_clickhouse_autogen(autogen_context):
-        return _default_render_add_column(autogen_context, op)
+        return _DEFAULT_RENDERERS[ops.AddColumnOp](autogen_context, op)
     schema, table_name, column, if_not_exists = op.schema, op.table_name, op.column, op.if_not_exists
     prefix = render._alembic_autogenerate_prefix(autogen_context)
     rendered_column = render_clickhouse_column(column, autogen_context)
@@ -173,13 +173,10 @@ def render_add_column(autogen_context: AutogenContext, op: ops.AddColumnOp) -> s
     return rendered + ")"
 
 
-_default_render_drop_table = render.renderers._registry[(ops.DropTableOp, "default")]
-
-
 @render.renderers.dispatch_for(ops.DropTableOp, replace=True)
 def render_drop_table(autogen_context: AutogenContext, op: ops.DropTableOp) -> str:
     if not _is_clickhouse_autogen(autogen_context):
-        return _default_render_drop_table(autogen_context, op)
+        return _DEFAULT_RENDERERS[ops.DropTableOp](autogen_context, op)
     prefix = render._alembic_autogenerate_prefix(autogen_context)
     rendered = f"{prefix}drop_table({render._ident(op.table_name)!r}"
     arguments = []

--- a/clickhouse_connect/cc_sqlalchemy/alembic/adapter.py
+++ b/clickhouse_connect/cc_sqlalchemy/alembic/adapter.py
@@ -5,6 +5,7 @@ from alembic.operations import Operations, ops
 from alembic.runtime.migration import MigrationContext
 from alembic.util import DispatchPriority, PriorityDispatchResult
 
+from clickhouse_connect.cc_sqlalchemy.alembic.impl import ClickHouseImpl
 from clickhouse_connect.cc_sqlalchemy.datatypes.base import ChSqlaType
 from clickhouse_connect.cc_sqlalchemy.sql.ddlcompiler import ClickHouseDDLHelper
 
@@ -57,6 +58,12 @@ def clickhouse_writer(context: MigrationContext, revision, directives):
             _add_common_imports(directive)
 
 
+def _is_clickhouse_autogen(autogen_context: AutogenContext) -> bool:
+    """True only when the active migration context targets the ClickHouse dialect."""
+    migration_context = getattr(autogen_context, "migration_context", None)
+    return isinstance(getattr(migration_context, "impl", None), ClickHouseImpl)
+
+
 def render_clickhouse_column(column, autogen_context: AutogenContext) -> str:
     rendered = render._user_defined_render("column", column, autogen_context)
     if rendered is not False:
@@ -98,8 +105,16 @@ def render_clickhouse_column(column, autogen_context: AutogenContext) -> str:
     )
 
 
+# Alembic renderers have no dialect qualifier, so replace=True overrides rendering
+# process-wide. Capture each built-in renderer and delegate to it for non-ClickHouse
+# dialects so autogenerate stays correct for other databases (#832).
+_default_render_create_table = render.renderers._registry[(ops.CreateTableOp, "default")]
+
+
 @render.renderers.dispatch_for(ops.CreateTableOp, replace=True)
 def render_create_table(autogen_context: AutogenContext, op: ops.CreateTableOp) -> str:
+    if not _is_clickhouse_autogen(autogen_context):
+        return _default_render_create_table(autogen_context, op)
     table = op.to_table()
 
     args = [column for column in [render_clickhouse_column(column, autogen_context) for column in table.columns] if column] + sorted(
@@ -136,8 +151,13 @@ def render_create_table(autogen_context: AutogenContext, op: ops.CreateTableOp) 
     return rendered
 
 
+_default_render_add_column = render.renderers._registry[(ops.AddColumnOp, "default")]
+
+
 @render.renderers.dispatch_for(ops.AddColumnOp, replace=True)
 def render_add_column(autogen_context: AutogenContext, op: ops.AddColumnOp) -> str:
+    if not _is_clickhouse_autogen(autogen_context):
+        return _default_render_add_column(autogen_context, op)
     schema, table_name, column, if_not_exists = op.schema, op.table_name, op.column, op.if_not_exists
     prefix = render._alembic_autogenerate_prefix(autogen_context)
     rendered_column = render_clickhouse_column(column, autogen_context)
@@ -153,8 +173,13 @@ def render_add_column(autogen_context: AutogenContext, op: ops.AddColumnOp) -> s
     return rendered + ")"
 
 
+_default_render_drop_table = render.renderers._registry[(ops.DropTableOp, "default")]
+
+
 @render.renderers.dispatch_for(ops.DropTableOp, replace=True)
 def render_drop_table(autogen_context: AutogenContext, op: ops.DropTableOp) -> str:
+    if not _is_clickhouse_autogen(autogen_context):
+        return _default_render_drop_table(autogen_context, op)
     prefix = render._alembic_autogenerate_prefix(autogen_context)
     rendered = f"{prefix}drop_table({render._ident(op.table_name)!r}"
     arguments = []

--- a/tests/unit_tests/test_sqlalchemy/test_alembic.py
+++ b/tests/unit_tests/test_sqlalchemy/test_alembic.py
@@ -699,3 +699,16 @@ def test_non_clickhouse_drop_table_render_is_unmodified():
     table = Table("widgets", MetaData(), Column("id", Integer, primary_key=True))
     rendered = render.render_op_text(autogen_context, ops.CreateTableOp.from_table(table).reverse())
     assert rendered == "op.drop_table('widgets')"
+
+
+def test_captured_default_renderers_are_alembic_builtins():
+    from clickhouse_connect.cc_sqlalchemy.alembic import adapter
+
+    for op_type, ours in (
+        (ops.CreateTableOp, adapter.render_create_table),
+        (ops.AddColumnOp, adapter.render_add_column),
+        (ops.DropTableOp, adapter.render_drop_table),
+    ):
+        default = adapter._DEFAULT_RENDERERS[op_type]
+        assert default is not ours
+        assert default.__module__.startswith("alembic.")

--- a/tests/unit_tests/test_sqlalchemy/test_alembic.py
+++ b/tests/unit_tests/test_sqlalchemy/test_alembic.py
@@ -666,3 +666,36 @@ def test_clickhouse_settings_string_value_quoted():
     rendered = ClickHouseDDLHelper.render_settings({"mutations_sync": "2", "alter_sync": 2})
     assert "mutations_sync = '2'" in rendered
     assert "alter_sync = 2" in rendered
+
+
+def _non_clickhouse_autogen_context():
+    """AutogenContext for a non-ClickHouse dialect, with the cc_sqlalchemy.alembic import side-effect active."""
+    context = MigrationContext.configure(dialect_name="sqlite", opts={"target_metadata": MetaData()})
+    return AutogenContext(
+        context,
+        opts={"sqlalchemy_module_prefix": "sa.", "alembic_module_prefix": "op.", "user_module_prefix": None},
+    )
+
+
+def test_non_clickhouse_add_column_render_keeps_nullable():
+    """Importing the ClickHouse Alembic adapter must not corrupt autogenerate for other dialects (#832)."""
+    autogen_context = _non_clickhouse_autogen_context()
+    rendered = render.render_op_text(autogen_context, ops.AddColumnOp("widgets", Column("name", String(32))))
+    assert rendered == "op.add_column('widgets', sa.Column('name', sa.String(length=32), nullable=True))"
+    assert "cc_sqlalchemy" not in rendered
+
+
+def test_non_clickhouse_create_table_render_keeps_nullable():
+    autogen_context = _non_clickhouse_autogen_context()
+    table = Table("widgets", MetaData(), Column("id", Integer, primary_key=True), Column("name", String(32)))
+    rendered = render.render_op_text(autogen_context, ops.CreateTableOp.from_table(table))
+    assert "sa.Column('id', sa.Integer(), nullable=False)" in rendered
+    assert "sa.Column('name', sa.String(length=32), nullable=True)" in rendered
+    assert "clickhouse_engine" not in rendered
+
+
+def test_non_clickhouse_drop_table_render_is_unmodified():
+    autogen_context = _non_clickhouse_autogen_context()
+    table = Table("widgets", MetaData(), Column("id", Integer, primary_key=True))
+    rendered = render.render_op_text(autogen_context, ops.CreateTableOp.from_table(table).reverse())
+    assert rendered == "op.drop_table('widgets')"


### PR DESCRIPTION
## Summary

Importing `clickhouse_connect.cc_sqlalchemy.alembic` changed Alembic autogenerate output for every other database in the same process. The adapter registers custom renderers for `CreateTableOp`, `AddColumnOp`, and `DropTableOp` with `dispatch_for(..., replace=True)`. Unlike comparators, Alembic renderers have no per-dialect qualifier, so there is a single process-global slot per op and `replace=True` overrides rendering for all dialects, not just ClickHouse. This resulted in silent corruption of non-ClickHouse migrations.

The fix captures each built-in renderer before replacing it and delegates back to it when the active dialect is not ClickHouse, guarded by `isinstance(autogen_context.migration_context.impl, ClickHouseImpl)`. ClickHouse rendering and the import-time registration that `env.py` relies on are unchanged.

Closes #832

## Checklist
Delete items not relevant to your PR:
- [X] Unit and integration tests covering the common scenarios were added
- [X] A human-readable description of the changes was provided to include in CHANGELOG