### PR TITLE
fix aiohttp resource waning

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## UNRELEASED
 
+### Bug Fixes
+- Async inserts and queries with an in-memory body larger than 1 MiB no longer emit an aiohttp `ResourceWarning` about sending a large body directly with raw bytes. Closes [#850](https://github.com/ClickHouse/clickhouse-connect/issues/850).
+
 ## 1.4.1, 2026-06-30
 
 ### Bug Fixes

--- a/clickhouse_connect/driver/asyncclient.py
+++ b/clickhouse_connect/driver/asyncclient.py
@@ -2044,8 +2044,10 @@ class AsyncClient(Client):
                         else:
                             form.add_field(field_name, field_value, content_type="text/plain")
                     request_kwargs["data"] = form
-                elif isinstance(data, dict):
-                    request_kwargs["data"] = data
+                elif isinstance(data, (bytes, bytearray, memoryview)):
+                    request_kwargs["data"] = io.BytesIO(data)
+                elif isinstance(data, str):
+                    request_kwargs["data"] = io.BytesIO(data.encode())
                 else:
                     request_kwargs["data"] = data
 


### PR DESCRIPTION
## Summary
AsyncClient passed raw `bytes` and `str` request bodies straight to `aiohttp`, which since version 3.13 emits a `ResourceWarning` for any in-memory body over 1 MiB because writing one large buffer can block the event loop. This wraps bytes and string bodies in an `io.BytesIO` so `aiohttp` writes them in chunks, which clears the warning on async Arrow inserts and any other large insert or query body.

Closes #850