### PR TITLE
Do not emit a phantom column for an empty argument list

### DIFF
--- a/clickhouse_connect/driver/parser.py
+++ b/clickhouse_connect/driver/parser.py
@@ -170,7 +170,11 @@ def parse_columns(expr: str, preserve_names: bool = False):
                     label = ""
                     continue
                 elif char == ")":
-                    columns.append(label.rstrip() if preserve_names and named and names[-1].upper() == "SKIP" else label)
+                    # An empty argument list contributes no column.  Appending
+                    # here produced a phantom column with an empty type name,
+                    # which get_from_name later rejects.
+                    if label or named or columns:
+                        columns.append(label.rstrip() if preserve_names and named and names[-1].upper() == "SKIP" else label)
                     break
             if char in ("'", '"', "`"):
                 quote = char

--- a/tests/unit_tests/test_driver/test_parser.py
+++ b/tests/unit_tests/test_driver/test_parser.py
@@ -462,3 +462,25 @@ def test_remove_comments_no_space_after_dashes():
 )
 def test_remove_comments_separates_tokens(sql: str, expected: str):
     assert remove_sql_comments(sql) == expected
+
+
+def test_parse_columns_empty_argument_list():
+    # An empty argument list has no columns.  Returning ('',) here produced a
+    # phantom column whose type name was the empty string.
+    assert parse_columns("()") == ((), ())
+    assert parse_columns("()", preserve_names=True) == ((), ())
+
+
+def test_parse_columns_non_empty_argument_lists_unchanged():
+    assert parse_columns("(Int32)") == ((), ("Int32",))
+    assert parse_columns("(a String, b Int32)") == (("a", "b"), ("String", "Int32"))
+    assert parse_columns("(Tuple(String), Int32)") == ((), ("Tuple(String)", "Int32"))
+
+
+def test_empty_parameterized_types_resolve():
+    # Variant() raised "Unrecognized ClickHouse type base:  name: " because the
+    # phantom column was passed to get_from_name.  Tuple() only worked because
+    # registry.parse_name special-cases the literal string.
+    assert get_from_name("Variant()").name == "Variant()"
+    assert get_from_name("Tuple()").name == "Tuple()"
+    assert get_from_name("Nested()").name == "Nested()"


### PR DESCRIPTION
Closes #971.

`parse_columns("()")` returned `((), ('',))`: one column whose type name is the
empty string. The `)` branch at `level == 0` appends the accumulated label
unconditionally, so an empty argument list still produces an entry.

The issue reports this as breaking `Tuple()`, but that case is masked on `main`
by `registry.parse_name`, which special-cases the literal strings `"Tuple"` and
`"Tuple()"`. The still-reachable failure is `Variant()`:

```
>>> get_from_name("Variant()")
InternalError: Unrecognized ClickHouse type base:  name:
```

`Nested()`, `Dynamic()` and `JSON()` carry the phantom element through instead
of raising.

The fix only skips the append when there is nothing to append, so non-empty
argument lists are untouched. `Variant()`, `Nested()` and `Tuple()` all resolve
afterwards, and the `Tuple()` special case in the registry is now redundant,
though I left it alone to keep this diff small.

Three regression tests added; all three fail without the change. `pytest
tests/unit_tests` goes from 1287 to 1290 passing with no change to the 17
pre-existing failures (missing optional `pyarrow` and `alembic`).
