### PR TITLE
Add publish workflow for clickhouse-connect-core wheels

### DIFF
--- a/.github/workflows/publish_core.yml
+++ b/.github/workflows/publish_core.yml
@@ -1,0 +1,256 @@
+name: 'Build and Publish clickhouse-connect-core'
+
+# Builds the clickhouse-connect-core wheels (the compiled _ch_core Rust codec)
+# with maturin. The ch-core-rs crate is fetched from its git tag pin in
+# rust/ch-core-py/Cargo.toml, so the ch-core-rs repository must be reachable
+# from CI.
+
+on:
+  workflow_dispatch:
+    inputs:
+      publish_type:
+        description: Publish Type
+        type: choice
+        default: test
+        options:
+          - test
+          - release
+          - build
+
+env:
+  MATURIN_MANIFEST: rust/ch-core-py/Cargo.toml
+
+jobs:
+  build_linux_wheels:
+    name: Build ${{ matrix.libc }} wheels (${{ matrix.arch }})
+    runs-on: ${{ matrix.runner }}
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - { runner: ubuntu-latest, arch: x86_64, libc: manylinux, manylinux: auto }
+          - { runner: ubuntu-latest, arch: x86_64, libc: musllinux, manylinux: musllinux_1_2 }
+          - { runner: ubuntu-24.04-arm, arch: aarch64, libc: manylinux, manylinux: auto }
+          - { runner: ubuntu-24.04-arm, arch: aarch64, libc: musllinux, manylinux: musllinux_1_2 }
+    steps:
+      - uses: actions/checkout@v6
+      - name: Build wheels
+        uses: PyO3/maturin-action@v1
+        with:
+          manylinux: ${{ matrix.manylinux }}
+          args: --release -m ${{ env.MATURIN_MANIFEST }} -o wheelhouse --find-interpreter
+      - uses: actions/upload-artifact@v7
+        with:
+          name: core-${{ matrix.libc }}-${{ matrix.arch }}
+          path: wheelhouse/*.whl
+
+  build_macos_wheels:
+    name: Build macos universal2 wheels (py${{ matrix.python-version }})
+    runs-on: macos-14
+    strategy:
+      fail-fast: false
+      matrix:
+        python-version: ['3.10', '3.11', '3.12', '3.13', '3.14']
+    steps:
+      - uses: actions/checkout@v6
+      - name: Set up Python ${{ matrix.python-version }}
+        uses: actions/setup-python@v6
+        with:
+          python-version: ${{ matrix.python-version }}
+      - name: Build wheels
+        uses: PyO3/maturin-action@v1
+        with:
+          target: universal2-apple-darwin
+          args: --release -m ${{ env.MATURIN_MANIFEST }} -o wheelhouse -i python${{ matrix.python-version }}
+      - uses: actions/upload-artifact@v7
+        with:
+          name: core-macos-${{ matrix.python-version }}
+          path: wheelhouse/*.whl
+
+  build_windows_wheels:
+    name: Build windows x64 wheels (py${{ matrix.python-version }})
+    runs-on: windows-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        python-version: ['3.10', '3.11', '3.12', '3.13', '3.14']
+    steps:
+      - uses: actions/checkout@v6
+      - name: Set up Python ${{ matrix.python-version }}
+        uses: actions/setup-python@v6
+        with:
+          python-version: ${{ matrix.python-version }}
+      - name: Build wheels
+        uses: PyO3/maturin-action@v1
+        with:
+          args: --release -m ${{ env.MATURIN_MANIFEST }} -o wheelhouse -i python
+      - uses: actions/upload-artifact@v7
+        with:
+          name: core-windows-${{ matrix.python-version }}
+          path: wheelhouse/*.whl
+
+  build_windows_arm64_wheels:
+    name: Build windows arm64 wheels (py${{ matrix.python-version }})
+    runs-on: windows-11-arm
+    strategy:
+      fail-fast: false
+      matrix:
+        # CPython ships native windows ARM64 builds from 3.11. The 3.10 wheel
+        # is cross-compiled in build_windows_arm64_310_wheel below.
+        python-version: ['3.11', '3.12', '3.13', '3.14']
+    steps:
+      - uses: actions/checkout@v6
+      - name: Set up Python ${{ matrix.python-version }}
+        uses: actions/setup-python@v6
+        with:
+          python-version: ${{ matrix.python-version }}
+          architecture: arm64
+      - name: Build wheels
+        uses: PyO3/maturin-action@v1
+        with:
+          args: --release -m ${{ env.MATURIN_MANIFEST }} -o wheelhouse -i python
+      - uses: actions/upload-artifact@v7
+        with:
+          name: core-windows-arm64-${{ matrix.python-version }}
+          path: wheelhouse/*.whl
+
+  build_windows_arm64_310_wheel:
+    name: Build windows arm64 wheel (py3.10 cross)
+    runs-on: windows-latest
+    env:
+      # No native ARM64 CPython 3.10 exists, so cross-compile from x64 with
+      # the import library synthesized by pyo3's generate-import-lib feature
+      PYO3_CROSS_PYTHON_VERSION: '3.10'
+    steps:
+      - uses: actions/checkout@v6
+      - name: Build wheels
+        uses: PyO3/maturin-action@v1
+        with:
+          target: aarch64-pc-windows-msvc
+          args: --release -m ${{ env.MATURIN_MANIFEST }} -o wheelhouse
+      - uses: actions/upload-artifact@v7
+        with:
+          name: core-windows-arm64-3.10
+          path: wheelhouse/*.whl
+
+  build_sdist:
+    name: Build sdist
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+      - name: Build sdist
+        uses: PyO3/maturin-action@v1
+        with:
+          command: sdist
+          args: -m ${{ env.MATURIN_MANIFEST }} -o wheelhouse
+      - uses: actions/upload-artifact@v7
+        with:
+          name: core-sdist
+          path: wheelhouse/*.tar.gz
+
+  smoke_test:
+    name: Wheel smoke test against ClickHouse
+    runs-on: ubuntu-latest
+    needs:
+      - build_linux_wheels
+    steps:
+      - uses: actions/checkout@v6
+      - name: Start ClickHouse (latest) in Docker
+        env:
+          CLICKHOUSE_CONNECT_TEST_CH_VERSION: latest
+          COMPOSE_PROJECT_NAME: clickhouse-connect-core-smoke
+        run: docker compose -f docker-compose.yml up -d --wait clickhouse
+      - name: Set up Python 3.12
+        uses: actions/setup-python@v6
+        with:
+          python-version: '3.12'
+      - name: Retrieve wheels
+        uses: actions/download-artifact@v8
+        with:
+          name: core-manylinux-x86_64
+          path: wheelhouse
+      - name: Install driver and core wheel
+        run: |
+          python -m pip install --upgrade pip
+          pip install .
+          pip install wheelhouse/clickhouse_connect_core-*-cp312-*.whl
+      - name: Query and insert round trip on rust_strict
+        run: |
+          python - <<'EOF'
+          import _ch_core
+          import clickhouse_connect
+
+          print("_ch_core", _ch_core.__version__, "binding API", _ch_core.BINDING_API_VERSION)
+          client = clickhouse_connect.get_client(host="localhost", native_codec="rust_strict")
+          assert client.query("SELECT number FROM numbers(10)").result_rows[-1][0] == 9
+          client.command("CREATE TABLE core_smoke (id UInt32, val String) ENGINE MergeTree ORDER BY id")
+          client.insert("core_smoke", [[1, "a"], [2, "b"]], column_names=["id", "val"])
+          assert client.query("SELECT val FROM core_smoke ORDER BY id").result_columns[0] == ["a", "b"]
+          print("smoke ok")
+          EOF
+      - name: Stop ClickHouse
+        if: ${{ always() && hashFiles('docker-compose.yml') != '' }}
+        env:
+          COMPOSE_PROJECT_NAME: clickhouse-connect-core-smoke
+        run: docker compose -f docker-compose.yml down --volumes --remove-orphans
+
+  publish_test:
+    needs:
+      - build_linux_wheels
+      - build_macos_wheels
+      - build_windows_wheels
+      - build_windows_arm64_wheels
+      - build_windows_arm64_310_wheel
+      - build_sdist
+      - smoke_test
+    name: Publish to TestPyPI
+    runs-on: ubuntu-latest
+    if: ${{ inputs.publish_type == 'test' }}
+    environment:
+      name: testpypi
+      url: https://test.pypi.org/p/clickhouse-connect-core
+    permissions:
+      id-token: write
+    steps:
+      - name: Retrieve artifacts
+        uses: actions/download-artifact@v8
+        with:
+          pattern: core-*
+          merge-multiple: true
+          path: dist
+      - name: List artifacts
+        run: ls -R dist
+      - name: Publish (Test)
+        uses: pypa/gh-action-pypi-publish@release/v1
+        with:
+          repository-url: https://test.pypi.org/legacy/
+          skip-existing: true
+
+  publish_release:
+    needs:
+      - build_linux_wheels
+      - build_macos_wheels
+      - build_windows_wheels
+      - build_windows_arm64_wheels
+      - build_windows_arm64_310_wheel
+      - build_sdist
+      - smoke_test
+    name: Publish to PyPI
+    runs-on: ubuntu-latest
+    if: ${{ inputs.publish_type == 'release' }}
+    environment:
+      name: pypi
+      url: https://pypi.org/p/clickhouse-connect-core
+    permissions:
+      id-token: write
+    steps:
+      - name: Retrieve artifacts
+        uses: actions/download-artifact@v8
+        with:
+          pattern: core-*
+          merge-multiple: true
+          path: dist
+      - name: List artifacts
+        run: ls -R dist
+      - name: Publish (Release)
+        uses: pypa/gh-action-pypi-publish@release/v1


### PR DESCRIPTION
Adds the workflow_dispatch workflow that builds and publishes the clickhouse-connect-core wheels with maturin.