### PR TITLE
SQA expose chainable modifiers as typed methods

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Improvements
 - SQLAlchemy: added a chainable `Select.ch_join()` so ClickHouse JOIN modifiers can be written in normal SQLAlchemy chaining style instead of nesting the `ch_join()` helper inside `select_from()`. It takes the strictness modifiers ALL, ANY, ASOF, SEMI, and ANTI, the GLOBAL distribution modifier, plus USING and CROSS, all as keyword arguments, and chains so multi-join queries stay readable. The existing `ch_join()` factory is unchanged. Closes [#827](https://github.com/ClickHouse/clickhouse-connect/issues/827).
+- SQLAlchemy: added `cc_sqlalchemy.select()` which returns a `ClickHouseSelect`. It exposes the ClickHouse chainable modifiers such as `ch_join`, `final`, `sample`, `array_join`, `prewhere`, and `limit_by` as typed methods so static type checkers accept them without suppressions. The existing `sqlalchemy.select()` path keeps working unchanged. Closes [#837](https://github.com/ClickHouse/clickhouse-connect/issues/837).
 
 ## 1.4.1, 2026-06-30
 

--- a/clickhouse_connect/cc_sqlalchemy/MIGRATING_FROM_CLICKHOUSE_SQLALCHEMY.md
+++ b/clickhouse_connect/cc_sqlalchemy/MIGRATING_FROM_CLICKHOUSE_SQLALCHEMY.md
@@ -99,6 +99,20 @@ select(tbl).final().prewhere(tbl.c.active == 1).left_array_join(tbl.c.tags).limi
 
 `final()`, `sample()`, and `limit_by()` use the same calling convention as `clickhouse-sqlalchemy`. `prewhere()` and explicit `Lambda(...)` are available on `sqlalchemy.select` in `clickhouse-connect`.
 
+### Typed entry point for the chainables
+
+`sqlalchemy.select(...)` gets the chainables by monkey-patch, so they work at runtime but static type checkers do not see them and flag calls like `.ch_join(...)`. Use `clickhouse_connect.cc_sqlalchemy.select` instead. It returns a `ClickHouseSelect` that declares `.ch_join()`, `.final()`, `.sample()`, `.array_join()`, `.left_array_join()`, `.prewhere()`, and `.limit_by()` as typed methods, so they type-check without suppressions. The subclass stays itself through SQLAlchemy generative methods like `.where()` and `.select_from()`, so a mixed chain keeps the typed methods.
+
+```python
+from clickhouse_connect.cc_sqlalchemy import select
+
+select(authors.c.name).select_from(books).ch_join(
+    authors, authors.c.id == books.c.author_id, isouter=True, strictness="ANY"
+).final(books)
+```
+
+The native `.join(..., strictness=...)` spelling that carries ClickHouse JOIN modifiers on SQLAlchemy's own `.join()` is future work.
+
 The dialect compiles these modifiers on SQLAlchemy Select statements, but the ClickHouse server still enforces its own rules. For example, the server rejects `FINAL` on a plain `MergeTree` and `PREWHERE` against `FROM (SELECT ...)`.
 
 ## Engine expressions accept `Column` objects

--- a/clickhouse_connect/cc_sqlalchemy/__init__.py
+++ b/clickhouse_connect/cc_sqlalchemy/__init__.py
@@ -6,7 +6,7 @@ from clickhouse_connect.cc_sqlalchemy import types
 from clickhouse_connect.cc_sqlalchemy.datatypes.base import schema_types
 from clickhouse_connect.cc_sqlalchemy.ddl import tableengine as engines
 from clickhouse_connect.cc_sqlalchemy.ddl.dictionary import Dictionary
-from clickhouse_connect.cc_sqlalchemy.sql import final, sample
+from clickhouse_connect.cc_sqlalchemy.sql import ClickHouseSelect, final, sample, select
 from clickhouse_connect.cc_sqlalchemy.sql.clauses import ArrayJoin, ClickHouseJoin, Lambda, array_join, ch_join
 from clickhouse_connect.dbapi.cursor import Cursor
 
@@ -30,6 +30,8 @@ __all__ = [
     "Lambda",
     "final",
     "sample",
+    "select",
+    "ClickHouseSelect",
     "Dictionary",
     "ClickhouseDictionary",
     "engines",

--- a/clickhouse_connect/cc_sqlalchemy/sql/__init__.py
+++ b/clickhouse_connect/cc_sqlalchemy/sql/__init__.py
@@ -1,4 +1,4 @@
-from typing import Any
+from typing import Any, cast
 
 from sqlalchemy import Table, and_
 from sqlalchemy.sql.selectable import FromClause, Select
@@ -231,3 +231,60 @@ Select.left_array_join = _select_left_array_join  # type: ignore[attr-defined]
 Select.prewhere = _select_prewhere  # type: ignore[attr-defined]
 Select.limit_by = _select_limit_by  # type: ignore[attr-defined]
 Select.ch_join = _select_ch_join  # type: ignore[attr-defined]
+
+
+class ClickHouseSelect(Select[Any]):
+    """Select subclass exposing ClickHouse chainables as typed methods.
+    Construct with cc_sqlalchemy.select(...)."""
+
+    inherit_cache = True
+
+    def final(self, table: FromClause | None = None) -> "ClickHouseSelect":
+        return cast("ClickHouseSelect", final(self, table=table))
+
+    def sample(self, sample_value: str | int | float, table: FromClause | None = None) -> "ClickHouseSelect":
+        return cast("ClickHouseSelect", sample(self, sample_value=sample_value, table=table))
+
+    def array_join(self, *cols: Any, alias: Any = None) -> "ClickHouseSelect":
+        return cast("ClickHouseSelect", _apply_array_join(self, cols, alias, is_left=False))
+
+    def left_array_join(self, *cols: Any, alias: Any = None) -> "ClickHouseSelect":
+        return cast("ClickHouseSelect", _apply_array_join(self, cols, alias, is_left=True))
+
+    def prewhere(self, whereclause: Any) -> "ClickHouseSelect":
+        return cast("ClickHouseSelect", prewhere(self, whereclause))
+
+    def limit_by(self, by_clauses: Any, limit: int, offset: int | None = None) -> "ClickHouseSelect":
+        return cast("ClickHouseSelect", limit_by(self, by_clauses, limit, offset))
+
+    def ch_join(
+        self,
+        right: Any,
+        onclause: Any = None,
+        *,
+        isouter: bool = False,
+        full: bool = False,
+        cross: bool = False,
+        using: Any = None,
+        strictness: str | None = None,
+        distribution: str | None = None,
+    ) -> "ClickHouseSelect":
+        return cast(
+            "ClickHouseSelect",
+            _select_ch_join(
+                self,
+                right,
+                onclause,
+                isouter=isouter,
+                full=full,
+                cross=cross,
+                using=using,
+                strictness=strictness,
+                distribution=distribution,
+            ),
+        )
+
+
+def select(*entities: Any) -> ClickHouseSelect:
+    """Typed drop-in for sqlalchemy.select with ClickHouse chainables."""
+    return ClickHouseSelect(*entities)

--- a/clickhouse_connect/cc_sqlalchemy/sql/__init__.py
+++ b/clickhouse_connect/cc_sqlalchemy/sql/__init__.py
@@ -286,5 +286,6 @@ class ClickHouseSelect(Select[Any]):
 
 
 def select(*entities: Any) -> ClickHouseSelect:
-    """Typed drop-in for sqlalchemy.select with ClickHouse chainables."""
+    """Runtime drop-in for sqlalchemy.select that adds the ClickHouse chainables as typed methods.
+    Result rows type as Any until the generic follow-up lands."""
     return ClickHouseSelect(*entities)

--- a/tests/unit_tests/test_sqlalchemy/test_ch_select.py
+++ b/tests/unit_tests/test_sqlalchemy/test_ch_select.py
@@ -1,0 +1,146 @@
+import warnings
+
+import pytest
+import sqlalchemy as db
+from sqlalchemy import select as sa_select
+from sqlalchemy.dialects import registry
+
+# Import sql module so the Select monkey-patches are installed for the SA path.
+import clickhouse_connect.cc_sqlalchemy.sql  # noqa: F401
+from clickhouse_connect.cc_sqlalchemy import ClickHouseSelect, dialect_name
+from clickhouse_connect.cc_sqlalchemy import select as ch_select
+from clickhouse_connect.cc_sqlalchemy.datatypes.sqltypes import String, UInt32
+
+dialect = registry.load(dialect_name)()
+metadata = db.MetaData()
+
+books = db.Table(
+    "books",
+    metadata,
+    db.Column("id", UInt32),
+    db.Column("author_id", UInt32),
+    db.Column("publisher_id", UInt32),
+    db.Column("active", UInt32),
+)
+
+authors = db.Table(
+    "authors",
+    metadata,
+    db.Column("id", UInt32),
+    db.Column("name", String),
+)
+
+publishers = db.Table(
+    "publishers",
+    metadata,
+    db.Column("id", UInt32),
+    db.Column("name", String),
+)
+
+
+def compile_sql(stmt):
+    return str(stmt.compile(dialect=dialect, compile_kwargs={"literal_binds": True}))
+
+
+# (name, ch-path builder, sa-path builder) for each chainable. The sa-path calls the
+# runtime monkey-patch, which is intentionally not statically typed, hence type: ignore.
+PARITY_CASES = [
+    (
+        "final",
+        lambda: ch_select(books.c.id).select_from(books).final(),
+        lambda: sa_select(books.c.id).select_from(books).final(),  # type: ignore[attr-defined]
+    ),
+    (
+        "sample",
+        lambda: ch_select(books.c.id).select_from(books).sample(0.1),
+        lambda: sa_select(books.c.id).select_from(books).sample(0.1),  # type: ignore[attr-defined]
+    ),
+    (
+        "array_join",
+        lambda: ch_select(books.c.id).select_from(books).array_join(books.c.author_id),
+        lambda: sa_select(books.c.id).select_from(books).array_join(books.c.author_id),  # type: ignore[attr-defined]
+    ),
+    (
+        "left_array_join",
+        lambda: ch_select(books.c.id).select_from(books).left_array_join(books.c.author_id),
+        lambda: sa_select(books.c.id).select_from(books).left_array_join(books.c.author_id),  # type: ignore[attr-defined]
+    ),
+    (
+        "prewhere",
+        lambda: ch_select(books.c.id).select_from(books).prewhere(books.c.active == 1),
+        lambda: sa_select(books.c.id).select_from(books).prewhere(books.c.active == 1),  # type: ignore[attr-defined]
+    ),
+    (
+        "limit_by",
+        lambda: ch_select(books.c.id).select_from(books).limit_by([books.c.author_id], 5),
+        lambda: sa_select(books.c.id).select_from(books).limit_by([books.c.author_id], 5),  # type: ignore[attr-defined]
+    ),
+    (
+        "ch_join",
+        lambda: (
+            ch_select(books.c.id, authors.c.name)
+            .select_from(books)
+            .ch_join(authors, authors.c.id == books.c.author_id, isouter=True, strictness="ANY")
+        ),
+        lambda: (
+            sa_select(books.c.id, authors.c.name)
+            .select_from(books)
+            .ch_join(authors, authors.c.id == books.c.author_id, isouter=True, strictness="ANY")  # type: ignore[attr-defined]
+        ),
+    ),
+]
+
+
+@pytest.mark.parametrize("name,ch_build,sa_build", PARITY_CASES, ids=[c[0] for c in PARITY_CASES])
+def test_subclass_parity_with_monkeypatched_select(name, ch_build, sa_build):
+    assert compile_sql(ch_build()) == compile_sql(sa_build())
+
+
+def test_subclass_class_preserved_through_mixed_chain():
+    base = ch_select(books.c.id, authors.c.name)
+    assert isinstance(base, ClickHouseSelect)
+
+    with_from = base.select_from(books)
+    assert isinstance(with_from, ClickHouseSelect)
+
+    joined = with_from.ch_join(authors, authors.c.id == books.c.author_id, strictness="ALL")
+    assert isinstance(joined, ClickHouseSelect)
+
+    filtered = joined.where(books.c.id > 13)
+    assert isinstance(filtered, ClickHouseSelect)
+
+    final_stmt = filtered.final(books)
+    assert isinstance(final_stmt, ClickHouseSelect)
+
+    sql = compile_sql(final_stmt)
+    assert "ALL INNER JOIN" in sql
+    assert "FINAL" in sql
+
+
+def test_subclass_compiles_without_warning():
+    stmt = ch_select(books.c.id).select_from(books).final().prewhere(books.c.active == 1).limit_by([books.c.author_id], 3)
+    with warnings.catch_warnings():
+        warnings.simplefilter("error")
+        compile_sql(stmt)
+
+
+def test_subclass_generates_cache_key():
+    stmt = ch_select(books.c.id).select_from(books).final()
+    key = stmt._generate_cache_key()
+    assert key is not None
+
+
+def test_subclass_multi_join_matches_monkeypatched_chain():
+    chained = (
+        ch_select(authors.c.name, publishers.c.name)
+        .select_from(books)
+        .ch_join(authors, authors.c.id == books.c.author_id, isouter=True, strictness="ANY")
+        .ch_join(publishers, publishers.c.id == books.c.publisher_id, isouter=True, strictness="ANY")
+    )
+    monkeypatched = (
+        sa_select(authors.c.name, publishers.c.name)
+        .select_from(books)
+        .ch_join(authors, authors.c.id == books.c.author_id, isouter=True, strictness="ANY")  # type: ignore[attr-defined]
+        .ch_join(publishers, publishers.c.id == books.c.publisher_id, isouter=True, strictness="ANY")
+    )
+    assert compile_sql(chained) == compile_sql(monkeypatched)


### PR DESCRIPTION
## Summary

- Adds `cc_sqlalchemy.select()` which returns a new `ClickHouseSelect`. It declares the ClickHouse chainable modifiers `ch_join`, `final`, `sample`, `array_join`, `left_array_join`, `prewhere`, and `limit_by` as real typed methods, so static type checkers accept them without per-call suppressions.
- The existing modifiers are attached by monkey-patching SQLAlchemy's `Select`, which works at runtime but is invisible to type checkers.
- The monkey-patches stay, so `sqlalchemy.select(...)` keeps working unchanged. Users opt into typing by switching `sa.select` to `cc_sqlalchemy.select`. The subclass stays itself through native generative methods like `.where()` and `.select_from()`, so mixed chains keep the typed methods.

Closes #837

## Checklist
Delete items not relevant to your PR:
- [X] Unit and integration tests covering the common scenarios were added
- [X] A human-readable description of the changes was provided to include in CHANGELOG