### PR TITLE
Joe/954 170 breaks on sqlalchemy 210b3

### DIFF
--- a/.github/workflows/on_push.yml
+++ b/.github/workflows/on_push.yml
@@ -282,7 +282,7 @@ jobs:
           CLICKHOUSE_CONNECT_TEST_TLS: 1
           CLICKHOUSE_CONNECT_TEST_DOCKER: 'False'
           SQLALCHEMY_SILENCE_UBER_WARNING: 1
-        run: pytest -n 4 tests/integration_tests/test_sqlalchemy tests/unit_tests/test_sqlalchemy/test_ch_select.py tests/unit_tests/test_sqlalchemy/test_materialized_cte.py
+        run: pytest -n 4 tests/integration_tests/test_sqlalchemy tests/unit_tests/test_sqlalchemy
       - name: Stop ClickHouse
         if: ${{ always() && hashFiles('docker-compose.yml') != '' }}
         env:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 ## UNRELEASED
 
+### Bug Fixes
+
+- SQLAlchemy 2.1 compatibility. Identifier quoting forwarded the deprecated `force` argument to `IdentifierPreparer.quote`, which SQLAlchemy 2.1 removed, so any dialect use raised `TypeError` on 2.1.0b3. The parent call now passes only the identifier. The optional `force` parameter stays on the ClickHouse preparer for direct callers. Closes [#954](https://github.com/ClickHouse/clickhouse-connect/issues/954).
+- SQLAlchemy 1.4 compatibility. Column DDL using the `clickhouse_materialized`, `clickhouse_alias`, or `clickhouse_ttl` options raised `AttributeError` on SQLAlchemy 1.4 because it called a rendering helper that only exists in 2.0. The helper is now implemented locally. This appears to have been broken since 1.1.0.
+
 ## 1.7.0, 2026-08-11
 
 ### Improvements

--- a/clickhouse_connect/cc_sqlalchemy/sql/ddlcompiler.py
+++ b/clickhouse_connect/cc_sqlalchemy/sql/ddlcompiler.py
@@ -7,6 +7,7 @@ from sqlalchemy import Column
 from sqlalchemy.exc import CompileError
 from sqlalchemy.sql import sqltypes
 from sqlalchemy.sql.compiler import DDLCompiler
+from sqlalchemy.sql.visitors import Visitable
 
 from clickhouse_connect.cc_sqlalchemy.datatypes.base import ChSqlaType
 from clickhouse_connect.cc_sqlalchemy.datatypes.sqltypes import Nullable
@@ -209,3 +210,8 @@ class ChDDLCompiler(DDLCompiler):
         if ttl is not None:
             text += f" TTL {self.render_default_string(ttl)}"
         return text
+
+    def render_default_string(self, default: Visitable | str) -> str:
+        if isinstance(default, str):
+            return self.sql_compiler.render_literal_value(default, sqltypes.STRINGTYPE)
+        return self.sql_compiler.process(default, literal_binds=True)

--- a/clickhouse_connect/cc_sqlalchemy/sql/preparer.py
+++ b/clickhouse_connect/cc_sqlalchemy/sql/preparer.py
@@ -26,7 +26,7 @@ class ChIdentifierPreparer(IdentifierPreparer):
         return identifier
 
     def quote(self, ident: str, force: Any = None) -> str:
-        return self._escape_percents(super().quote(ident, force))
+        return self._escape_percents(super().quote(ident))
 
     def _quote_raw_identifier(self, value: str) -> str:
         """Quote raw identifier content even when it already looks quoted."""

--- a/tests/unit_tests/test_sqlalchemy/test_preparer.py
+++ b/tests/unit_tests/test_sqlalchemy/test_preparer.py
@@ -1,0 +1,24 @@
+from unittest import mock
+
+from sqlalchemy.sql.compiler import IdentifierPreparer
+
+from clickhouse_connect import dbapi
+from clickhouse_connect.cc_sqlalchemy.dialect import ClickHouseDialect
+
+
+def _make_preparer():
+    return ClickHouseDialect(dbapi=dbapi).identifier_preparer
+
+
+def test_quote_passes_only_ident_to_parent():
+    preparer = _make_preparer()
+    with mock.patch.object(IdentifierPreparer, "quote", return_value="`user_1`") as parent_quote:
+        assert preparer.quote("user_1") == "`user_1`"
+    parent_quote.assert_called_once_with("user_1")
+
+
+def test_quote_still_accepts_force_from_direct_callers():
+    preparer = _make_preparer()
+    assert preparer.quote("user_1", True) == "`user_1`"
+    assert preparer.quote("user_2", force=False) == "`user_2`"
+    assert preparer.quote("user_3") == "`user_3`"


### PR DESCRIPTION
## Summary
SQLAlchemy 2.1 removed the deprecated `force` argument to `IdentifierPreparer.quote`, so 1.7.0 raises `TypeError` on 2.1.0b3. The parent call now passes only the identifier. Since our declared range is `<3.0`, stable 2.1 would have broken all fresh installs.

Also fixes a latent SQLAlchemy 1.4 break found while verifying: column DDL with `clickhouse_materialized`, `clickhouse_alias`, or `clickhouse_ttl` used a 2.0-only helper and has raised `AttributeError` since 1.1.0. The 1.x compat CI job ran only two unit test files, which is how it slipped through. It now runs the full unit suite.

Closes #954

## Checklist
Delete items not relevant to your PR:
- [X] Unit and integration tests covering the common scenarios were added
- [X] A human-readable description of the changes was provided to include in CHANGELOG