### PR TITLE
fix test failing on head

### DIFF
--- a/tests/integration_tests/test_sqlalchemy/test_reflect.py
+++ b/tests/integration_tests/test_sqlalchemy/test_reflect.py
@@ -25,7 +25,7 @@ def test_full_table_reflection(test_engine: Engine, test_db: str):
             text(
                 f"CREATE TABLE {test_db}.reflect_test (key UInt32, value FixedString(20),"
                 + "agg SimpleAggregateFunction(anyLast, String))"
-                + "ENGINE AggregatingMergeTree ORDER BY key"
+                + "ENGINE AggregatingMergeTree ORDER BY (key, value)"
             )
         )
         metadata = db.MetaData(schema=test_db)


### PR DESCRIPTION
## Summary

ClickHouse PR ClickHouse/clickhouse#108087 ("Reject AggregatingMergeTree dimensions outside the sorting key", merged 2026-07-07) made the server reject `AggregatingMergeTree` tables with a plain column that is neither in the sorting key nor an aggregate measure. In a SQLAlchemy test here `FixedString(20)` is exactly that. Therefore `CREATE TABLE` now fails with `code 36 (BAD_ARGUMENTS): "Column(s) value ... are neither part of the sorting key nor aggregate measures ... Add them to the sorting key (ORDER BY), or set 'allow_dimensions_outside_sorting_key = 1'".`

Nothing in the driver itself needs changing.