### PR TITLE
Consolidated fixes for nested Enum parsing, nested NULL binding, and empty FixedString inserts, plus CI matrix refresh

### DIFF
--- a/.github/workflows/on_push.yml
+++ b/.github/workflows/on_push.yml
@@ -137,8 +137,9 @@ jobs:
         clickhouse-version:
           - '25.8' # LTS
           - '26.3' # LTS
-          - '26.4' # Stable
           - '26.5' # Stable
+          - '26.6' # Stable
+          - '26.7' # Stable
         use-c:
           - '1'
         include:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 ## UNRELEASED
 
+### Bug Fixes
+
+- Parsing a nested `Variant`, `Tuple`, `Nested`, or typed `JSON` column type whose element is an `Enum` with an escaped single quote in a value name no longer corrupts the escape sequence and fails while re-parsing the element type. Closes [#878](https://github.com/ClickHouse/clickhouse-connect/issues/878).
+- `None` nested inside an `Array` or `Tuple`, or inside a `Map` when `dict_parameter_format="map"`, now renders as the SQL `NULL` keyword instead of the `\N` sentinel used for top-level values. Top-level scalar `None` binds are unchanged. Closes [#879](https://github.com/ClickHouse/clickhouse-connect/issues/879).
+- Inserting empty bytes `b""` into a non-nullable `FixedString(N)` column now zero-pads to N bytes instead of raising `DataError`, matching the existing string and nullable-bytes write paths. Closes [#880](https://github.com/ClickHouse/clickhouse-connect/issues/880).
+
 ## 1.6.0, 2026-07-23
 
 ### Bug Fixes

--- a/clickhouse_connect/datatypes/string.py
+++ b/clickhouse_connect/datatypes/string.py
@@ -128,6 +128,9 @@ class FixedString(ClickHouseType):
                     ext(b)
         else:
             for b in column:
-                if len(b) != sz:
+                if len(b) == sz:
+                    ext(b)
+                elif not b:
+                    ext(empty)
+                else:
                     raise ctx.data_error(f"Fixed String binary value {b.hex(' ')} does not match column size {sz}")
-                ext(b)

--- a/clickhouse_connect/driver/binding.py
+++ b/clickhouse_connect/driver/binding.py
@@ -288,7 +288,9 @@ def format_bind_value(value: Any, server_tz: tzinfo | None = timezone.utc, top_l
         return format_bind_value(x, server_tz, False)
 
     if value is None:
-        return "\\N"
+        # Top-level NULL bind parameters use the escaped-text sentinel. Nested
+        # container elements are parsed as SQL literals and must use NULL.
+        return "\\N" if top_level else "NULL"
     if isinstance(value, str):
         if top_level:
             # At the top levels, strings must not be surrounded by quotes

--- a/clickhouse_connect/driver/parser.py
+++ b/clickhouse_connect/driver/parser.py
@@ -135,8 +135,9 @@ def parse_columns(expr: str):
             if char == quote:
                 quote = None
             elif char == "\\" and expr[pos] == "'" and expr[pos : pos + 4] != "' = " and expr[pos : pos + 2] != "')":
-                label += expr[pos]
+                label += char + expr[pos]
                 pos += 1
+                continue
         else:
             if level == 0:
                 if char in (" ", "="):

--- a/docs/additional-options.mdx
+++ b/docs/additional-options.mdx
@@ -31,7 +31,7 @@ The following global settings are currently defined:
 |--------------|---------|---------|-------------|
 | `autogenerate_session_id` | `True` | `True`, `False` | Generate a UUID session ID for each synchronous client unless a session ID is supplied. The async factory overrides this to `False` by default. |
 | `autogenerate_query_id` | `True` | `True`, `False` | Generate a UUID query ID for each request unless one is supplied. |
-| `dict_parameter_format` | `"json"` | `"json"`, `"map"` | Format Python dictionaries used in client-side parameter binding as JSON or ClickHouse map literals. |
+| `dict_parameter_format` | `"json"` | `"json"`, `"map"` | Format Python dictionaries used in parameter binding as JSON or ClickHouse map literals. |
 | `invalid_setting_action` | `"error"` | `"drop"`, `"send"`, `"error"` | Drop, send, or reject a setting that is unrecognized by the server or is readonly. `"error"` raises `ProgrammingError`. |
 | `max_connection_age` | `600` | Any number of seconds | Maximum age for a reused HTTP keep-alive connection. Rotation helps distribute connections across nodes behind a load balancer. |
 | `product_name` | `""` | Any string | Product identifier added to client information. Use a value such as `"my-product/1.0"`. |

--- a/docs/advanced-inserting.mdx
+++ b/docs/advanced-inserting.mdx
@@ -48,7 +48,7 @@ It is normally unnecessary to override a write format, but the methods in `click
 | Float64               | float                   |                   |                                                                                                             |
 | Decimal               | decimal.Decimal         |                   |                                                                                                             |
 | String                | str or bytes            |                   | A column must consistently contain text or bytes.                                                           |
-| FixedString           | bytes                   | string            | If inserted as a string, additional bytes will be set to zeros                                              |
+| FixedString           | bytes                   | string            | String values are padded with zero bytes. Empty bytes are written as all zero bytes.                        |
 | Enum[8,16]            | str or int              |                   | Insert labels as strings or their underlying integer values.                                                |
 | Date                  | datetime.date           | int               | Integer values are interpreted as days since 1970-01-01.                                                    |
 | Date32                | datetime.date           | int               | Integer values are interpreted as signed day offsets.                                                       |

--- a/docs/driver-api.mdx
+++ b/docs/driver-api.mdx
@@ -291,6 +291,8 @@ ClickHouse Connect Client `query*` and `command` methods accept an optional `par
 
 ClickHouse supports [server-side binding](/concepts/features/interfaces/client#cli-queries-with-parameters) for query values. The bound value is sent separately from the query as an HTTP parameter. ClickHouse Connect uses this mode when it detects an expression of the form `{<name>:<datatype>}`. Pass the values as a Python dictionary.
 
+Use Python `None` for nullable values. Nested `None` values are supported inside `Array` and `Tuple` parameters, and inside `Map` literals when `dict_parameter_format` is set to `"map"`.
+
 - Server-side binding with Python dictionary, DateTime value, and string value
 
 ```python

--- a/tests/integration_tests/test_inserts.py
+++ b/tests/integration_tests/test_inserts.py
@@ -55,6 +55,35 @@ def test_bad_strings(param_client: Client, call, table_context: Callable):
             assert "encoded" in str(ex)
 
 
+def test_fixed_string_empty_bytes(param_client: Client, call, table_context: Callable):
+    with table_context(
+        "test_fs_empty_bytes",
+        "key Int32, fs FixedString(6), nfs Nullable(FixedString(6)), afs Array(FixedString(6))",
+    ):
+        empty = b"\x00" * 6
+        data = [
+            [79, b"needle", b"abcdef", [b"needle", b""]],
+            [13, b"", b"", [b"", b"abcdef"]],
+        ]
+        call(param_client.insert, "test_fs_empty_bytes", data)
+        result = call(param_client.query, "SELECT key, fs, nfs, afs FROM test_fs_empty_bytes ORDER BY key").result_set
+        assert result == [
+            (13, empty, empty, [empty, b"abcdef"]),
+            (79, b"needle", b"abcdef", [b"needle", empty]),
+        ]
+        with pytest.raises(DataError, match="does not match column size"):
+            call(param_client.insert, "test_fs_empty_bytes", [[102, b"abc", None, []]])
+        # None into a non-nullable FixedString fails with TypeError from len(None).
+        # Current behavior, not a promised contract.
+        with pytest.raises(TypeError):
+            call(param_client.insert, "test_fs_empty_bytes", [[102, None, b"abcdef", []]])
+
+    with table_context("test_lc_fs_empty_bytes", "key Int32, lc LowCardinality(FixedString(6))"):
+        call(param_client.insert, "test_lc_fs_empty_bytes", [[79, b"needle"], [13, b""]])
+        result = call(param_client.query, "SELECT key, lc FROM test_lc_fs_empty_bytes ORDER BY key").result_set
+        assert result == [(13, b"\x00" * 6), (79, b"needle")]
+
+
 def test_low_card_dictionary_size(param_client: Client, call, table_context: Callable):
     with table_context("test_low_card_dict", "key Int32, lc LowCardinality(String)", settings={"index_granularity": 65536}):
         data = [[x, str(x)] for x in range(30000)]

--- a/tests/integration_tests/test_params.py
+++ b/tests/integration_tests/test_params.py
@@ -1,6 +1,7 @@
 from collections.abc import Callable
 from datetime import date, datetime
 
+from clickhouse_connect import common
 from clickhouse_connect.driver import Client
 from clickhouse_connect.driver.binding import DT64Param
 
@@ -99,3 +100,38 @@ def test_datetime_64_params(param_client: Client, call):
 
     result = call(param_client.query, "SELECT {a1:Array(DateTime64(6))}", parameters={"a1": dt_values}).first_row
     assert result[0] == dt_values
+
+
+def test_null_in_containers(param_client: Client, call):
+    result = call(
+        param_client.query,
+        "SELECT {t:Tuple(String, Nullable(String), Int32)}",
+        parameters={"t": ("user_1", None, 79)},
+    ).first_row
+    assert result[0] == ("user_1", None, 79)
+
+    result = call(
+        param_client.query,
+        "SELECT {a:Array(Nullable(String))}",
+        parameters={"a": ["user_1", None]},
+    ).first_row
+    assert result[0] == ["user_1", None]
+
+    result = call(
+        param_client.query,
+        "SELECT {a:Array(Tuple(String, Nullable(String)))}",
+        parameters={"a": [("user_1", None)]},
+    ).first_row
+    assert result[0] == [("user_1", None)]
+
+    original = common.get_setting("dict_parameter_format")
+    common.set_setting("dict_parameter_format", "map")
+    try:
+        result = call(
+            param_client.query,
+            "SELECT {m:Map(String, Nullable(String))}",
+            parameters={"m": {"user_1": None}},
+        ).first_row
+        assert result[0] == {"user_1": None}
+    finally:
+        common.set_setting("dict_parameter_format", original)

--- a/tests/unit_tests/test_driver/test_params.py
+++ b/tests/unit_tests/test_driver/test_params.py
@@ -5,6 +5,7 @@ from datetime import date, datetime, timezone
 
 import pytest
 
+from clickhouse_connect import common
 from clickhouse_connect.driver import tzutil
 from clickhouse_connect.driver.binding import (
     DT64Param,
@@ -58,10 +59,25 @@ def test_finalize():
         ([ipaddress.IPv4Address("10.13.79.1")], "['10.13.79.1']"),
         (ipaddress.IPv6Address("2001:db8::79"), "2001:db8::79"),
         ([ipaddress.IPv6Address("2001:db8::79")], "['2001:db8::79']"),
+        (None, "\\N"),
+        (["user_1", None], "['user_1', NULL]"),
+        (("user_1", None, 79), "('user_1', NULL, 79)"),
+        (("user_1", ("user_2", None)), "('user_1', ('user_2', NULL))"),
+        ([("user_1", None)], "[('user_1', NULL)]"),
     ],
 )
 def test_format_bind_value(value, expected):
     assert format_bind_value(value) == expected
+
+
+def test_format_bind_value_map_null():
+    original = common.get_setting("dict_parameter_format")
+    common.set_setting("dict_parameter_format", "map")
+    try:
+        assert format_bind_value({"user_1": None}) == "{'user_1':NULL}"
+        assert format_bind_value({"user_1": "user_2", "user_3": None}) == "{'user_1':'user_2', 'user_3':NULL}"
+    finally:
+        common.set_setting("dict_parameter_format", original)
 
 
 @pytest.mark.parametrize(

--- a/tests/unit_tests/test_driver/test_parser.py
+++ b/tests/unit_tests/test_driver/test_parser.py
@@ -1,7 +1,9 @@
+import pytest
+
 from clickhouse_connect.datatypes.registry import get_from_name
 from clickhouse_connect.driver.binding import quote_identifier
 from clickhouse_connect.driver.common import unescape_identifier
-from clickhouse_connect.driver.parser import parse_callable, parse_enum
+from clickhouse_connect.driver.parser import parse_callable, parse_columns, parse_enum
 from clickhouse_connect.driver.query import remove_sql_comments
 
 
@@ -20,6 +22,41 @@ def test_parse_callable():
 def test_parse_enum():
     assert parse_enum("Enum8('one' = 1)") == (("one",), (1,))
     assert parse_enum("Enum16('**\\'5' = 5, '578' = 7)") == (("**'5", "578"), (5, 7))
+
+
+ESCAPED_ENUM = "Enum8('user\\'1' = 1, 'user_2' = 2)"
+REPEATED_NON_FIRST_ENUM = "Enum16('user_1' = 1, 'user\\'2\\'3' = 2)"
+# Server-emitted enum names escape a backslash as \\ (v26.6.1.1193, DataTypeEnum
+# generateName -> writeQuotedString).
+BACKSLASH_ENUM = "Enum8('a\\\\b' = 1, 'user_2' = 2)"
+TRAILING_BACKSLASH_ENUM = "Enum8('user\\\\' = 1, 'user_2' = 2)"
+
+
+def test_parse_columns_escaped_quote_in_scalar_enum():
+    assert parse_columns(f"({ESCAPED_ENUM}, String)") == (
+        (),
+        (ESCAPED_ENUM, "String"),
+    )
+
+
+@pytest.mark.parametrize(
+    "type_name, expected_name",
+    [
+        (ESCAPED_ENUM, ESCAPED_ENUM),
+        (f"Array({ESCAPED_ENUM})", f"Array({ESCAPED_ENUM})"),
+        (f"Tuple({ESCAPED_ENUM}, UInt32)", f"Tuple({ESCAPED_ENUM}, UInt32)"),
+        (f"Array(Tuple({ESCAPED_ENUM}, UInt32))", f"Array(Tuple({ESCAPED_ENUM}, UInt32))"),
+        (f"Nullable({ESCAPED_ENUM})", f"Nullable({ESCAPED_ENUM})"),
+        (f"Variant({ESCAPED_ENUM}, String)", f"Variant({ESCAPED_ENUM}, String)"),
+        (f"Nested(status {ESCAPED_ENUM}, value UInt32)", f"Nested(status {ESCAPED_ENUM}, value UInt32)"),
+        (f"JSON(status {ESCAPED_ENUM})", f"JSON(`status` {ESCAPED_ENUM})"),
+        (f"Tuple({REPEATED_NON_FIRST_ENUM}, UInt32)", f"Tuple({REPEATED_NON_FIRST_ENUM}, UInt32)"),
+        (BACKSLASH_ENUM, BACKSLASH_ENUM),
+        (f"Tuple({TRAILING_BACKSLASH_ENUM}, UInt32)", f"Tuple({TRAILING_BACKSLASH_ENUM}, UInt32)"),
+    ],
+)
+def test_get_from_name_preserves_escaped_quote_in_enum(type_name, expected_name):
+    assert get_from_name(type_name).name == expected_name
 
 
 def test_unescape_identifier():


### PR DESCRIPTION
## Summary

This PR consolidates the fixes from the polyglot bot PRs #882, #883, and #884 plus the CI matrix update from #892 into a single change, so they go through CI, review, and release together. It closes #878, #879, and #880.

## Fixes

### Escaped single quotes in nested Enum type names, closes #878, replaces #882

`parse_columns` reversed a \' escape into '\ while re-accumulating a quoted Enum value name, so nested Enums inside Variant, Tuple, Nested, and typed JSON failed to re-parse. The escape branch now appends the backslash and quote in order and continues. Taken from #882 unchanged. The test was reworked into a parametrized matrix over every container that routes through `parse_columns`, plus scalar and backslash escape cases.

### None inside container bind parameters, closes #879, replaces #883

`format_bind_value` returned the `\N` sentinel for `None` at every level. The server only recognizes `\N` for a top level scalar parameter, which is parsed with `deserializeTextEscaped`. Elements inside Array, Tuple, and Map literals are parsed with `deserializeTextQuoted`, which only recognizes the NULL keyword. `None` now renders as NULL when nested and stays `\N` at top level, matching the server expectation exactly. A bare NULL at top level would parse as the literal string NULL, so the split is required. Taken from #883 unchanged, with docs updated to note nested `None` support.

### Empty bytes into non-nullable FixedString, closes #880, replaces #884

The non-nullable bytes branch of `FixedString._write_column_binary` raised `DataError` for `b""`. The server requires exactly N bytes per value in Native format and zero-pads short values only in text formats, and its pad is a zero fill, so writing N zero bytes for an empty value matches what '' produces through a textual insert. Same behavior as #884 with the branch restructured so the common exact-size case is checked first. `None` still raises before the empty check is reached, preserving the rejection #884 called out. Tests extended with Array(FixedString), LowCardinality, nullable, and wrong-size coverage.

### CI matrix, replaces #892

Tests now run against 25.8, 26.3, 26.5, 26.6, and 26.7, matching the 2 LTS plus 3 stable support policy. Verified the 26.6 and 26.7 image tags exist.

## Not included

- #885, description precision and scale. PEP 249 permits None there, so this is a feature rather than a bug fix, and the full type name already exposes the information. Closed with notes on the preferred design if we take it up later.
- #886, `executemany` `type_code`. The path is undefined behavior under PEP 249 and the patch would not have made `type_code` uniform anyway, since the no-metadata introspection branch in execute stores Python classes. Closed.

## Known follow-ups

- Enum labels where an escaped quote is followed by delimiter-like text, for example `'user\' = admin'`, still fail to parse. This also fails on main. The real fix is replacing the lookahead heuristics in `parse_columns`, `parse_callable`, and `parse_enum` with unconditional backslash escape handling, which the server escaping rules make safe. `parse_enum` also fails to unescape `\\`, which can silently insert enum value 0 for labels containing a backslash. Both will get a follow-up issue.
- `None` into a non-nullable FixedString raises a raw TypeError from `len` rather than `DataError`. Pre-existing, noted in the new test.

## Checklist
Delete items not relevant to your PR:
- [X] Unit and integration tests covering the common scenarios were added
- [X] A human-readable description of the changes was provided to include in CHANGELOG
- [X] For significant changes, documentation in https://github.com/ClickHouse/clickhouse-docs was updated with further explanations or tutorials
