### PR TITLE
fix test with shared state

### DIFF
--- a/tests/integration_tests/test_params.py
+++ b/tests/integration_tests/test_params.py
@@ -86,10 +86,8 @@ def test_params(param_client: Client, call, table_context: Callable):
     assert tp_params == result[0]
 
     num_params = {"p_0": 2, "p_1": 100523.55}
-    result = call(
-        param_client.query, "SELECT count() FROM system.tables WHERE total_rows > %(p_0)d and total_rows < %(p_1)f", parameters=num_params
-    )
-    assert result.first_row[0] > 0
+    result = call(param_client.query, "SELECT %(p_0)d < %(p_1)f", parameters=num_params)
+    assert result.first_row[0] == 1
 
 
 def test_datetime_64_params(param_client: Client, call):


### PR DESCRIPTION
Intermittently fails becuase it depends on a table's state that may or may not be available when run in parallel. Changing the assertion to simply test `%d` and `%f` binding directly.