### PR TITLE
fix dialect-aware SQLAlchemy DDL types

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## UNRELEASED
 
+### Bug Fixes
+
+- SQLAlchemy column DDL now compiles `TypeDecorator` and `with_variant()` types through the active ClickHouse dialect. Dialect-aware types such as a decorator that selects `DateTime64(6, 'UTC')` no longer fall back to generic `DATETIME` in `CREATE TABLE` and related column DDL. Closes [#984](https://github.com/ClickHouse/clickhouse-connect/issues/984).
+
 ## 1.7.2, 2026-08-19
 
 ### Bug Fixes

--- a/clickhouse_connect/cc_sqlalchemy/sql/ddlcompiler.py
+++ b/clickhouse_connect/cc_sqlalchemy/sql/ddlcompiler.py
@@ -186,7 +186,9 @@ class ChDDLCompiler(DDLCompiler):
         return f"ALTER TABLE {format_table(drop.element)} DROP COLUMN {quote_identifier(drop.column.name)}"
 
     def get_column_specification(self, column: Column, **_):
-        text = f"{quote_identifier(column.name)} {ClickHouseDDLHelper.effective_column_type(column).compile()}"
+        effective_type = ClickHouseDDLHelper.effective_column_type(column)
+        compiled_type = self.dialect.type_compiler.process(effective_type, type_expression=column)
+        text = f"{quote_identifier(column.name)} {compiled_type}"
         materialized = ClickHouseDDLHelper.get_option(column, "materialized")
         alias = ClickHouseDDLHelper.get_option(column, "alias")
         # DEFAULT, MATERIALIZED, and ALIAS are mutually exclusive in ClickHouse.

--- a/tests/unit_tests/test_sqlalchemy/test_ddl.py
+++ b/tests/unit_tests/test_sqlalchemy/test_ddl.py
@@ -7,7 +7,7 @@ from sqlalchemy.orm import declarative_base
 from sqlalchemy.sql.ddl import CreateTable
 
 from clickhouse_connect import dbapi
-from clickhouse_connect.cc_sqlalchemy.datatypes.sqltypes import Date, DateTime, String, UInt32, UInt64
+from clickhouse_connect.cc_sqlalchemy.datatypes.sqltypes import Date, DateTime, DateTime64, String, UInt32, UInt64
 from clickhouse_connect.cc_sqlalchemy.ddl.dictionary import Dictionary
 from clickhouse_connect.cc_sqlalchemy.ddl.tableengine import (
     GraphiteMergeTree,
@@ -25,6 +25,17 @@ from clickhouse_connect.cc_sqlalchemy.sql.ddlcompiler import column_specificatio
 from clickhouse_connect.driver.binding import format_str
 
 dialect = ClickHouseDialect()
+
+
+class DialectDateTime(db.TypeDecorator):
+    impl = db.DateTime
+    cache_ok = True
+
+    def load_dialect_impl(self, dialect):
+        if dialect.name == "clickhousedb":
+            return dialect.type_descriptor(DateTime64(6, "UTC"))
+        return self.impl
+
 
 replicated_mt_ddl = """\
 CREATE TABLE `replicated_mt_test` (`key` UInt64) Engine ReplicatedMergeTree('/clickhouse/tables/repl_mt_test',\
@@ -272,6 +283,24 @@ def _engine_ddl(name, columns, engine):
     metadata = db.MetaData()
     table = db.Table(name, metadata, *columns, engine)
     return str(CreateTable(table).compile("", dialect=dialect))
+
+
+@pytest.mark.parametrize(
+    "type_factory",
+    [
+        DialectDateTime,
+        lambda: db.DateTime().with_variant(DateTime64(6, "UTC"), "clickhousedb"),
+    ],
+    ids=["type-decorator", "variant"],
+)
+def test_column_type_uses_clickhouse_dialect(type_factory):
+    ddl = _engine_ddl(
+        "events",
+        [db.Column("created_at", type_factory())],
+        MergeTree(order_by="created_at"),
+    )
+
+    assert ddl == "CREATE TABLE `events` (`created_at` DateTime64(6, 'UTC')) Engine MergeTree ORDER BY created_at"
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
## Summary
Compiles SQLAlchemy column types through the active ClickHouse dialect. This prevents `TypeDecorator` and `with_variant()` types from incorrectly falling back to generic types such as `DATETIME`.

Closes #984

## Checklist
Delete items not relevant to your PR:
- [X] Unit and integration tests covering the common scenarios were added
- [X] A human-readable description of the changes was provided to include in CHANGELOG