### PR TITLE
Test docs drift check

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## UNRELEASED
 
+### Improvements
+
+- Added `Client.server_timezone`, which returns the timezone name reported by the connected ClickHouse server. The property is also available on `AsyncClient`.
+
 ## 1.7.1, 2026-08-12
 
 ### Bug Fixes

--- a/clickhouse_connect/driver/client.py
+++ b/clickhouse_connect/driver/client.py
@@ -169,6 +169,11 @@ class Client(ABC):
         else:
             self._apply_server_tz = value == "server"
 
+    @property
+    def server_timezone(self) -> str:
+        """Return the timezone name reported by the connected ClickHouse server."""
+        return str(self.server_tz)
+
     def __init__(
         self,
         database: str | None,

--- a/tests/integration_tests/test_client.py
+++ b/tests/integration_tests/test_client.py
@@ -146,6 +146,10 @@ def test_initial_settings_override_generated_defaults(client_factory):
     assert default_client.get_client_setting("date_time_input_format") == "best_effort"
 
 
+def test_server_timezone(param_client, call):
+    assert param_client.server_timezone == call(param_client.command, "SELECT timezone()")
+
+
 def test_client_init_unaffected_by_global_read_formats(client_factory, call):
     set_default_formats("String", "bytes")
     client = client_factory()


### PR DESCRIPTION
## Summary

- add an intentionally undocumented public `Client.server_timezone` property
- cover it against the live server timezone for both sync and async clients
- exercise the newly merged docs drift workflow

This is a dummy PR for validating the docs drift automation and is not intended to merge. The expected result is a `needs-docs` label and a sticky comment pointing to the missing driver API documentation. No `docs/` or `README.md` file is changed on purpose.

## Validation

- `ruff check clickhouse_connect/driver/client.py tests/integration_tests/test_client.py`
- `ruff format --check clickhouse_connect/driver/client.py tests/integration_tests/test_client.py`
- `mypy`
- `pytest -q -n0 tests/integration_tests/test_client.py::test_server_timezone`