### PR TITLE
change pkg install command in nightly workflow

### DIFF
--- a/.github/workflows/clickhouse_ci.yml
+++ b/.github/workflows/clickhouse_ci.yml
@@ -26,7 +26,7 @@ jobs:
       - name: Build cython extensions
         run: python setup.py build_ext --inplace
       - name: "Add distribution info"  #  This lets SQLAlchemy find entry points
-        run: python setup.py develop
+        run: pip install -e . --no-deps
 
       - name: run ClickHouse Cloud tests
         env:


### PR DESCRIPTION
## Summary
- The `backports.zstd` migration updated on-push CI but missed the nightly workflow
- Nightly still used deprecated `python setup.py develop`. This PR fixes it