### PR TITLE
add consumer-facing public API type checking to CI

### DIFF
--- a/.github/workflows/on_push.yml
+++ b/.github/workflows/on_push.yml
@@ -86,7 +86,7 @@ jobs:
           cd "$RUNNER_TEMP"
           "$RUNNER_TEMP/consumer/bin/mypy" --strict --follow-imports=silent consumer_smoke.py
       - name: Public type completeness ratchet
-        run: python scripts/check_public_types.py clickhouse_connect --max-untyped 1120 --python "$RUNNER_TEMP/consumer/bin/python"
+        run: python scripts/check_public_types.py clickhouse_connect --max-untyped 1129 --python "$RUNNER_TEMP/consumer/bin/python"
 
   bare-import-test:
     runs-on: ubuntu-latest

--- a/.github/workflows/on_push.yml
+++ b/.github/workflows/on_push.yml
@@ -60,6 +60,34 @@ jobs:
       - name: Mypy check
         run: mypy
 
+  public-api-types:
+    runs-on: ubuntu-latest
+    name: Public API Type Surface
+    steps:
+      - uses: actions/checkout@v6
+      - name: Set up Python 3.12
+        uses: actions/setup-python@v6
+        with:
+          python-version: "3.12"
+      - name: Install into a clean consumer environment
+        run: |
+          python -m venv "$RUNNER_TEMP/consumer"
+          pip install build
+          CLICKHOUSE_CONNECT_SKIP_CYTHON=1 python -m build --sdist --outdir "$RUNNER_TEMP/dist"
+          CLICKHOUSE_CONNECT_SKIP_CYTHON=1 "$RUNNER_TEMP/consumer/bin/pip" install "$RUNNER_TEMP"/dist/*.tar.gz
+          # Stub packages are intentionally unpinned. If the ratchet count shifts without a repo change, pin them here.
+          "$RUNNER_TEMP/consumer/bin/pip" install numpy pandas pandas-stubs pyarrow polars
+          "$RUNNER_TEMP/consumer/bin/pip" install "mypy==2.1.0" "pyright==1.1.408"
+      - name: Confirm py.typed shipped with the install
+        run: test -f "$RUNNER_TEMP"/consumer/lib/python*/site-packages/clickhouse_connect/py.typed
+      - name: Consumer smoke test (mypy --strict against installed wheel)
+        run: |
+          cp tests/type_check/consumer_smoke.py "$RUNNER_TEMP/consumer_smoke.py"
+          cd "$RUNNER_TEMP"
+          "$RUNNER_TEMP/consumer/bin/mypy" --strict --follow-imports=silent consumer_smoke.py
+      - name: Public type completeness ratchet
+        run: python scripts/check_public_types.py clickhouse_connect --max-untyped 1120 --python "$RUNNER_TEMP/consumer/bin/python"
+
   bare-import-test:
     runs-on: ubuntu-latest
     needs: lint

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,1 +1,2 @@
 global-include *.pxd *.pyx
+include clickhouse_connect/py.typed

--- a/scripts/check_public_types.py
+++ b/scripts/check_public_types.py
@@ -1,0 +1,107 @@
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import subprocess
+import sys
+
+
+def run_verifytypes(package: str, python: str | None) -> dict:
+    env = dict(os.environ)
+    pyright = "pyright"
+    cwd = None
+    if python:
+        bindir = os.path.dirname(os.path.abspath(python))
+        venv = os.path.dirname(bindir)
+        env["VIRTUAL_ENV"] = venv
+        env["PATH"] = bindir + os.pathsep + env["PATH"]
+        pyright = os.path.join(bindir, "pyright")
+        # Run outside any source checkout so pyright can only resolve the installed
+        # package, never a sibling ./clickhouse_connect on disk.
+        cwd = venv
+    proc = subprocess.run(
+        [pyright, "--verifytypes", package, "--ignoreexternal", "--outputjson"],
+        capture_output=True,
+        text=True,
+        env=env,
+        cwd=cwd,
+    )
+    # pyright exits nonzero whenever completeness < 100%, which is expected here,
+    # so parse the JSON regardless of the exit code.
+    try:
+        return json.loads(proc.stdout)
+    except json.JSONDecodeError:
+        sys.stderr.write(proc.stdout)
+        sys.stderr.write(proc.stderr)
+        raise SystemExit("could not parse pyright --verifytypes output") from None
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser(description=__doc__)
+    ap.add_argument("package", nargs="?", default="clickhouse_connect")
+    ap.add_argument(
+        "--max-untyped",
+        type=int,
+        required=True,
+        help="Max exported public symbols allowed to lack a complete type (the ratchet baseline)",
+    )
+    ap.add_argument("--python", help="Interpreter of the environment where the package is installed")
+    ap.add_argument("--top", type=int, default=30, help="How many untyped public symbols to list")
+    args = ap.parse_args()
+
+    data = run_verifytypes(args.package, args.python)
+    summary = data.get("typeCompleteness")
+    if not summary:
+        raise SystemExit(
+            "pyright reported no typeCompleteness section. The package is likely not "
+            "installed in the target environment, or its py.typed marker is missing."
+        )
+
+    # Confirm we measured the installed package, not a stray copy. pyright resolution is
+    # sensitive, so verify the resolved py.typed lives under the target environment.
+    if args.python:
+        venv = os.path.dirname(os.path.dirname(os.path.abspath(args.python)))
+        resolved = summary.get("pyTypedPath") or summary.get("packageRootDirectory") or ""
+        if not resolved.startswith(venv):
+            raise SystemExit(
+                f"pyright resolved {args.package} at {resolved or '<unknown>'}, not under the "
+                f"target environment {venv}. Refusing to report a score for the wrong package."
+            )
+
+    score = round(summary["completenessScore"] * 100, 2)
+    counts = summary["exportedSymbolCounts"]
+
+    symbols = summary.get("symbols", [])
+    untyped = [s for s in symbols if s.get("isExported") and not s.get("isTypeKnown", True)]
+    # Gate on pyright's authoritative summary counts rather than the per-symbol flag.
+    count = counts["withAmbiguousType"] + counts["withUnknownType"]
+
+    print(f"public type completeness: {score}%  ({count} untyped, baseline {args.max_untyped})")
+    print(
+        f"  exported symbols: known={counts['withKnownType']} ambiguous={counts['withAmbiguousType']} unknown={counts['withUnknownType']}"
+    )
+    if untyped:
+        print(f"  top {min(args.top, count)} public symbols missing complete types:")
+        for s in untyped[: args.top]:
+            message = (s.get("diagnostics") or [{}])[0].get("message", "")
+            diag = message.splitlines()[0] if message else "type is partially unknown"
+            print(f"    - {s['name']}: {diag}")
+
+    if count > args.max_untyped:
+        print(
+            f"\nFAIL: {count} public symbols lack a complete type, above the baseline of "
+            f"{args.max_untyped}. Public API was likely added or changed without full "
+            "annotations. Annotate it, or raise --max-untyped only with justification.",
+            file=sys.stderr,
+        )
+        return 1
+    if count < args.max_untyped:
+        print(f"\nOK, and you can tighten the ratchet: lower --max-untyped to {count}.")
+        return 0
+    print("\nOK: no new untyped public API.")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/setup.py
+++ b/setup.py
@@ -5,18 +5,23 @@ from setuptools import find_packages, setup
 
 c_modules = []
 
-try:
-    from Cython import __version__ as cython_version
-    from Cython.Build import cythonize
+skip_cython = os.environ.get("CLICKHOUSE_CONNECT_SKIP_CYTHON") == "1"
 
-    print(f"Using Cython {cython_version} to build cython modules")
-    c_modules = cythonize("clickhouse_connect/driverc/*.pyx", language_level="3str")
-except ImportError as ex:
-    print("Cython Install Failed, Not Building C Extensions: ", ex)
-    cythonize = None
-except Exception as ex:
-    print("Cython Build Failed, Not Building C Extensions: ", ex)
-    cythonize = None
+if skip_cython:
+    print("CLICKHOUSE_CONNECT_SKIP_CYTHON set, not building C extensions")
+else:
+    try:
+        from Cython import __version__ as cython_version
+        from Cython.Build import cythonize
+
+        print(f"Using Cython {cython_version} to build cython modules")
+        c_modules = cythonize("clickhouse_connect/driverc/*.pyx", language_level="3str")
+    except ImportError as ex:
+        print("Cython Install Failed, Not Building C Extensions: ", ex)
+        cythonize = None
+    except Exception as ex:
+        print("Cython Build Failed, Not Building C Extensions: ", ex)
+        cythonize = None
 
 
 def run_setup(try_c: bool = True):
@@ -54,6 +59,7 @@ def run_setup(try_c: bool = True):
         long_description_content_type="text/markdown",
         url="https://github.com/ClickHouse/clickhouse-connect",
         packages=find_packages(exclude=["tests*"]),
+        package_data={"clickhouse_connect": ["py.typed"]},
         python_requires=">=3.10,<3.15",
         license="Apache-2.0",
         install_requires=[

--- a/tests/type_check/consumer_smoke.py
+++ b/tests/type_check/consumer_smoke.py
@@ -1,0 +1,51 @@
+from __future__ import annotations
+
+from collections.abc import Generator, Sequence
+from typing import Any, assert_type
+
+import numpy
+import pandas
+
+import clickhouse_connect
+from clickhouse_connect.driver import AsyncClient, Client, create_async_client, create_client
+from clickhouse_connect.driver.query import QueryResult
+from clickhouse_connect.driver.summary import QuerySummary
+
+
+def entry_points() -> None:
+    # Every name in clickhouse_connect.__all__ must stay importable and typed.
+    assert_type(clickhouse_connect.__version__, str)
+    assert_type(clickhouse_connect.driver_name, str)
+    assert_type(clickhouse_connect.get_client(host="localhost"), Client)
+    assert_type(create_client(host="localhost"), Client)
+
+
+def sync_query() -> None:
+    client = clickhouse_connect.get_client(host="localhost", username="default", password="")
+    result = client.query("SELECT number FROM system.numbers LIMIT 13")
+    assert_type(result, QueryResult)
+    assert_type(result.result_rows, Sequence[Sequence[Any]])
+    assert_type(result.result_set, Sequence[Sequence[Any]])
+    assert_type(result.named_results(), Generator[dict[Any, Any], None, None])
+
+    assert_type(client.query_df("SELECT 13"), pandas.DataFrame)
+    assert_type(client.query_np("SELECT 13"), numpy.ndarray)
+    assert_type(client.ping(), bool)
+
+    summary = client.insert("target", [[13], [79]], column_names=["value"])
+    assert_type(summary, QuerySummary)
+    client.close()
+
+
+def context_manager() -> None:
+    with clickhouse_connect.get_client(host="localhost") as client:
+        assert_type(client, Client)
+        client.command("SELECT 1")
+
+
+async def async_query() -> None:
+    client = await clickhouse_connect.get_async_client(host="localhost")
+    assert_type(client, AsyncClient)
+    assert_type(await create_async_client(host="localhost"), AsyncClient)
+    async with client:
+        assert_type(await client.query("SELECT 13"), QueryResult)


### PR DESCRIPTION
## Summary
- New `public-api-types` CI job installs clickhouse-connect into a clean environment and checks its typing the way a downstream user would. This catches problems internal mypy cannot see, such as a missing `py.typed`, broken public re-exports, or return types that decay to `Any`.
- The job runs a `mypy --strict` smoke test that pins the common public call chains with `assert_type`, plus a `pyright --verifytypes` ratchet that fails when the count of untyped public symbols rises above the baseline.
- `py.typed` is now declared explicitly in `setup.py` and `MANIFEST.in`, so the marker ships in both the wheel and the sdist regardless of the setuptools version at build time. Wheel contents are otherwise unchanged.
- Added a `CLICKHOUSE_CONNECT_SKIP_CYTHON=1` build flag that skips the C extension build for a pure-Python install. The CI job uses it to build and install from the sdist, which exercises the full checkout to sdist to wheel to install path.