### PR TITLE
support per-query settings via execution_options

### DIFF
--- a/clickhouse_connect/cc_sqlalchemy/dialect.py
+++ b/clickhouse_connect/cc_sqlalchemy/dialect.py
@@ -1,3 +1,5 @@
+from typing import Any, cast
+
 import sqlalchemy.schema as sa_schema
 from sqlalchemy import text
 from sqlalchemy.engine.default import DefaultDialect
@@ -10,6 +12,7 @@ from clickhouse_connect.cc_sqlalchemy.sql import full_table
 from clickhouse_connect.cc_sqlalchemy.sql.compiler import ChStatementCompiler
 from clickhouse_connect.cc_sqlalchemy.sql.ddlcompiler import ChDDLCompiler
 from clickhouse_connect.cc_sqlalchemy.sql.preparer import ChIdentifierPreparer
+from clickhouse_connect.dbapi.cursor import Cursor
 from clickhouse_connect.driver.binding import format_str, quote_identifier
 
 
@@ -65,6 +68,22 @@ class ClickHouseDialect(DefaultDialect):
         # Set before super().__init__() so ChIdentifierPreparer can read it when built.
         self.server_side_params = server_side_params
         super().__init__(**kwargs)
+
+    @staticmethod
+    def _ch_query_settings(context: Any) -> dict[str, Any] | None:
+        # Pull per-statement ClickHouse settings from execution_options["settings"].
+        if context is None:
+            return None
+        return context.execution_options.get("settings")
+
+    def do_execute(self, cursor, statement, parameters, context=None):
+        cast(Cursor, cursor).execute(statement, parameters, settings=self._ch_query_settings(context))
+
+    def do_executemany(self, cursor, statement, parameters, context=None):
+        cast(Cursor, cursor).executemany(statement, parameters, settings=self._ch_query_settings(context))
+
+    def do_execute_no_params(self, cursor, statement, context=None):
+        cast(Cursor, cursor).execute(statement, settings=self._ch_query_settings(context))
 
     # SQA 1 compatibility
 

--- a/clickhouse_connect/dbapi/cursor.py
+++ b/clickhouse_connect/dbapi/cursor.py
@@ -51,7 +51,7 @@ class Cursor:
     def close(self) -> None:
         self.data = None
 
-    def execute(self, operation: str, parameters: Any = None) -> None:
+    def execute(self, operation: str, parameters: Any = None, settings: dict[str, Any] | None = None) -> None:
         if not parameters and isinstance(operation, str):
             # Per PEP 249 pyformat paramstyle, callers (e.g. SQLAlchemy) escape
             # literal percent signs as %% in operation strings.  When there are
@@ -59,7 +59,7 @@ class Cursor:
             # unescaping automatically.  When there are no parameters,
             # finalize_query short-circuits, so we must unescape here.
             operation = operation.replace("%%", "%")
-        query_result = self.client.query(operation, parameters)
+        query_result = self.client.query(operation, parameters, settings=settings)
         self.data = query_result.result_set
         self._rowcount = len(self.data)
         self._summary.append(query_result.summary)
@@ -76,12 +76,13 @@ class Cursor:
         else:
             stripped = operation.strip().rstrip(";").strip()
             if stripped.upper().startswith(("SELECT", "WITH")):
-                meta_result = self.client.query(f"SELECT * FROM ({stripped}) LIMIT 0", parameters)
+                # Introspection re-query carries the same settings so the derived column shape matches.
+                meta_result = self.client.query(f"SELECT * FROM ({stripped}) LIMIT 0", parameters, settings=settings)
                 if meta_result.column_names:
                     self.names = meta_result.column_names
                     self.types = [x.name for x in meta_result.column_types]
 
-    def _try_bulk_insert(self, operation: str, data: Any) -> bool:
+    def _try_bulk_insert(self, operation: str, data: Any, settings: dict[str, Any] | None = None) -> bool:
         match = insert_re.match(remove_sql_comments(operation))
         if not match:
             return False
@@ -112,20 +113,20 @@ class Cursor:
             data_values = data
         else:
             return False
-        insert_summary = self.client.insert(table, data_values, col_names)
+        insert_summary = self.client.insert(table, data_values, col_names, settings=settings)
         self.data = []
         self._rowcount = insert_summary.written_rows
         self._ix = 0
         self._summary.append(insert_summary.summary)
         return True
 
-    def executemany(self, operation: str, parameters: Any) -> None:
-        if not parameters or self._try_bulk_insert(operation, parameters):
+    def executemany(self, operation: str, parameters: Any, settings: dict[str, Any] | None = None) -> None:
+        if not parameters or self._try_bulk_insert(operation, parameters, settings):
             return
         self.data = []
         try:
             for param_row in parameters:
-                query_result = self.client.query(operation, param_row)
+                query_result = self.client.query(operation, param_row, settings=settings)
                 self.data.extend(query_result.result_set)
                 if self.names or self.types:
                     if query_result.column_names != self.names:

--- a/tests/integration_tests/test_sqlalchemy/test_query_settings.py
+++ b/tests/integration_tests/test_sqlalchemy/test_query_settings.py
@@ -1,0 +1,36 @@
+from sqlalchemy import select, text
+from sqlalchemy.engine import Engine
+
+_get_max_threads = "SELECT getSetting('max_threads') AS v"
+
+
+def test_statement_settings_text(test_engine: Engine):
+    with test_engine.begin() as conn:
+        # Pick a target that always differs from the server default so the assertion is meaningful.
+        baseline = int(conn.execute(text(_get_max_threads)).scalar_one())
+        target = baseline + 1
+
+        stmt = text(_get_max_threads).execution_options(settings={"max_threads": target})
+        assert int(conn.execute(stmt).scalar_one()) == target
+
+        # Setting is per-statement; a plain query reverts to the baseline.
+        assert int(conn.execute(text(_get_max_threads)).scalar_one()) == baseline
+
+
+def test_statement_settings_select(test_engine: Engine):
+    with test_engine.begin() as conn:
+        baseline = int(conn.execute(select(text("getSetting('max_threads') AS v"))).scalar_one())
+        target = baseline + 1
+
+        stmt = select(text("getSetting('max_threads') AS v")).execution_options(settings={"max_threads": target})
+        assert int(conn.execute(stmt).scalar_one()) == target
+
+
+def test_connection_settings(test_engine: Engine):
+    with test_engine.begin() as conn:
+        baseline = int(conn.execute(text(_get_max_threads)).scalar_one())
+        target = baseline + 1
+
+        # Connection.execution_options is generative in SQLAlchemy 1.4, so use the returned connection.
+        c = conn.execution_options(settings={"max_threads": target})
+        assert int(c.execute(text(_get_max_threads)).scalar_one()) == target

--- a/tests/unit_tests/test_driver/test_cursor.py
+++ b/tests/unit_tests/test_driver/test_cursor.py
@@ -234,7 +234,7 @@ def test_executemany_bulk_insert_with_tuple_rows():
     rows = [(13, "user_1"), (79, "user_2")]
     cursor.executemany("INSERT INTO test_table (id, name) VALUES (%s, %s)", rows)
 
-    client.insert.assert_called_once_with("test_table", rows, ["id", "name"])
+    client.insert.assert_called_once_with("test_table", rows, ["id", "name"], settings=None)
     client.query.assert_not_called()
 
 
@@ -246,7 +246,7 @@ def test_executemany_bulk_insert_tuple_rows_without_column_list():
     rows = [(13, "user_1"), (79, "user_2")]
     cursor.executemany("INSERT INTO test_table VALUES (%s, %s)", rows)
 
-    client.insert.assert_called_once_with("test_table", rows, "*")
+    client.insert.assert_called_once_with("test_table", rows, "*", settings=None)
     client.query.assert_not_called()
 
 
@@ -258,7 +258,7 @@ def test_executemany_bulk_insert_with_dict_rows():
     rows = [{"id": 13, "name": "user_1"}, {"id": 79, "name": "user_2"}]
     cursor.executemany("INSERT INTO test_table (id, name) VALUES (%(id)s, %(name)s)", rows)
 
-    client.insert.assert_called_once_with("test_table", [[13, "user_1"], [79, "user_2"]], ["id", "name"])
+    client.insert.assert_called_once_with("test_table", [[13, "user_1"], [79, "user_2"]], ["id", "name"], settings=None)
     client.query.assert_not_called()
 
 

--- a/tests/unit_tests/test_sqlalchemy/test_query_settings.py
+++ b/tests/unit_tests/test_sqlalchemy/test_query_settings.py
@@ -1,0 +1,88 @@
+"""Per-query ClickHouse settings threading through the DB-API cursor and dialect (issue #838)."""
+
+from typing import Any
+from unittest.mock import Mock
+
+from clickhouse_connect.cc_sqlalchemy.dialect import ClickHouseDialect
+from clickhouse_connect.dbapi.cursor import Cursor
+
+
+class _StubQueryResult:
+    result_set: list[Any] = []
+    column_names: list[str] = []
+    column_types: list[Any] = []
+    summary: dict[str, Any] = {}
+
+
+class _StubInsertResult:
+    written_rows = 0
+    summary: dict[str, Any] = {}
+
+
+class _FakeContext:
+    def __init__(self, execution_options):
+        self.execution_options = execution_options
+
+
+def _mock_client():
+    client = Mock()
+    client.query.return_value = _StubQueryResult()
+    client.insert.return_value = _StubInsertResult()
+    return client
+
+
+def _query_settings(client):
+    return [call.kwargs.get("settings") for call in client.query.call_args_list]
+
+
+def test_cursor_execute_forwards_settings():
+    client = _mock_client()
+    Cursor(client).execute("SELECT 13", settings={"max_threads": 3})
+    # Main query plus the LIMIT 0 introspection re-query both carry the settings.
+    assert _query_settings(client) == [{"max_threads": 3}, {"max_threads": 3}]
+
+
+def test_cursor_executemany_forwards_settings():
+    client = _mock_client()
+    Cursor(client).executemany("SELECT %(v)s", [{"v": 13}, {"v": 79}], settings={"max_threads": 3})
+    assert _query_settings(client) == [{"max_threads": 3}, {"max_threads": 3}]
+
+
+def test_cursor_bulk_insert_forwards_settings():
+    client = _mock_client()
+    Cursor(client).executemany("INSERT INTO tbl (a, b) VALUES", [{"a": 13, "b": 79}], settings={"max_threads": 3})
+    client.insert.assert_called_once_with("tbl", [[13, 79]], ["a", "b"], settings={"max_threads": 3})
+
+
+def test_dialect_do_execute_forwards_settings():
+    client = _mock_client()
+    context = _FakeContext({"settings": {"max_threads": 3}})
+    ClickHouseDialect().do_execute(Cursor(client), "SELECT 13", None, context=context)
+    assert _query_settings(client)[0] == {"max_threads": 3}
+
+
+def test_dialect_do_executemany_forwards_settings():
+    client = _mock_client()
+    context = _FakeContext({"settings": {"max_threads": 3}})
+    ClickHouseDialect().do_executemany(Cursor(client), "SELECT %(v)s", [{"v": 13}], context=context)
+    assert _query_settings(client)[0] == {"max_threads": 3}
+
+
+def test_dialect_do_execute_no_params_forwards_settings():
+    client = _mock_client()
+    context = _FakeContext({"settings": {"max_threads": 3}})
+    ClickHouseDialect().do_execute_no_params(Cursor(client), "SELECT 13", context=context)
+    assert _query_settings(client)[0] == {"max_threads": 3}
+
+
+def test_dialect_do_execute_context_none_forwards_none():
+    client = _mock_client()
+    ClickHouseDialect().do_execute(Cursor(client), "SELECT 13", None, context=None)
+    assert _query_settings(client)[0] is None
+
+
+def test_dialect_do_execute_missing_settings_key_forwards_none():
+    client = _mock_client()
+    context = _FakeContext({})
+    ClickHouseDialect().do_execute(Cursor(client), "SELECT 13", None, context=context)
+    assert _query_settings(client)[0] is None


### PR DESCRIPTION
## Summary

- Adds first-class per-query ClickHouse settings to the SQLAlchemy dialect. `stmt.execution_options(settings={...})` now reaches the server instead of being silently ignored, so callers no longer need to hand-render a trailing `SETTINGS` clause.
- The dialect reads `settings` from the merged execution options and forwards them to the client protocol settings through the DB-API cursor. This covers Core statements, `text()` statements, and connection-level `execution_options`.
- Applies to `execute`, `executemany`, and the bulk-insert path. Values go through the existing client validation that strips unknown or readonly keys, so no new validation or escaping logic is added.
- No SQL rewriting. This removes the app-level `SETTINGS` rendering, string escaping, and double-clause handling described in the issue.
- The option key is `settings`, matching `client.query(settings=...)` and the connection URL convention.

Closes #838

## Checklist
Delete items not relevant to your PR:
- [X] Unit and integration tests covering the common scenarios were added
- [X] A human-readable description of the changes was provided to include in CHANGELOG
- [ ] For significant changes, documentation in https://github.com/ClickHouse/clickhouse-docs was updated with further explanations or tutorials
