### PR TITLE
docs: add missing colons to :param directives in docstrings

### DIFF
--- a/clickhouse_connect/driver/__init__.py
+++ b/clickhouse_connect/driver/__init__.py
@@ -225,7 +225,7 @@ def create_client(
     :param generic_args: Used internally to parse DBAPI connection strings into keyword arguments and ClickHouse settings.
       It is not recommended to use this parameter externally.
 
-    :param kwargs -- Recognized keyword arguments (used by the HTTP client), see below
+    :param kwargs: Recognized keyword arguments (used by the HTTP client), see below
 
     :param compress: Enable compression for ClickHouse HTTP inserts and query results.  True will select the preferred
       compression method (lz4).  A str of 'lz4', 'zstd', 'br', or 'gzip' can be used to use a specific compression type
@@ -244,24 +244,24 @@ def create_client(
       applicable intermediate certificates
     :param client_cert_key: File path to the private key for the Client Certificate.  Required if the private key
       is not included the Client Certificate key file
-    :param session_id ClickHouse session id.  If not specified and the common setting 'autogenerate_session_id'
+    :param session_id: ClickHouse session id.  If not specified and the common setting 'autogenerate_session_id'
       is True, the client will generate a UUID1 session id
-    :param pool_mgr Optional urllib3 PoolManager for this client.  Useful for creating separate connection
+    :param pool_mgr: Optional urllib3 PoolManager for this client.  Useful for creating separate connection
       pools for multiple client endpoints for applications with many clients
-    :param http_proxy  http proxy address.  Equivalent to setting the HTTP_PROXY environment variable
-    :param https_proxy https proxy address.  Equivalent to setting the HTTPS_PROXY environment variable
-    :param server_host_name  This is the server host name that will be checked against a TLS certificate for
+    :param http_proxy: http proxy address.  Equivalent to setting the HTTP_PROXY environment variable
+    :param https_proxy: https proxy address.  Equivalent to setting the HTTPS_PROXY environment variable
+    :param server_host_name: This is the server host name that will be checked against a TLS certificate for
       validity.  This option can be used if using an ssh_tunnel or other indirect means to an ClickHouse server
       where the `host` argument refers to the tunnel or proxy and not the actual ClickHouse server
-    :param tz_source Controls how the client determines the fallback timezone for DateTime columns without an
+    :param tz_source: Controls how the client determines the fallback timezone for DateTime columns without an
       explicit timezone. "auto" (default) auto-detects based on DST safety of server timezone. "server" always
       uses the server timezone. "local" always uses the local timezone.
-    :param tz_mode Controls timezone-aware behavior for UTC DateTime columns. "naive_utc" (default) returns
+    :param tz_mode: Controls timezone-aware behavior for UTC DateTime columns. "naive_utc" (default) returns
       naive UTC timestamps. "aware" forces timezone-aware UTC datetimes. "schema" returns datetimes that
       match the server's column definition which means timezone-aware when the column defines a timezone and naive
       for bare DateTime columns.
-    :param autogenerate_session_id  If set, this will override the 'autogenerate_session_id' common setting.
-    :param form_encode_query_params  If True, always send query parameters as form-encoded data in the request body
+    :param autogenerate_session_id: If set, this will override the 'autogenerate_session_id' common setting.
+    :param form_encode_query_params: If True, always send query parameters as form-encoded data in the request body
       instead of as URL parameters. When False, large parameter payloads are still automatically sent as form data to
       avoid exceeding URL length limits, except for queries using binary parameter binds, which are only form-encoded
       when this is True. Only available for query operations (not inserts). Default: False
@@ -381,7 +381,7 @@ async def create_async_client(
     :param connector_limit: Maximum number of allowable connections to the server
     :param connector_limit_per_host: Maximum number of connections per host
     :param keepalive_timeout: Time limit on idle keepalive connections
-    :param kwargs -- Recognized keyword arguments (used by the async HTTP client), see below
+    :param kwargs: Recognized keyword arguments (used by the async HTTP client), see below
 
     :param compress: Enable compression for ClickHouse HTTP inserts and query results.  True will select the preferred
       compression method (lz4).  A str of 'lz4', 'zstd', 'br', or 'gzip' can be used to use a specific compression type
@@ -399,22 +399,22 @@ async def create_async_client(
       applicable intermediate certificates
     :param client_cert_key: File path to the private key for the Client Certificate.  Required if the private key
       is not included the Client Certificate key file
-    :param session_id ClickHouse session id.  If not specified and the common setting 'autogenerate_session_id'
+    :param session_id: ClickHouse session id.  If not specified and the common setting 'autogenerate_session_id'
       is True, the client will generate a UUID1 session id
-    :param http_proxy  http proxy address.  Equivalent to setting the HTTP_PROXY environment variable
-    :param https_proxy https proxy address.  Equivalent to setting the HTTPS_PROXY environment variable
-    :param server_host_name  This is the server host name that will be checked against a TLS certificate for
+    :param http_proxy: http proxy address.  Equivalent to setting the HTTP_PROXY environment variable
+    :param https_proxy: https proxy address.  Equivalent to setting the HTTPS_PROXY environment variable
+    :param server_host_name: This is the server host name that will be checked against a TLS certificate for
       validity.  This option can be used if using an ssh_tunnel or other indirect means to an ClickHouse server
       where the `host` argument refers to the tunnel or proxy and not the actual ClickHouse server
-    :param tz_source Controls how the client determines the fallback timezone for DateTime columns without an
+    :param tz_source: Controls how the client determines the fallback timezone for DateTime columns without an
       explicit timezone. "auto" (default) auto-detects based on DST safety of server timezone. "server" always
       uses the server timezone. "local" always uses the local timezone.
-    :param tz_mode Controls timezone-aware behavior for UTC DateTime columns. "naive_utc" (default) returns
+    :param tz_mode: Controls timezone-aware behavior for UTC DateTime columns. "naive_utc" (default) returns
       naive UTC timestamps. "aware" forces timezone-aware UTC datetimes. "schema" returns datetimes that
       match the server's column definition which means timezone-aware when the column defines a timezone and naive
       for bare DateTime columns.
-    :param autogenerate_session_id  If set, this will override the 'autogenerate_session_id' common setting.
-    :param form_encode_query_params  If True, always send query parameters as form-encoded data in the request body
+    :param autogenerate_session_id: If set, this will override the 'autogenerate_session_id' common setting.
+    :param form_encode_query_params: If True, always send query parameters as form-encoded data in the request body
       instead of as URL parameters. When False, large parameter payloads are still automatically sent as form data to
       avoid exceeding URL length limits, except for queries using binary parameter binds, which are only form-encoded
       when this is True. Only available for query operations (not inserts). Default: False

--- a/clickhouse_connect/driver/client.py
+++ b/clickhouse_connect/driver/client.py
@@ -619,7 +619,7 @@ class Client(ABC):
         :param parameters: Optional dictionary used to format the query
         :param settings: Optional dictionary of ClickHouse settings (key/string values)
         :param fmt: ClickHouse output format
-        :param use_database  Send the database parameter to ClickHouse so the command will be executed in the client
+        :param use_database: Send the database parameter to ClickHouse so the command will be executed in the client
          database context.
         :param external_data: External data to send with the query.
         :param transport_settings: Optional dictionary of transport level settings (HTTP headers, etc.)
@@ -777,9 +777,9 @@ class Client(ABC):
           UTC datetimes, "naive_utc" returns naive UTC datetimes, and "schema" returns datetimes matching the
           server's column definition.
         :param use_na_values: Deprecated alias for use_advanced_dtypes
-        :param as_pandas Return the result columns as pandas.Series objects
-        :param streaming Marker used to correctly configure streaming queries
-        :param external_data ClickHouse "external data" to send with query
+        :param as_pandas: Return the result columns as pandas.Series objects
+        :param streaming: Marker used to correctly configure streaming queries
+        :param external_data: ClickHouse "external data" to send with query
         :param use_extended_dtypes:  Only relevant to Pandas Dataframe queries.  Use Pandas "missing types", such as
           pandas.NA and pandas.NaT for ClickHouse NULL values, as well as extended Pandas dtypes such as IntegerArray
           and StringArray.  Defaulted to True for query_df methods

--- a/clickhouse_connect/driver/query.py
+++ b/clickhouse_connect/driver/query.py
@@ -92,15 +92,15 @@ class QueryContext(BaseQueryContext):
         :param column_formats: Optional dictionary
         :param use_none: Use a Python None for ClickHouse NULL values in nullable columns.  Otherwise the default
           value of the column (such as 0 for numbers) will be returned in the result_set
-        :param max_str_len Limit returned ClickHouse String values to this length, which allows a Numpy
+        :param max_str_len: Limit returned ClickHouse String values to this length, which allows a Numpy
           structured array even with ClickHouse variable length String columns.  If 0, Numpy arrays for
           String columns will always be object arrays
-        :param query_tz  Either a string IANA timezone name or a tzinfo object (strings are resolved via zoneinfo).
+        :param query_tz: Either a string IANA timezone name or a tzinfo object (strings are resolved via zoneinfo).
           Values for any DateTime or DateTime64 column in the query will be converted to Python datetime.datetime
           objects with the selected timezone
-        :param column_tzs A dictionary of column names to tzinfo objects (or strings that will be converted to
+        :param column_tzs: A dictionary of column names to tzinfo objects (or strings that will be converted to
           tzinfo objects).  The timezone will be applied to datetime objects returned in the query
-        :param tz_mode Controls timezone-aware behavior for UTC DateTime columns. "naive_utc" (default) returns
+        :param tz_mode: Controls timezone-aware behavior for UTC DateTime columns. "naive_utc" (default) returns
           naive UTC timestamps. "aware" forces timezone-aware UTC datetimes. "schema" returns datetimes that
           match the server's column definition which means timezone-aware when the column schema defines a timezone
           (e.g. DateTime('UTC')) and naive for bare DateTime columns.


### PR DESCRIPTION
## Summary

Closes #985

Adds the missing colon to 27 `:param` directives. Without it Sphinx does not
recognise the field, and the parameter description is rendered as part of the
preceding text rather than as a parameter entry.

```
-        :param as_pandas Return the result columns as pandas.Series objects
+        :param as_pandas: Return the result columns as pandas.Series objects
```

Affected: `driver/__init__.py` (19, split evenly between `create_client()`
and `create_async_client()`), `driver/client.py` (4), `driver/query.py` (4).

Two directives separated the name from the description with `--`
(`:param kwargs -- Recognized keyword arguments`); those become `: ` to match
the surrounding style.

Docstrings only — no code, signatures or behaviour are touched.

## Checklist
- [x] A human-readable description of the changes was provided to include in CHANGELOG
