### PR TITLE
fix: escape dict-valued settings as ClickHouse map literals (#501)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## UNRELEASED
 
+### Bug Fixes
+- Dict-valued settings such as `additional_table_filters` no longer crash with `DB::Exception: Cannot parse quoted string` when passed through `query()`'s `settings` parameter. The value was rendered with Python's own `str()`/`repr()` of the dict, which mixes single and double quotes and is not valid ClickHouse map-literal syntax; it is now rendered as a properly single-quoted, escaped ClickHouse map literal. Closes [#501](https://github.com/ClickHouse/clickhouse-connect/issues/501).
+
 ## 1.5.0, 2026-07-15
 
 ### Bug Fixes

--- a/clickhouse_connect/driver/client.py
+++ b/clickhouse_connect/driver/client.py
@@ -19,7 +19,7 @@ from clickhouse_connect.datatypes import dynamic as dynamic_module
 from clickhouse_connect.datatypes.base import ClickHouseType
 from clickhouse_connect.datatypes.registry import get_from_name
 from clickhouse_connect.driver import options, tzutil
-from clickhouse_connect.driver.binding import quote_identifier
+from clickhouse_connect.driver.binding import quote_identifier, str_query_value
 from clickhouse_connect.driver.common import (
     StreamContext,
     coerce_bool,
@@ -259,11 +259,24 @@ class Client(ABC):
         for key, value in settings.items():
             str_value = self._validate_setting(key, value, invalid_action)
             if str_value is not None:
-                validated[key] = value
+                # Container values (e.g. `additional_table_filters`) must be sent as a properly
+                # quoted/escaped ClickHouse literal (str_value); Python's own str()/repr of a dict
+                # or list is not valid ClickHouse syntax and would otherwise be mangled by urlencode.
+                # Scalar values are passed through as-is to preserve their original type.
+                validated[key] = str_value if isinstance(value, (dict, list, tuple)) else value
         return validated
 
     def _validate_setting(self, key: str, value: Any, invalid_action: str) -> str | None:
-        str_value = str(value)
+        if isinstance(value, dict):
+            # Settings of Map type (e.g. `additional_table_filters`) must be sent as a ClickHouse
+            # map literal, always with single-quoted/escaped keys and values -- regardless of the
+            # unrelated `dict_parameter_format` setting, which only governs bound query parameters.
+            pairs = (f"{str_query_value(k)}: {str_query_value(v)}" for k, v in value.items())
+            str_value = f"{{{', '.join(pairs)}}}"
+        elif isinstance(value, (list, tuple)):
+            str_value = str_query_value(value)
+        else:
+            str_value = str(value)
         if value is True:
             str_value = "1"
         elif value is False:

--- a/tests/unit_tests/test_driver/test_httpclient.py
+++ b/tests/unit_tests/test_driver/test_httpclient.py
@@ -698,6 +698,36 @@ class TestQuery:
         assert not fields
 
     @patch.object(HttpClient, "_raw_request")
+    def test_raw_query_with_map_setting(self, mock_raw_request):
+        """A dict-valued setting (e.g. `additional_table_filters`) must be rendered as a
+        properly quoted/escaped ClickHouse map literal, not Python's own str()/repr of the
+        dict. Python's repr uses double quotes for values containing a single quote, which
+        the server rejects with "Cannot parse quoted string: expected opening quote ''', got
+        '"'." (see GH issue #501)."""
+        self.client.form_encode_query_params = False
+
+        mock_response = Mock()
+        mock_response.data = b"result_with_map_setting"
+        mock_raw_request.return_value = mock_response
+
+        query = "SELECT * FROM table"
+        settings = {"additional_table_filters": {"a": "'some_value'"}}
+
+        result = self.client.raw_query(query, settings=settings)
+
+        assert result == b"result_with_map_setting"
+
+        body, params, fields = self.extract_raw_request_params(mock_raw_request)
+
+        assert "additional_table_filters" in params
+        rendered = params["additional_table_filters"]
+        assert isinstance(rendered, str)
+        # Must be a single-quoted ClickHouse map literal with the embedded quotes escaped,
+        # never Python's dict repr (which mixes double and single quotes).
+        assert rendered == "{'a': '\\'some_value\\''}"
+        assert '"' not in rendered
+
+    @patch.object(HttpClient, "_raw_request")
     def test_raw_query_with_format(self, mock_raw_request):
         """Test raw_query properly appends FORMAT clause"""
         self.client.form_encode_query_params = False


### PR DESCRIPTION
Fixes #501

Root cause: `additional_table_filters` (and any Map-typed setting) passed via
`query(settings={...})` crashed with `DB::Exception: Cannot parse quoted string:
expected opening quote ''', got '"'`. `_validate_settings()` stored the raw Python
dict instead of a validated string, so `urlencode()` fell back to Python's own
`str()`/`repr()` of the dict — which mixes single and double quotes — producing
invalid ClickHouse map-literal syntax.

What changed: `_validate_setting()` now renders dict values as a proper
single-quoted, escaped ClickHouse map literal (via the existing
`binding.str_query_value` helper), independent of the unrelated
`dict_parameter_format` setting which only governs bound query parameters.
`_validate_settings()` now forwards that rendered string for dict/list/tuple
values instead of the raw object, so it survives `urlencode()` unchanged.
Scalar setting values (int/bool/str) are unaffected — same behavior as before.

Test evidence:
- Added `TestQuery.test_raw_query_with_map_setting` (tests/unit_tests/test_driver/test_httpclient.py).
  Before fix: `AssertionError: assert False == isinstance({'a': "'some_value'"}, str)`.
  After fix: passes, asserting `additional_table_filters` renders as
  `{'a': '\'some_value\''}` with no double quotes.
- Verified end-to-end against a live ClickHouse 25.6 server: before the fix, the
  exact repro from the issue raises `Code: 26 ... Cannot parse quoted string`;
  after the fix, `SELECT ... SETTINGS additional_table_filters=...` succeeds.
- Full suite: `pytest tests/unit_tests` (922 passed, 1 skipped),
  `pytest tests/integration_tests/test_client.py` (84 passed),
  `ruff format --check`, `ruff check`, and `mypy` all clean.

CHANGELOG.md updated under UNRELEASED per repo convention (AGENTS.md).

Prepared with AI assistance (Claude, agent: claude-sonnet-5), reviewed for correctness before submission.