### PR TITLE
update minimum supported version of alembic

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## UNRELEASED
 
+### Compatibility
+
+- SQLAlchemy: the `alembic` extra now requires `alembic>=1.18`. Earlier versions satisfied the package metadata but failed when importing the ClickHouse Alembic integration because the priority-dispatch API it uses was added in Alembic 1.18. See [#983](https://github.com/ClickHouse/clickhouse-connect/pull/983).
+
 ### Bug Fixes
 
 - SQLAlchemy column DDL now compiles `TypeDecorator` and `with_variant()` types through the active ClickHouse dialect. Dialect-aware types such as a decorator that selects `DateTime64(6, 'UTC')` no longer fall back to generic `DATETIME` in `CREATE TABLE` and related column DDL. Closes [#984](https://github.com/ClickHouse/clickhouse-connect/issues/984).

--- a/setup.py
+++ b/setup.py
@@ -72,7 +72,7 @@ def run_setup(try_c: bool = True):
         ],
         extras_require={
             "sqlalchemy": ["sqlalchemy>=1.4.40,<3.0"],
-            "alembic": ["sqlalchemy>=1.4.40,<3.0", "alembic>=1.16"],
+            "alembic": ["sqlalchemy>=1.4.40,<3.0", "alembic>=1.18"],
             "numpy": ["numpy"],
             "pandas": ["pandas>=2,<4"],
             "polars": ["polars>=1.0"],

--- a/tests/test_requirements.txt
+++ b/tests/test_requirements.txt
@@ -3,7 +3,7 @@ setuptools
 certifi
 aiohttp>=3.9.0
 sqlalchemy>=2.0,<3.0
-alembic>=1.16
+alembic>=1.18
 cython==3.2.5
 pyarrow
 pytest
@@ -25,4 +25,3 @@ pyjwt[crypto]==2.10.1
 pre-commit==4.3.0
 ruff==0.15.8
 mypy==2.1.0
- 


### PR DESCRIPTION
## Summary
<!-- A short description of the changes with a link to an open issue. -->

When trying to use `clickhouse-connect` in our project which was using alembic==1.17.2, we were seeing the following error:

> ImportError: cannot import name 'DispatchPriority' from 'alembic.util'

which was originating from:

https://github.com/ClickHouse/clickhouse-connect/blob/928365467f6b1224116a1db3a35a16243e1632d7/clickhouse_connect/cc_sqlalchemy/alembic/adapter.py#L9

Per the docs for [`alembic.util.DispatchPriority`](https://alembic.sqlalchemy.org/en/latest/api/plugins.html#alembic.util.langhelpers.DispatchPriority):

> Added in version 1.18.0.

As such, updated the minimum alembic version for this library to be 1.18.0 so to better inform consumers they must be on alembic >= 1.18.0 to utilize `clickhouse-connect[alembic]`.

I was uncertain on what/if should add something to changelog for this.

## Checklist
Delete items not relevant to your PR:
- [ ] A human-readable description of the changes was provided to include in CHANGELOG
- [ ] For significant changes, documentation in https://github.com/ClickHouse/clickhouse-docs was updated with further explanations or tutorials
