### PR TITLE
use centralized docs drift checker

### DIFF
--- a/.github/workflows/docs_drift_check.yml
+++ b/.github/workflows/docs_drift_check.yml
@@ -1,10 +1,11 @@
 name: 'Docs Drift Check'
 
-# Advisory docs-drift check on pull requests. The shared workflow has Claude
-# compare this PR's code changes against docs/ and README.md using the rubric
-# in .claude/agents/docs-drift-reviewer.md, then applies or removes the
-# `needs-docs` label and keeps one sticky comment up to date. Comment and
-# label only: the check never blocks a merge.
+# Advisory docs-drift check on pull requests. The shared workflow dispatches
+# the PR to the central AI automation repo using the Workflow Authentication
+# GitHub App. The central worker compares the diff against docs/ and README.md
+# using .claude/agents/docs-drift-reviewer.md, then applies or removes the
+# `needs-docs` label and keeps one sticky comment up to date. Model credentials
+# stay in the central repo.
 #
 # Not to be confused with docs_sync.yml, which ships docs/ to the aggregator
 # repo, or docs_verify.yml, which validates the Mintlify build. This check
@@ -13,8 +14,9 @@ name: 'Docs Drift Check'
 # Every push to the PR re-runs the check, so fixing the docs in a later commit
 # clears the label and marks the comment resolved.
 #
-# Fork PRs are skipped automatically because they do not receive secrets. A
-# maintainer can run one manually via workflow_dispatch with the PR number.
+# Fork PRs are skipped automatically. A maintainer can run one manually via
+# workflow_dispatch with the PR number; the central worker reads the diff but
+# checks out only the trusted base revision.
 
 on:
   pull_request:
@@ -36,9 +38,7 @@ on:
         type: string
 
 permissions:
-  contents: read
-  pull-requests: write
-  issues: write
+  pull-requests: read
 
 jobs:
   docs-drift:
@@ -47,4 +47,6 @@ jobs:
     # reads it from the event automatically, so pr_number can be empty there.
     with:
       pr_number: ${{ github.event.inputs.pr_number }}
-    secrets: inherit
+    secrets:
+      WORKFLOW_AUTH_PUBLIC_APP_ID: ${{ secrets.WORKFLOW_AUTH_PUBLIC_APP_ID }}
+      WORKFLOW_AUTH_PUBLIC_PRIVATE_KEY: ${{ secrets.WORKFLOW_AUTH_PUBLIC_PRIVATE_KEY }}


### PR DESCRIPTION
## Summary

- migrate the docs drift caller from direct Claude authentication to the central relay
- pass the existing Workflow Authentication GitHub App credentials explicitly
- reduce the caller `GITHUB_TOKEN` to pull-request read access

No Anthropic credential is required in `clickhouse-connect`. The central worker owns model authentication and writes the result back with a short-lived App token.

Depends on:

1. ClickHouse/integrations-ai-playground#405
2. ClickHouse/integrations-shared-workflows#8

Merge those PRs in that order before this one. After all three merge, refresh test PR #960 from `main` to exercise the complete label/comment path.