### PR TITLE
Docs: move integration metadata from index.mdx comment to docs/_meta.yml

### DIFF
--- a/docs/_meta.yml
+++ b/docs/_meta.yml
@@ -13,7 +13,7 @@ formats: [Native, RowBinary, Arrow, Parquet, JSONEachRow, CSV, TSV]
 ecosystem: [Apache Arrow, Pandas, SQLAlchemy, Alembic, Superset]
 install:
   pip: pip install clickhouse-connect
-quickStartCode: /examples/run_async.py
+quickStartCode: /examples/quickstart.py
 desc: >-
   HTTP client with NumPy/Pandas/Arrow/Polars integration and async
   support. The default for new Python projects.

--- a/docs/_meta.yml
+++ b/docs/_meta.yml
@@ -1,0 +1,19 @@
+schemaVersion: 1
+id: python
+name: Python
+pkg: clickhouse-connect
+category: language_client
+supportLevel: core
+license: Apache-2.0
+repository: https://github.com/ClickHouse/clickhouse-connect
+packageRegistry: pypi
+slug: /integrations/python
+transports: [HTTP]
+formats: [Native, RowBinary, Arrow, Parquet, JSONEachRow, CSV, TSV]
+ecosystem: [Apache Arrow, Pandas, SQLAlchemy, Alembic, Superset]
+install:
+  pip: pip install clickhouse-connect
+quickStartCode: /examples/run_async.py
+desc: >-
+  HTTP client with NumPy/Pandas/Arrow/Polars integration and async
+  support. The default for new Python projects.

--- a/docs/index.mdx
+++ b/docs/index.mdx
@@ -11,30 +11,6 @@ integration:
   - website: 'https://github.com/ClickHouse/clickhouse-connect'
 ---
 
-{/*
-{
-  "id": "python",
-  "name": "Python",
-  "pkg": "clickhouse-connect",
-  "install": "pip install clickhouse-connect",
-  "quickStartCode": "/examples/run_async.py",
-  "transports": ["HTTP"],
-  "formats": ["Native", "RowBinary", "Arrow", "Parquet", "JSONEachRow", "CSV", "TSV"],
-  "ecosystem": ["Apache Arrow", "Pandas", "SQLAlchemy", "Alembic", "Superset"],
-  "desc": "HTTP client with NumPy/Pandas/Arrow/Polars integration and async support. The default for new Python projects.",
-  "stars": "0.4k",
-  "version": "0.8.x",
-  "slug": "/integrations/python",
-  "repository": "https://github.com/ClickHouse/clickhouse-connect",
-  "packageRegistry": "pypi",
-  "packageRegistryURL": "https://pypi.org/project/clickhouse-connect/",
-  "supportLevel": "core",
-  "category": "language_client",
-  "license": "Apache-2.0",
-  "changelog": "https://github.com/ClickHouse/clickhouse-connect/blob/main/CHANGELOG.md"
-}
-*/}
-
 import ConnectionDetails from '/snippets/_gather_your_details_http.mdx';
 
 ClickHouse Connect is a core database driver providing interoperability with a wide range of Python applications.

--- a/examples/quickstart.py
+++ b/examples/quickstart.py
@@ -1,0 +1,16 @@
+#!/usr/bin/env python3
+
+import clickhouse_connect
+
+client = clickhouse_connect.get_client(host="localhost", username="default", password="password")
+
+client.command("DROP TABLE IF EXISTS new_table")
+client.command("CREATE TABLE new_table (key UInt32, value String, metric Float64) ENGINE MergeTree ORDER BY key")
+
+row1 = [1000, "String Value 1000", 5.233]
+row2 = [2000, "String Value 2000", -107.04]
+
+client.insert("new_table", [row1, row2], column_names=["key", "value", "metric"])
+
+result = client.query("SELECT max(key), avg(metric) FROM new_table")
+print(result.result_rows)


### PR DESCRIPTION
## Summary
Test metadata file for use with in-product documentation

Replaces the JSON metadata blob embedded as an MDX comment in `docs/index.mdx` (added in #873) with a dedicated `docs/_meta.yml` file.

- Adds `docs/_meta.yml` with the integration metadata (`schemaVersion: 1`) for website usage
- Removes the now-redundant JSON comment block from `docs/index.mdx`

Notes:
- `quickStartCode` still points at `/examples/run_async.py`, unchanged from the previous JSON comment. The path resolves in the repo.
- Volatile fields from the old JSON blob (`stars`, `version`, `packageRegistryURL`, `changelog`) are intentionally not carried over.