### PR TITLE
fix Alembic named container rendering

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 
 ### Bug Fixes
 
+- Alembic autogenerate now emits valid, lossless Python for `Nested` and named `Tuple` columns, including when they are inside another container. Generated upgrades preserve field names and no longer produce repeated type migrations. Closes [#988](https://github.com/ClickHouse/clickhouse-connect/issues/988).
 - SQLAlchemy column DDL now compiles `TypeDecorator` and `with_variant()` types through the active ClickHouse dialect. Dialect-aware types such as a decorator that selects `DateTime64(6, 'UTC')` no longer fall back to generic `DATETIME` in `CREATE TABLE` and related column DDL. Closes [#984](https://github.com/ClickHouse/clickhouse-connect/issues/984).
 
 ## 1.7.2, 2026-08-19

--- a/clickhouse_connect/cc_sqlalchemy/alembic/adapter.py
+++ b/clickhouse_connect/cc_sqlalchemy/alembic/adapter.py
@@ -65,6 +65,7 @@ def patch_alembic_version(context: MigrationContext) -> MigrationContext:
 
 def _add_common_imports(directive):
     directive.imports.add("from clickhouse_connect import cc_sqlalchemy")
+    directive.imports.add("from clickhouse_connect.cc_sqlalchemy.datatypes.base import sqla_type_from_name")
     directive.imports.add("from clickhouse_connect.cc_sqlalchemy.ddl.tableengine import *  # noqa: F401,F403")
     directive.imports.add("from clickhouse_connect.cc_sqlalchemy.datatypes.sqltypes import *  # noqa: F401,F403")
 

--- a/clickhouse_connect/cc_sqlalchemy/alembic/impl.py
+++ b/clickhouse_connect/cc_sqlalchemy/alembic/impl.py
@@ -13,6 +13,7 @@ from clickhouse_connect.cc_sqlalchemy.datatypes.base import ChSqlaType, sqla_typ
 from clickhouse_connect.cc_sqlalchemy.datatypes.sqltypes import Array as ChSqlaArray
 from clickhouse_connect.cc_sqlalchemy.datatypes.sqltypes import Enum as ChSqlaEnum
 from clickhouse_connect.cc_sqlalchemy.datatypes.sqltypes import Map as ChSqlaMap
+from clickhouse_connect.cc_sqlalchemy.datatypes.sqltypes import Nested as ChSqlaNested
 from clickhouse_connect.cc_sqlalchemy.datatypes.sqltypes import Nullable
 from clickhouse_connect.cc_sqlalchemy.datatypes.sqltypes import Tuple as ChSqlaTuple
 from clickhouse_connect.cc_sqlalchemy.ddl.tableengine import MergeTree
@@ -42,8 +43,22 @@ def _reject_standard_index() -> None:
     raise CommandError(_STANDARD_INDEX_MESSAGE)
 
 
+def _contains_named_container(type_obj: ChSqlaType) -> bool:
+    if isinstance(type_obj, ChSqlaNested) or (isinstance(type_obj, ChSqlaTuple) and type_obj.type_def.keys):
+        return True
+    if isinstance(type_obj, ChSqlaArray):
+        nested_types = type_obj.type_def.values[:1]
+    elif isinstance(type_obj, (ChSqlaMap, ChSqlaTuple)):
+        nested_types = type_obj.type_def.values
+    else:
+        return False
+    return any(_contains_named_container(sqla_type_from_name(str(name))) for name in nested_types)
+
+
 def _render_ch_type(type_obj):
     """Render a ChSqlaType as valid Python source for autogen migrations"""
+    if _contains_named_container(type_obj):
+        return f"sqla_type_from_name({type_obj.name!r})"
     wrappers = type_obj.type_def.wrappers
     if isinstance(type_obj, ChSqlaEnum):
         keys = list(type_obj.type_def.keys)

--- a/tests/integration_tests/test_sqlalchemy/test_alembic.py
+++ b/tests/integration_tests/test_sqlalchemy/test_alembic.py
@@ -19,6 +19,7 @@ from clickhouse_connect.cc_sqlalchemy.alembic import (
     ClickHouseIndex,
     ClickHouseProjection,
 )
+from clickhouse_connect.cc_sqlalchemy.datatypes.base import sqla_type_from_name
 from clickhouse_connect.cc_sqlalchemy.datatypes.sqltypes import (
     Boolean,
     DateTime64,
@@ -478,6 +479,45 @@ def test_alembic_autogenerate_positional_engine_live(test_engine: Engine, test_d
         assert "index_granularity = 1024" in engine_full
         rows = conn.execute(text(f"SELECT version_num FROM `{test_db}`.`alembic_version`")).fetchall()
         assert rows
+
+
+def test_alembic_named_container_types_round_trip_live(test_engine: Engine, test_db: str, tmp_path: Path, ch_name):
+    table_name = ch_name("alembic_named_containers")
+    nested_type = sqla_type_from_name("Nested(a String, b UInt32)")
+    named_tuple_type = sqla_type_from_name("Tuple(a String, b UInt32)")
+    array_tuple_type = sqla_type_from_name("Array(Tuple(a String, b UInt32))")
+    metadata = MetaData(schema=test_db)
+    Table(
+        table_name,
+        metadata,
+        Column("id", UInt32, nullable=False),
+        Column("nested_value", nested_type, nullable=False),
+        Column("tuple_value", named_tuple_type, nullable=False),
+        Column("array_tuple_value", array_tuple_type, nullable=False),
+        MergeTree(order_by="id"),
+    )
+
+    with test_engine.connect().execution_options(settings={"flatten_nested": 0}) as conn:
+        config = _alembic_config(tmp_path, conn, metadata, frozenset({table_name}))
+        revision = command.revision(config, message="create named containers", autogenerate=True)
+        assert revision is not None
+        assert not isinstance(revision, list)
+        contents = Path(revision.path).read_text(encoding="utf-8")
+        assert "from clickhouse_connect.cc_sqlalchemy.datatypes.base import sqla_type_from_name" in contents
+        assert contents.count("sqla_type_from_name(") == 3
+        command.upgrade(config, "head")
+
+        reflected = Table(table_name, MetaData(schema=test_db), autoload_with=conn)
+        assert reflected.c.nested_value.type.name == nested_type.name
+        assert reflected.c.tuple_value.type.name == named_tuple_type.name
+        assert reflected.c.array_tuple_value.type.name == array_tuple_type.name
+
+        noop_revision = command.revision(config, message="named containers noop", autogenerate=True)
+        assert noop_revision is not None
+        assert not isinstance(noop_revision, list)
+        noop_contents = Path(noop_revision.path).read_text(encoding="utf-8")
+        assert "pass" in noop_contents
+        assert "alter_column" not in noop_contents
 
 
 def test_alembic_autogenerate_text_expression_ttl_round_trip_live(test_engine: Engine, test_db: str, tmp_path: Path, ch_name):

--- a/tests/unit_tests/test_sqlalchemy/test_alembic.py
+++ b/tests/unit_tests/test_sqlalchemy/test_alembic.py
@@ -42,6 +42,7 @@ from clickhouse_connect.cc_sqlalchemy.alembic.operations import (
     _ResetClickHouseTableSettingsOp,
 )
 from clickhouse_connect.cc_sqlalchemy.alembic.utils import make_include_object
+from clickhouse_connect.cc_sqlalchemy.datatypes.base import sqla_type_from_name
 from clickhouse_connect.cc_sqlalchemy.ddl.dictionary import Dictionary
 from clickhouse_connect.cc_sqlalchemy.ddl.tableengine import (
     CollapsingMergeTree,
@@ -330,6 +331,34 @@ def test_render_type_non_enum_containers_use_clickhouse_names():
     assert context.impl.render_type(types.Tuple(types.UInt32, types.String), None) == "Tuple(UInt32, String)"
     assert context.impl.render_type(types.Array(types.Nullable(types.String)), None) == "Array(Nullable(String))"
     assert context.impl.render_type(types.Array(types.DateTime64(3, "UTC")), None) == "Array(DateTime64(3, 'UTC'))"
+
+
+@pytest.mark.parametrize(
+    "type_name",
+    [
+        "Nested(a String, b UInt32)",
+        "Nested(state Enum8('it\\'s' = 1, 'ok' = 2), value UInt32)",
+        "Tuple(a String, b UInt32)",
+        "Tuple(`field name` String, b UInt32)",
+        "Array(Nested(a String, b UInt32))",
+        "Array(Tuple(a String, b UInt32))",
+        "Array(Array(Tuple(a String, b UInt32)))",
+        "Tuple(String, Tuple(a String, b UInt32))",
+        "Tuple(a Array(Tuple(id UInt32, value String)), b Nullable(String))",
+        "Map(String, Tuple(a String, b UInt32))",
+        "Nullable(Tuple(a String, b UInt32))",
+    ],
+)
+def test_render_type_named_containers_emit_lossless_python(type_name):
+    context = MigrationContext.configure(dialect=ClickHouseDialect(), opts={"target_metadata": MetaData()})
+    type_obj = sqla_type_from_name(type_name)
+
+    rendered = context.impl.render_type(type_obj, None)
+
+    namespace = {"sqla_type_from_name": sqla_type_from_name}
+    exec("from clickhouse_connect.cc_sqlalchemy.datatypes.sqltypes import *", namespace)
+    rebuilt = eval(rendered, namespace)
+    assert rebuilt.name == type_obj.name
 
 
 def test_explicit_nullable_column_renders_nullable_type():
@@ -751,11 +780,13 @@ def test_clickhouse_writer_adds_template_imports():
     assert "from clickhouse_connect import cc_sqlalchemy" in directive.imports
     assert any("ddl.tableengine import *" in value for value in directive.imports)
     assert any("datatypes.sqltypes import *" in value for value in directive.imports)
+    assert "from clickhouse_connect.cc_sqlalchemy.datatypes.base import sqla_type_from_name" in directive.imports
 
     downgrade_only = _Directive(downgrade_ops=_Ops())
     clickhouse_writer(None, None, [downgrade_only])
     assert any("ddl.tableengine import *" in value for value in downgrade_only.imports)
     assert any("datatypes.sqltypes import *" in value for value in downgrade_only.imports)
+    assert "from clickhouse_connect.cc_sqlalchemy.datatypes.base import sqla_type_from_name" in downgrade_only.imports
 
 
 def test_set_type_nullable_accepts_type_classes():


### PR DESCRIPTION
## Summary

Alembic autogenerate now renders `Nested` and named `Tuple` columns through raw ClickHouse type strings. Generated migrations import successfully, preserve field names through nested containers, and no longer repeat type changes.

Closes #988

## Checklist
Delete items not relevant to your PR:
- [X] Unit and integration tests covering the common scenarios were added
- [X] A human-readable description of the changes was provided to include in CHANGELOG