### PR TITLE
fix: protect SQLAlchemy reflection from String bytes format

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Bug Fixes
 
+- SQLAlchemy reflection (`get_columns`, `get_table_names`, `Table(..., autoload_with=...)`, and related inspector methods) no longer breaks when a global String read format such as `set_default_formats("String", "bytes")` is configured. Metadata queries now use the same internal `String` → `string` query format override as the core driver's orchestration path, so schema cells decode as `str` while user queries still honor the global format. Closes [#920](https://github.com/ClickHouse/clickhouse-connect/issues/920).
 - Parsing a nested `Variant`, `Tuple`, `Nested`, or typed `JSON` column type whose element is an `Enum` with an escaped single quote in a value name no longer corrupts the escape sequence and fails while re-parsing the element type. Closes [#878](https://github.com/ClickHouse/clickhouse-connect/issues/878).
 - `None` nested inside an `Array` or `Tuple`, or inside a `Map` when `dict_parameter_format="map"`, now renders as the SQL `NULL` keyword instead of the `\N` sentinel used for top-level values. Top-level scalar `None` binds are unchanged. Closes [#879](https://github.com/ClickHouse/clickhouse-connect/issues/879).
 - Inserting empty bytes `b""` into a non-nullable `FixedString(N)` column now zero-pads to N bytes instead of raising `DataError`, matching the existing string and nullable-bytes write paths. Closes [#880](https://github.com/ClickHouse/clickhouse-connect/issues/880).

--- a/clickhouse_connect/cc_sqlalchemy/dialect.py
+++ b/clickhouse_connect/cc_sqlalchemy/dialect.py
@@ -7,7 +7,12 @@ from sqlalchemy.exc import NoResultFound, NoSuchTableError
 
 from clickhouse_connect import dbapi
 from clickhouse_connect.cc_sqlalchemy import dialect_name, ischema_names
-from clickhouse_connect.cc_sqlalchemy.inspector import ChInspector, get_columns, get_table_metadata
+from clickhouse_connect.cc_sqlalchemy.inspector import (
+    ChInspector,
+    get_columns,
+    get_table_metadata,
+    with_internal_query_formats,
+)
 from clickhouse_connect.cc_sqlalchemy.sql import full_table
 from clickhouse_connect.cc_sqlalchemy.sql.compiler import ChStatementCompiler
 from clickhouse_connect.cc_sqlalchemy.sql.ddlcompiler import ChDDLCompiler
@@ -83,14 +88,42 @@ class ClickHouseDialect(DefaultDialect):
             return dict(stmt_settings)
         return {**merged, **stmt_settings}
 
+    @staticmethod
+    def _ch_query_formats(context: Any) -> dict[str, str] | None:
+        # Deep-merge one level of execution_options["query_formats"], statement wins per key.
+        if context is None:
+            return None
+        merged = context.execution_options.get("query_formats")
+        stmt = getattr(context, "invoked_statement", None)
+        stmt_formats = stmt.get_execution_options().get("query_formats") if stmt is not None else None
+        if not stmt_formats:
+            return dict(merged) if merged else None
+        if not merged:
+            return dict(stmt_formats)
+        return {**merged, **stmt_formats}
+
     def do_execute(self, cursor, statement, parameters, context=None):
-        cast(Cursor, cursor).execute(statement, parameters, settings=self._ch_query_settings(context))
+        cast(Cursor, cursor).execute(
+            statement,
+            parameters,
+            settings=self._ch_query_settings(context),
+            query_formats=self._ch_query_formats(context),
+        )
 
     def do_executemany(self, cursor, statement, parameters, context=None):
-        cast(Cursor, cursor).executemany(statement, parameters, settings=self._ch_query_settings(context))
+        cast(Cursor, cursor).executemany(
+            statement,
+            parameters,
+            settings=self._ch_query_settings(context),
+            query_formats=self._ch_query_formats(context),
+        )
 
     def do_execute_no_params(self, cursor, statement, context=None):
-        cast(Cursor, cursor).execute(statement, settings=self._ch_query_settings(context))
+        cast(Cursor, cursor).execute(
+            statement,
+            settings=self._ch_query_settings(context),
+            query_formats=self._ch_query_formats(context),
+        )
 
     # SQA 1 compatibility
 
@@ -105,16 +138,16 @@ class ClickHouseDialect(DefaultDialect):
         return dbapi
 
     def _get_default_schema_name(self, connection):
-        return connection.execute(text("SELECT currentDatabase()")).scalar()
+        return connection.execute(with_internal_query_formats(text("SELECT currentDatabase()"))).scalar()
 
     def get_schema_names(self, connection, **_):
-        return [row.name for row in connection.execute(text("SHOW DATABASES"))]
+        return [row.name for row in connection.execute(with_internal_query_formats(text("SHOW DATABASES")))]
 
     @staticmethod
     def has_database(connection, db_name):
         # EXISTS DATABASE consults DatabaseCatalog directly, so it sees DataLakeCatalog
         # and other remote databases that system.databases omitted by default before server 26.5.
-        result = connection.execute(text(f"EXISTS DATABASE {quote_identifier(db_name)}"))
+        result = connection.execute(with_internal_query_formats(text(f"EXISTS DATABASE {quote_identifier(db_name)}")))
         row = result.fetchone()
         return row[0] == 1
 
@@ -122,7 +155,7 @@ class ClickHouseDialect(DefaultDialect):
         cmd = "SHOW TABLES"
         if schema:
             cmd += " FROM " + quote_identifier(schema)
-        return [row.name for row in connection.execute(text(cmd))]
+        return [row.name for row in connection.execute(with_internal_query_formats(text(cmd)))]
 
     def get_columns(self, connection, table_name, schema=None, **kw):
         return get_columns(connection, table_name, schema)
@@ -165,7 +198,7 @@ class ClickHouseDialect(DefaultDialect):
         return []
 
     def has_table(self, connection, table_name, schema=None, **_kw):
-        result = connection.execute(text(f"EXISTS TABLE {full_table(table_name, schema)}"))
+        result = connection.execute(with_internal_query_formats(text(f"EXISTS TABLE {full_table(table_name, schema)}")))
         row = result.fetchone()
         return row[0] == 1
 

--- a/clickhouse_connect/cc_sqlalchemy/inspector.py
+++ b/clickhouse_connect/cc_sqlalchemy/inspector.py
@@ -7,6 +7,7 @@ import sqlalchemy.schema as sa_schema
 from sqlalchemy import String, bindparam, text
 from sqlalchemy.engine.reflection import Inspector
 from sqlalchemy.exc import NoResultFound
+from sqlalchemy.sql.elements import TextClause
 
 from clickhouse_connect.cc_sqlalchemy.datatypes.base import sqla_type_from_name
 from clickhouse_connect.cc_sqlalchemy.ddl.tableengine import build_engine
@@ -16,19 +17,32 @@ from clickhouse_connect.cc_sqlalchemy.sql.sqlparse import (
     find_top_level_clause,
     split_top_level,
 )
+from clickhouse_connect.driver.client import _INTERNAL_QUERY_FORMATS
+
+
+def with_internal_query_formats(clause: TextClause) -> TextClause:
+    """Force String columns to decode as str for driver metadata introspection.
+
+    User-configured global read formats such as set_default_formats("String", "bytes")
+    must not affect DESCRIBE / system.tables / SHOW TABLES results used by reflection.
+    Mirrors driver.client._INTERNAL_QUERY_FORMATS on the orchestration path.
+    """
+    return clause.execution_options(query_formats=dict(_INTERNAL_QUERY_FORMATS))
 
 
 def _database_name(connection, schema: str | None) -> str:
     if schema:
         return schema
-    return connection.execute(text("SELECT currentDatabase()")).scalar()
+    return connection.execute(with_internal_query_formats(text("SELECT currentDatabase()"))).scalar()
 
 
 def get_table_metadata(connection, table_name, schema=None):
     database = _database_name(connection, schema)
     result_set = connection.execute(
-        text("SELECT engine, engine_full, comment FROM system.tables WHERE database = :database AND name = :table_name").bindparams(
-            bindparam("database", type_=String()), bindparam("table_name", type_=String())
+        with_internal_query_formats(
+            text("SELECT engine, engine_full, comment FROM system.tables WHERE database = :database AND name = :table_name").bindparams(
+                bindparam("database", type_=String()), bindparam("table_name", type_=String())
+            )
         ),
         {"database": database, "table_name": table_name},
     )
@@ -44,7 +58,7 @@ def get_engine(connection, table_name, schema=None):
 
 
 def get_dictionary_create_sql(connection, table_name: str, schema: str | None = None) -> str:
-    create_sql = connection.execute(text(f"SHOW CREATE DICTIONARY {full_table(table_name, schema)}")).scalar()
+    create_sql = connection.execute(with_internal_query_formats(text(f"SHOW CREATE DICTIONARY {full_table(table_name, schema)}"))).scalar()
     return create_sql or ""
 
 
@@ -126,7 +140,7 @@ def get_columns(connection, table_name: str, schema: str | None = None) -> list[
     if table_metadata.engine == "Dictionary":
         return get_dictionary_columns(connection, table_name, schema)
     table_id = full_table(table_name, schema)
-    result_set = connection.execute(text(f"DESCRIBE TABLE {table_id}"))
+    result_set = connection.execute(with_internal_query_formats(text(f"DESCRIBE TABLE {table_id}")))
     if not result_set:
         raise NoResultFound(f"Table {table_id} does not exist")
     columns = []

--- a/clickhouse_connect/dbapi/cursor.py
+++ b/clickhouse_connect/dbapi/cursor.py
@@ -51,7 +51,13 @@ class Cursor:
     def close(self) -> None:
         self.data = None
 
-    def execute(self, operation: str, parameters: Any = None, settings: dict[str, Any] | None = None) -> None:
+    def execute(
+        self,
+        operation: str,
+        parameters: Any = None,
+        settings: dict[str, Any] | None = None,
+        query_formats: dict[str, str] | None = None,
+    ) -> None:
         if not parameters and isinstance(operation, str):
             # Per PEP 249 pyformat paramstyle, callers (e.g. SQLAlchemy) escape
             # literal percent signs as %% in operation strings.  When there are
@@ -59,7 +65,7 @@ class Cursor:
             # unescaping automatically.  When there are no parameters,
             # finalize_query short-circuits, so we must unescape here.
             operation = operation.replace("%%", "%")
-        query_result = self.client.query(operation, parameters, settings=settings)
+        query_result = self.client.query(operation, parameters, settings=settings, query_formats=query_formats)
         self.data = query_result.result_set
         self._rowcount = len(self.data)
         self._summary.append(query_result.summary)
@@ -76,8 +82,13 @@ class Cursor:
         else:
             stripped = operation.strip().rstrip(";").strip()
             if stripped.upper().startswith(("SELECT", "WITH")):
-                # Introspection re-query carries the same settings so the derived column shape matches.
-                meta_result = self.client.query(f"SELECT * FROM ({stripped}) LIMIT 0", parameters, settings=settings)
+                # Introspection re-query carries the same settings/formats so the derived column shape matches.
+                meta_result = self.client.query(
+                    f"SELECT * FROM ({stripped}) LIMIT 0",
+                    parameters,
+                    settings=settings,
+                    query_formats=query_formats,
+                )
                 if meta_result.column_names:
                     self.names = meta_result.column_names
                     self.types = [x.name for x in meta_result.column_types]
@@ -120,13 +131,19 @@ class Cursor:
         self._summary.append(insert_summary.summary)
         return True
 
-    def executemany(self, operation: str, parameters: Any, settings: dict[str, Any] | None = None) -> None:
+    def executemany(
+        self,
+        operation: str,
+        parameters: Any,
+        settings: dict[str, Any] | None = None,
+        query_formats: dict[str, str] | None = None,
+    ) -> None:
         if not parameters or self._try_bulk_insert(operation, parameters, settings):
             return
         self.data = []
         try:
             for param_row in parameters:
-                query_result = self.client.query(operation, param_row, settings=settings)
+                query_result = self.client.query(operation, param_row, settings=settings, query_formats=query_formats)
                 self.data.extend(query_result.result_set)
                 if self.names or self.types:
                     if query_result.column_names != self.names:

--- a/tests/integration_tests/test_sqlalchemy/test_reflect.py
+++ b/tests/integration_tests/test_sqlalchemy/test_reflect.py
@@ -1,9 +1,10 @@
 import sqlalchemy as db
-from sqlalchemy import inspect, text
+from sqlalchemy import MetaData, Table, inspect, text
 from sqlalchemy.engine import Engine
 
 from clickhouse_connect import common
 from clickhouse_connect.cc_sqlalchemy.datatypes.sqltypes import Point, SimpleAggregateFunction, UInt32
+from clickhouse_connect.datatypes.format import clear_all_formats, set_default_formats
 
 
 def test_basic_reflection(test_engine: Engine):
@@ -122,3 +123,44 @@ def test_user_declared_primary_key(test_engine: Engine, test_db: str):
     )
     assert [c.name for c in table.primary_key.columns] == ["org_id", "id"]
     assert {c.name for c in table.columns} == {"org_id", "id", "payload"}
+
+
+def test_reflection_with_string_bytes_format(test_engine: Engine, test_db: str):
+    """Global set_default_formats("String", "bytes") must not break SQLAlchemy reflection.
+
+    Metadata queries force String→string decode (same as core _INTERNAL_QUERY_FORMATS).
+    User SELECT data still returns bytes. Closes #920.
+    """
+    common.set_setting("invalid_setting_action", "drop")
+    table_name = "reflect_bytes_fmt"
+    try:
+        with test_engine.begin() as conn:
+            conn.execute(text(f"DROP TABLE IF EXISTS {test_db}.{table_name}"))
+            conn.execute(text(f"CREATE TABLE {test_db}.{table_name} (k UInt32, s String) ENGINE MergeTree ORDER BY k"))
+            conn.execute(text(f"INSERT INTO {test_db}.{table_name} VALUES (1, 'hello')"))
+
+        set_default_formats("String", "bytes")
+
+        with test_engine.connect() as conn:
+            insp = inspect(conn)
+            table_names = insp.get_table_names(schema=test_db)
+            assert table_name in table_names
+            assert all(isinstance(name, str) for name in table_names)
+
+            columns = insp.get_columns(table_name, schema=test_db)
+            assert [(c["name"], type(c["name"])) for c in columns] == [
+                ("k", str),
+                ("s", str),
+            ]
+            assert all(isinstance(c["name"], str) for c in columns)
+
+            table = Table(table_name, MetaData(schema=test_db), autoload_with=conn)
+            assert {c.name for c in table.columns} == {"k", "s"}
+
+            # User data still honors the global bytes format.
+            row = conn.execute(text(f"SELECT s FROM {test_db}.{table_name} WHERE k = 1")).fetchone()
+            assert row[0] == b"hello"
+    finally:
+        clear_all_formats()
+        with test_engine.begin() as conn:
+            conn.execute(text(f"DROP TABLE IF EXISTS {test_db}.{table_name}"))

--- a/tests/unit_tests/test_sqlalchemy/test_query_formats.py
+++ b/tests/unit_tests/test_sqlalchemy/test_query_formats.py
@@ -1,0 +1,204 @@
+"""Per-query query_formats threading and SQLAlchemy metadata internal formats (issue #920)."""
+
+from typing import Any
+from unittest.mock import Mock, patch
+
+import pytest
+from sqlalchemy import create_engine, text
+from sqlalchemy.engine import Engine
+
+from clickhouse_connect.cc_sqlalchemy.dialect import ClickHouseDialect
+from clickhouse_connect.cc_sqlalchemy.inspector import with_internal_query_formats
+from clickhouse_connect.datatypes.format import clear_all_formats, set_default_formats
+from clickhouse_connect.dbapi.cursor import Cursor
+from clickhouse_connect.driver.client import _INTERNAL_QUERY_FORMATS
+
+
+class _StubQueryResult:
+    result_set: list[Any] = []
+    column_names: list[str] = []
+    column_types: list[Any] = []
+    summary: dict[str, Any] = {}
+
+
+class _StubInsertResult:
+    written_rows = 0
+    summary: dict[str, Any] = {}
+
+
+class _FakeContext:
+    def __init__(self, execution_options, invoked_statement=None):
+        self.execution_options = execution_options
+        self.invoked_statement = invoked_statement
+
+
+def _mock_client():
+    client = Mock()
+    client.query.return_value = _StubQueryResult()
+    client.insert.return_value = _StubInsertResult()
+    return client
+
+
+def _query_formats(client):
+    return [call.kwargs.get("query_formats") for call in client.query.call_args_list]
+
+
+def test_cursor_execute_forwards_query_formats():
+    client = _mock_client()
+    Cursor(client).execute("SELECT 13", query_formats={"String": "string"})
+    # Main query plus the LIMIT 0 introspection re-query both carry the formats.
+    assert _query_formats(client) == [{"String": "string"}, {"String": "string"}]
+
+
+def test_cursor_executemany_forwards_query_formats():
+    client = _mock_client()
+    Cursor(client).executemany("SELECT %(v)s", [{"v": 13}, {"v": 79}], query_formats={"String": "string"})
+    assert _query_formats(client) == [{"String": "string"}, {"String": "string"}]
+
+
+def test_dialect_do_execute_forwards_query_formats():
+    client = _mock_client()
+    context = _FakeContext({"query_formats": {"String": "string"}})
+    ClickHouseDialect().do_execute(Cursor(client), "SELECT 13", None, context=context)
+    assert _query_formats(client)[0] == {"String": "string"}
+
+
+def test_dialect_do_executemany_forwards_query_formats():
+    client = _mock_client()
+    context = _FakeContext({"query_formats": {"String": "string"}})
+    ClickHouseDialect().do_executemany(Cursor(client), "SELECT %(v)s", [{"v": 13}], context=context)
+    assert _query_formats(client)[0] == {"String": "string"}
+
+
+def test_dialect_do_execute_no_params_forwards_query_formats():
+    client = _mock_client()
+    context = _FakeContext({"query_formats": {"String": "string"}})
+    ClickHouseDialect().do_execute_no_params(Cursor(client), "SELECT 13", context=context)
+    assert _query_formats(client)[0] == {"String": "string"}
+
+
+def test_dialect_do_execute_context_none_forwards_none_formats():
+    client = _mock_client()
+    ClickHouseDialect().do_execute(Cursor(client), "SELECT 13", None, context=None)
+    assert _query_formats(client)[0] is None
+
+
+def test_dialect_do_execute_missing_query_formats_key_forwards_none():
+    client = _mock_client()
+    context = _FakeContext({})
+    ClickHouseDialect().do_execute(Cursor(client), "SELECT 13", None, context=context)
+    assert _query_formats(client)[0] is None
+
+
+def test_with_internal_query_formats_sets_execution_option():
+    clause = with_internal_query_formats(text("SHOW TABLES"))
+    assert clause.get_execution_options()["query_formats"] == dict(_INTERNAL_QUERY_FORMATS)
+
+
+class _StubColType:
+    name = "String"
+
+
+class _NamedRowsResult:
+    def __init__(self, rows: list[list[Any]], names: list[str]):
+        self.result_set = rows
+        self.column_names = names
+        self.column_types = [_StubColType()] * len(names)
+        self.summary: dict[str, Any] = {}
+
+
+@pytest.fixture(name="mock_engine")
+def mock_engine_fixture():
+    client = Mock()
+    client.query.return_value = _NamedRowsResult([["default"]], ["name"])
+    with patch("clickhouse_connect.dbapi.connection.create_client", return_value=client):
+        engine: Engine = create_engine("clickhousedb://user_1:pwd@localhost:8123/default")
+        try:
+            yield engine, client
+        finally:
+            engine.dispose()
+
+
+def test_public_statement_query_formats_reach_client(mock_engine):
+    engine, client = mock_engine
+    with engine.connect() as conn:
+        conn.exec_driver_sql("SELECT 1")
+        client.query.reset_mock()
+        client.query.return_value = _NamedRowsResult([["x"]], ["name"])
+        stmt = text("SHOW TABLES").execution_options(query_formats={"String": "string"})
+        conn.execute(stmt)
+    assert _query_formats(client) == [{"String": "string"}]
+
+
+def test_get_table_names_uses_internal_query_formats(mock_engine):
+    engine, client = mock_engine
+    with engine.connect() as conn:
+        conn.exec_driver_sql("SELECT 1")
+        client.query.reset_mock()
+        client.query.return_value = _NamedRowsResult([["my_table"]], ["name"])
+        names = conn.dialect.get_table_names(conn)
+    assert names == ["my_table"]
+    assert all(fmt == dict(_INTERNAL_QUERY_FORMATS) for fmt in _query_formats(client))
+
+
+def test_get_schema_names_uses_internal_query_formats(mock_engine):
+    engine, client = mock_engine
+    with engine.connect() as conn:
+        conn.exec_driver_sql("SELECT 1")
+        client.query.reset_mock()
+        client.query.return_value = _NamedRowsResult([["system"], ["default"]], ["name"])
+        names = conn.dialect.get_schema_names(conn)
+    assert names == ["system", "default"]
+    assert all(fmt == dict(_INTERNAL_QUERY_FORMATS) for fmt in _query_formats(client))
+
+
+def test_get_columns_uses_internal_query_formats(mock_engine):
+    engine, client = mock_engine
+
+    def _side_effect(operation, *args, **kwargs):
+        op = str(operation)
+        if "system.tables" in op:
+            return _NamedRowsResult([["MergeTree", "MergeTree ORDER BY k", ""]], ["engine", "engine_full", "comment"])
+        if op.upper().startswith("DESCRIBE") or "DESCRIBE TABLE" in op.upper():
+            return _NamedRowsResult(
+                [["k", "UInt32", "", "", "", "", ""], ["s", "String", "", "", "", "", ""]],
+                ["name", "type", "default_type", "default_expression", "comment", "codec_expression", "ttl_expression"],
+            )
+        if "currentDatabase" in op:
+            return _NamedRowsResult([["default"]], ["name"])
+        return _NamedRowsResult([[1]], ["result"])
+
+    with engine.connect() as conn:
+        conn.exec_driver_sql("SELECT 1")
+        client.query.reset_mock()
+        client.query.side_effect = _side_effect
+        cols = conn.dialect.get_columns(conn, "scratch_bytes_fmt")
+    assert [c["name"] for c in cols] == ["k", "s"]
+    formats = _query_formats(client)
+    assert formats
+    assert all(fmt == dict(_INTERNAL_QUERY_FORMATS) for fmt in formats)
+
+
+def test_user_query_without_formats_stays_unaffected(mock_engine):
+    """Ordinary user SELECTs must not receive the internal metadata format override."""
+    engine, client = mock_engine
+    with engine.connect() as conn:
+        conn.exec_driver_sql("SELECT 1")
+        client.query.reset_mock()
+        client.query.return_value = _NamedRowsResult([[b"hello"]], ["s"])
+        conn.execute(text("SELECT s FROM t"))
+    assert _query_formats(client) == [None]
+
+
+def test_internal_formats_constant_matches_core_driver():
+    assert _INTERNAL_QUERY_FORMATS == {"String": "string"}
+
+
+def test_set_default_formats_bytes_does_not_alter_internal_constant():
+    try:
+        set_default_formats("String", "bytes")
+        assert dict(_INTERNAL_QUERY_FORMATS) == {"String": "string"}
+        clause = with_internal_query_formats(text("SELECT 1"))
+        assert clause.get_execution_options()["query_formats"] == {"String": "string"}
+    finally:
+        clear_all_formats()


### PR DESCRIPTION
## Summary

Fixes #920.

`set_default_formats("String", "bytes")` (or `set_read_format("String", "bytes")`) is a global read format that makes `String` columns decode as `bytes`. The core driver already protects orchestration queries via `_INTERNAL_QUERY_FORMATS = {"String": "string"}`, but the SQLAlchemy reflection path (`cc_sqlalchemy` inspector + dialect metadata methods) issued ordinary DB-API queries and was unprotected.

Under the global bytes format this caused:

1. **Loud** — `Inspector.get_columns()` / `Table(..., autoload_with=...)` raised `TypeError: a bytes-like object is required, not 'str'` on `row.type.replace("\n", "")`.
2. **Silent** — `get_table_names()` returned `[b'my_table']` instead of `['my_table']`, and engine/comment comparisons like `row.engine == "Dictionary"` failed.

### Changes

- Thread per-query `query_formats` through `dbapi.Cursor.execute` / `executemany` and the SQLAlchemy dialect `do_execute*` methods, mirroring the existing `settings` / `execution_options` plumbing.
- Apply the same `_INTERNAL_QUERY_FORMATS` override to all SQLAlchemy metadata queries (`DESCRIBE TABLE`, `system.tables`, `SHOW TABLES` / `SHOW DATABASES`, dictionary create SQL, etc.) via `with_internal_query_formats(...)`.
- User SELECTs are unchanged and still honor the global bytes format.

## Checklist
- [x] Unit and integration tests covering the common scenarios were added
- [x] A human-readable description of the changes was provided to include in CHANGELOG
- [ ] For significant changes, documentation in https://github.com/ClickHouse/clickhouse-docs was updated with further explanations or tutorials

## AI disclosure

This change was drafted with AI assistance and reviewed by the author before submission.


### AI/LLM disclosure
- AI coding tools (including Grok and/or Codex agent-assisted editing) were used to help draft or modify code and this PR description.
- I reviewed the complete change, understand the reasoning, and ran the reported local tests before submitting.
- This submission is original work of authorship under the project CLA / contributor terms; AI output was not pasted unreviewed.