### PR TITLE
fix sqa variant reflection

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,7 @@
 
 ### Bug Fixes
 
-- SQLAlchemy can now construct and reflect standalone `Variant` columns, and Alembic autogeneration can compare and round-trip them. Closes [#989](https://github.com/ClickHouse/clickhouse-connect/issues/989).
+- SQLAlchemy can now reflect standalone `Variant` columns, and Alembic autogeneration can compare and round-trip them. Closes [#989](https://github.com/ClickHouse/clickhouse-connect/issues/989).
 - Alembic autogenerate now emits valid, lossless Python for `Nested` and named `Tuple` columns, including when they are inside another container. Generated upgrades preserve field names and no longer produce repeated type migrations. Closes [#988](https://github.com/ClickHouse/clickhouse-connect/issues/988).
 - The client now sorts and deduplicates `Variant` members to the server's canonical order. Previously a client-declared `Variant` type with non-canonical member order wrote native insert data under the wrong member types.
 - `Time64` negative timedelta inserts previously stored incorrect values. `Time64` NumPy timedelta inserts previously stored wrong magnitudes. Both now store correct tick values, and out-of-range NumPy values are rejected instead of incorrectly wrapping.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@
 
 ### Bug Fixes
 
+- SQLAlchemy can now construct and reflect standalone `Variant` columns, and Alembic autogeneration can compare and round-trip them. Closes [#989](https://github.com/ClickHouse/clickhouse-connect/issues/989).
 - Alembic autogenerate now emits valid, lossless Python for `Nested` and named `Tuple` columns, including when they are inside another container. Generated upgrades preserve field names and no longer produce repeated type migrations. Closes [#988](https://github.com/ClickHouse/clickhouse-connect/issues/988).
 - The client now sorts and deduplicates `Variant` members to the server's canonical order. Previously a client-declared `Variant` type with non-canonical member order wrote native insert data under the wrong member types.
 - `Time64` negative timedelta inserts previously stored incorrect values. `Time64` NumPy timedelta inserts previously stored wrong magnitudes. Both now store correct tick values, and out-of-range NumPy values are rejected instead of incorrectly wrapping.

--- a/clickhouse_connect/cc_sqlalchemy/alembic/impl.py
+++ b/clickhouse_connect/cc_sqlalchemy/alembic/impl.py
@@ -17,6 +17,7 @@ from clickhouse_connect.cc_sqlalchemy.datatypes.sqltypes import Map as ChSqlaMap
 from clickhouse_connect.cc_sqlalchemy.datatypes.sqltypes import Nested as ChSqlaNested
 from clickhouse_connect.cc_sqlalchemy.datatypes.sqltypes import Nullable
 from clickhouse_connect.cc_sqlalchemy.datatypes.sqltypes import Tuple as ChSqlaTuple
+from clickhouse_connect.cc_sqlalchemy.datatypes.sqltypes import Variant as ChSqlaVariant
 from clickhouse_connect.cc_sqlalchemy.ddl.tableengine import MergeTree
 from clickhouse_connect.cc_sqlalchemy.inspector import with_internal_query_formats
 from clickhouse_connect.cc_sqlalchemy.sql import full_table
@@ -50,7 +51,7 @@ def _contains_named_container(type_obj: ChSqlaType) -> bool:
         return True
     if isinstance(type_obj, ChSqlaArray):
         nested_types = type_obj.type_def.values[:1]
-    elif isinstance(type_obj, (ChSqlaMap, ChSqlaTuple)):
+    elif isinstance(type_obj, (ChSqlaMap, ChSqlaTuple, ChSqlaVariant)):
         nested_types = type_obj.type_def.values
     else:
         return False
@@ -74,6 +75,9 @@ def _render_ch_type(type_obj):
     elif isinstance(type_obj, ChSqlaTuple):
         elements = ", ".join(_render_inner(v) for v in type_obj.type_def.values)
         rendered = f"Tuple({elements})"
+    elif isinstance(type_obj, ChSqlaVariant):
+        elements = ", ".join(_render_inner(v) for v in type_obj.type_def.values)
+        rendered = f"Variant({elements})"
     elif isinstance(type_obj, ChSqlaJSON):
         ch_type = cast(ChJSON, type_obj.ch_type)
         args = []

--- a/clickhouse_connect/cc_sqlalchemy/alembic/impl.py
+++ b/clickhouse_connect/cc_sqlalchemy/alembic/impl.py
@@ -17,7 +17,7 @@ from clickhouse_connect.cc_sqlalchemy.datatypes.sqltypes import Map as ChSqlaMap
 from clickhouse_connect.cc_sqlalchemy.datatypes.sqltypes import Nested as ChSqlaNested
 from clickhouse_connect.cc_sqlalchemy.datatypes.sqltypes import Nullable
 from clickhouse_connect.cc_sqlalchemy.datatypes.sqltypes import Tuple as ChSqlaTuple
-from clickhouse_connect.cc_sqlalchemy.datatypes.sqltypes import Variant as ChSqlaVariant
+from clickhouse_connect.cc_sqlalchemy.datatypes.sqltypes import _Variant as ChSqlaVariant
 from clickhouse_connect.cc_sqlalchemy.ddl.tableengine import MergeTree
 from clickhouse_connect.cc_sqlalchemy.inspector import with_internal_query_formats
 from clickhouse_connect.cc_sqlalchemy.sql import full_table
@@ -51,7 +51,7 @@ def _contains_named_container(type_obj: ChSqlaType) -> bool:
         return True
     if isinstance(type_obj, ChSqlaArray):
         nested_types = type_obj.type_def.values[:1]
-    elif isinstance(type_obj, (ChSqlaMap, ChSqlaTuple, ChSqlaVariant)):
+    elif isinstance(type_obj, (ChSqlaMap, ChSqlaTuple)):
         nested_types = type_obj.type_def.values
     else:
         return False
@@ -60,6 +60,8 @@ def _contains_named_container(type_obj: ChSqlaType) -> bool:
 
 def _render_ch_type(type_obj):
     """Render a ChSqlaType as valid Python source for autogen migrations"""
+    if isinstance(type_obj, ChSqlaVariant):
+        return f"sqla_type_from_name({type_obj.name!r})"
     if _contains_named_container(type_obj):
         return f"sqla_type_from_name({type_obj.name!r})"
     wrappers = type_obj.type_def.wrappers
@@ -75,9 +77,6 @@ def _render_ch_type(type_obj):
     elif isinstance(type_obj, ChSqlaTuple):
         elements = ", ".join(_render_inner(v) for v in type_obj.type_def.values)
         rendered = f"Tuple({elements})"
-    elif isinstance(type_obj, ChSqlaVariant):
-        elements = ", ".join(_render_inner(v) for v in type_obj.type_def.values)
-        rendered = f"Variant({elements})"
     elif isinstance(type_obj, ChSqlaJSON):
         ch_type = cast(ChJSON, type_obj.ch_type)
         args = []

--- a/clickhouse_connect/cc_sqlalchemy/datatypes/base.py
+++ b/clickhouse_connect/cc_sqlalchemy/datatypes/base.py
@@ -22,13 +22,14 @@ class ChSqlaType:
     generic_type: None
     _ch_type_cls: type[ClickHouseType] | None = None
     _instance_cache: dict[TypeDef, "ChSqlaType"] | None = None
+    _schema_name: str | None = None
 
     def __init_subclass__(cls):
         """
         Registers ChSqla type in the type map and sets the underlying ClickHouseType class to use to initialize
         ChSqlaType instances
         """
-        base = cls.__name__
+        base = cls.__dict__.get("_schema_name") or cls.__name__
         if not cls._ch_type_cls:
             try:
                 cls._ch_type_cls = type_map[base]

--- a/clickhouse_connect/cc_sqlalchemy/datatypes/sqltypes.py
+++ b/clickhouse_connect/cc_sqlalchemy/datatypes/sqltypes.py
@@ -31,6 +31,7 @@ from sqlalchemy.types import (
 from clickhouse_connect.cc_sqlalchemy.datatypes.base import ChSqlaType, sqla_type_from_name
 from clickhouse_connect.cc_sqlalchemy.sql.clauses import json_subcolumn
 from clickhouse_connect.datatypes.base import EMPTY_TYPE_DEF, LC_TYPE_DEF, NULLABLE_TYPE_DEF, TypeDef
+from clickhouse_connect.datatypes.dynamic import Variant as ChVariant
 from clickhouse_connect.datatypes.numeric import Enum8 as ChEnum8
 from clickhouse_connect.datatypes.numeric import Enum16 as ChEnum16
 from clickhouse_connect.datatypes.registry import get_from_name, type_map
@@ -516,6 +517,36 @@ class Tuple(ChSqlaType, UserDefinedType):  # type: ignore[misc]
     def adapt(self, cls, **kw):
         # Bypass SA's constructor_copy: it can't see keyword-only args behind *args and
         # would produce an empty Tuple. Copy state directly.
+        inst = cls.__new__(cls)
+        inst.__dict__.update(self.__dict__)
+        return inst
+
+
+class Variant(ChSqlaType, UserDefinedType):  # type: ignore[misc]
+    python_type = object
+
+    def __init__(
+        self,
+        *args: ChSqlaType | type[ChSqlaType],
+        elements: Sequence[ChSqlaType | type[ChSqlaType]] | None = None,
+        type_def: TypeDef | None = None,
+    ):
+        """Variant(String, UInt32) variadic form or Variant(elements=[String, UInt32]) list form, not both."""
+        if type_def is None:
+            if args and elements is not None:
+                raise ArgumentError("Cannot specify both positional elements and the 'elements' kwarg")
+            if args:
+                elements = args
+            if not elements:
+                raise ArgumentError("Variant requires at least one member type")
+            values = [element() if callable(element) else element for element in elements or ()]
+            type_def = TypeDef(values=tuple(value.name for value in values))
+        elif not type_def.values:
+            raise ArgumentError("Variant requires at least one member type")
+        super().__init__(type_def)
+        self.type_def = cast(ChVariant, self.ch_type).type_def
+
+    def adapt(self, cls, **kw):
         inst = cls.__new__(cls)
         inst.__dict__.update(self.__dict__)
         return inst
@@ -1132,6 +1163,7 @@ __all__ = [
     "UInt64",
     "UInt8",
     "UUID",
+    "Variant",
     "LowCardinality",
     "Nullable",
 ]

--- a/clickhouse_connect/cc_sqlalchemy/datatypes/sqltypes.py
+++ b/clickhouse_connect/cc_sqlalchemy/datatypes/sqltypes.py
@@ -522,27 +522,11 @@ class Tuple(ChSqlaType, UserDefinedType):  # type: ignore[misc]
         return inst
 
 
-class Variant(ChSqlaType, UserDefinedType):  # type: ignore[misc]
+class _Variant(ChSqlaType, UserDefinedType):  # type: ignore[misc]
+    _schema_name = "Variant"
     python_type = object
 
-    def __init__(
-        self,
-        *args: ChSqlaType | type[ChSqlaType],
-        elements: Sequence[ChSqlaType | type[ChSqlaType]] | None = None,
-        type_def: TypeDef | None = None,
-    ):
-        """Variant(String, UInt32) variadic form or Variant(elements=[String, UInt32]) list form, not both."""
-        if type_def is None:
-            if args and elements is not None:
-                raise ArgumentError("Cannot specify both positional elements and the 'elements' kwarg")
-            if args:
-                elements = args
-            if not elements:
-                raise ArgumentError("Variant requires at least one member type")
-            values = [element() if callable(element) else element for element in elements or ()]
-            type_def = TypeDef(values=tuple(value.name for value in values))
-        elif not type_def.values:
-            raise ArgumentError("Variant requires at least one member type")
+    def __init__(self, type_def: TypeDef):
         super().__init__(type_def)
         self.type_def = cast(ChVariant, self.ch_type).type_def
 
@@ -1163,7 +1147,6 @@ __all__ = [
     "UInt64",
     "UInt8",
     "UUID",
-    "Variant",
     "LowCardinality",
     "Nullable",
 ]

--- a/docs/sqlalchemy.mdx
+++ b/docs/sqlalchemy.mdx
@@ -156,7 +156,7 @@ For simple Python identifier paths, keyword arguments are shorthand for `typed_p
 
 Up to 1000 typed paths can be configured. `max_dynamic_paths` accepts 0 through 10000. `max_dynamic_types` accepts 0 through 254. These ranges also apply inside raw nested JSON type strings. Explicit server defaults of 1024 and 32 are omitted from generated DDL. Plain skip paths are deduplicated. Regular expression strings are not validated by Python because ClickHouse uses RE2 syntax. Duplicate regular expressions are preserved.
 
-A plain skip path cannot be named exactly `REGEXP` because ClickHouse reserves that token for `SKIP REGEXP`. Names such as `REGEXP_foo` remain valid. In a raw JSON type string, a plain `SKIP` operand must be one ClickHouse identifier or a dot-separated compound identifier. An unquoted compound identifier cannot start with `REGEXP`; quote that first component when it is path data. `SKIP REGEXP` must have one single-quoted string literal. Quote identifier parts with backticks or double quotes when they contain spaces or punctuation. `Variant` members are ordered and deduplicated by the same canonical names used by ClickHouse.
+A plain skip path cannot be named exactly `REGEXP` because ClickHouse reserves that token for `SKIP REGEXP`. Names such as `REGEXP_foo` remain valid. In a raw JSON type string, a plain `SKIP` operand must be one ClickHouse identifier or a dot-separated compound identifier. An unquoted compound identifier cannot start with `REGEXP`; quote that first component when it is path data. `SKIP REGEXP` must have one single-quoted string literal. Quote identifier parts with backticks or double quotes when they contain spaces or punctuation. Raw JSON type hints support `Variant(...)`; standalone `Variant` has no public SQLAlchemy constructor. `Variant` members are ordered and deduplicated by the same canonical names used by ClickHouse.
 
 The constructor orders arguments in the same canonical form returned by ClickHouse. Reflected types, SQLAlchemy type copies, and Alembic autogeneration preserve the configuration.
 
@@ -328,7 +328,7 @@ ClickHouse does not support recursive materialized CTEs. The SQLAlchemy helpers 
 
 ClickHouse Connect provides ClickHouse data types, table engines, dictionary constructs, database DDL, and table reflection.
 
-Standalone `Variant` columns can be declared with `Variant(String, UInt32)` or `Variant(elements=[String, UInt32])`. Member types can be type classes or configured instances. The constructor uses ClickHouse's canonical member order. Reflected `Variant` columns use the same SQLAlchemy type, so Alembic autogenerate can compare them without repeated type changes.
+Standalone `Variant` columns reflect through an internal SQLAlchemy type, and Alembic autogenerate preserves their canonical raw type names without repeated type changes.
 
 ```python
 import sqlalchemy as db

--- a/docs/sqlalchemy.mdx
+++ b/docs/sqlalchemy.mdx
@@ -121,7 +121,7 @@ When SQLAlchemy inlines a bound value through `literal_binds` or `literal_execut
 
 ### JSON type hints {#sqlalchemy-json-type-hints}
 
-Declare typed JSON paths with the `typed_paths` mapping. A path type can be a ClickHouse SQLAlchemy type class, a configured instance, or a ClickHouse type name string. Type name strings support types without a SQLAlchemy constructor, including `Variant` and `Dynamic`, and preserve names in a named `Tuple`.
+Declare typed JSON paths with the `typed_paths` mapping. A path type can be a ClickHouse SQLAlchemy type class, a configured instance, or a ClickHouse type name string. Type name strings support types without a SQLAlchemy constructor, such as `Dynamic`, and can still be used for complex configured type expressions. They preserve names in a named `Tuple`.
 
 Type name strings can contain configured nested JSON types such as ``Array(JSON(`child` UInt32))``. Recognized ClickHouse type names are case-insensitive in these strings and are emitted with their canonical capitalization. A string must contain one complete type expression. Trailing text and malformed nested JSON arguments are rejected.
 
@@ -327,6 +327,8 @@ ClickHouse does not support recursive materialized CTEs. The SQLAlchemy helpers 
 ## DDL and reflection {#sqlalchemy-ddl-reflection}
 
 ClickHouse Connect provides ClickHouse data types, table engines, dictionary constructs, database DDL, and table reflection.
+
+Standalone `Variant` columns can be declared with `Variant(String, UInt32)` or `Variant(elements=[String, UInt32])`. Member types can be type classes or configured instances. The constructor uses ClickHouse's canonical member order. Reflected `Variant` columns use the same SQLAlchemy type, so Alembic autogenerate can compare them without repeated type changes.
 
 ```python
 import sqlalchemy as db

--- a/tests/integration_tests/test_sqlalchemy/test_alembic.py
+++ b/tests/integration_tests/test_sqlalchemy/test_alembic.py
@@ -31,6 +31,7 @@ from clickhouse_connect.cc_sqlalchemy.datatypes.sqltypes import (
     String,
     Tuple,
     UInt32,
+    Variant,
 )
 from clickhouse_connect.cc_sqlalchemy.ddl.dictionary import Dictionary
 from clickhouse_connect.cc_sqlalchemy.ddl.tableengine import (
@@ -517,6 +518,39 @@ def test_alembic_named_container_types_round_trip_live(test_engine: Engine, test
         assert reflected.c.array_tuple_value.type.name == array_tuple_type.name
 
         noop_revision = command.revision(config, message="named containers noop", autogenerate=True)
+        assert noop_revision is not None
+        assert not isinstance(noop_revision, list)
+        noop_contents = Path(noop_revision.path).read_text(encoding="utf-8")
+        assert "pass" in noop_contents
+        assert "alter_column" not in noop_contents
+
+
+def test_alembic_variant_type_round_trip_live(test_engine: Engine, test_db: str, tmp_path: Path, ch_name):
+    table_name = ch_name("alembic_variant")
+    variant_type = Variant(UInt32, String, UInt32)
+    metadata = MetaData(schema=test_db)
+    Table(
+        table_name,
+        metadata,
+        Column("id", UInt32, nullable=False),
+        Column("value", variant_type, nullable=False),
+        MergeTree(order_by="id"),
+    )
+
+    with test_engine.connect() as conn:
+        config = _alembic_config(tmp_path, conn, metadata, frozenset({table_name}))
+        revision = command.revision(config, message="create variant", autogenerate=True)
+        assert revision is not None
+        assert not isinstance(revision, list)
+        contents = Path(revision.path).read_text(encoding="utf-8")
+        assert "Variant(String, UInt32)" in contents
+        command.upgrade(config, "head")
+
+        reflected = Table(table_name, MetaData(schema=test_db), autoload_with=conn)
+        assert reflected.c.value.type.__class__ is Variant
+        assert reflected.c.value.type.name == variant_type.name
+
+        noop_revision = command.revision(config, message="variant noop", autogenerate=True)
         assert noop_revision is not None
         assert not isinstance(noop_revision, list)
         noop_contents = Path(noop_revision.path).read_text(encoding="utf-8")

--- a/tests/integration_tests/test_sqlalchemy/test_alembic.py
+++ b/tests/integration_tests/test_sqlalchemy/test_alembic.py
@@ -31,7 +31,6 @@ from clickhouse_connect.cc_sqlalchemy.datatypes.sqltypes import (
     String,
     Tuple,
     UInt32,
-    Variant,
 )
 from clickhouse_connect.cc_sqlalchemy.ddl.dictionary import Dictionary
 from clickhouse_connect.cc_sqlalchemy.ddl.tableengine import (
@@ -527,7 +526,7 @@ def test_alembic_named_container_types_round_trip_live(test_engine: Engine, test
 
 def test_alembic_variant_type_round_trip_live(test_engine: Engine, test_db: str, tmp_path: Path, ch_name):
     table_name = ch_name("alembic_variant")
-    variant_type = Variant(UInt32, String, UInt32)
+    variant_type = sqla_type_from_name("Variant(UInt32, String, UInt32)")
     metadata = MetaData(schema=test_db)
     Table(
         table_name,
@@ -543,11 +542,11 @@ def test_alembic_variant_type_round_trip_live(test_engine: Engine, test_db: str,
         assert revision is not None
         assert not isinstance(revision, list)
         contents = Path(revision.path).read_text(encoding="utf-8")
-        assert "Variant(String, UInt32)" in contents
+        assert "sqla_type_from_name('Variant(String, UInt32)')" in contents
         command.upgrade(config, "head")
 
         reflected = Table(table_name, MetaData(schema=test_db), autoload_with=conn)
-        assert reflected.c.value.type.__class__ is Variant
+        assert reflected.c.value.type.__class__ is type(variant_type)
         assert reflected.c.value.type.name == variant_type.name
 
         noop_revision = command.revision(config, message="variant noop", autogenerate=True)

--- a/tests/integration_tests/test_sqlalchemy/test_reflect.py
+++ b/tests/integration_tests/test_sqlalchemy/test_reflect.py
@@ -5,7 +5,7 @@ from sqlalchemy.engine import Connection, Engine
 from sqlalchemy.exc import NoResultFound
 
 from clickhouse_connect import common
-from clickhouse_connect.cc_sqlalchemy.datatypes.sqltypes import Point, SimpleAggregateFunction, UInt32
+from clickhouse_connect.cc_sqlalchemy.datatypes.sqltypes import Point, SimpleAggregateFunction, UInt32, Variant
 from clickhouse_connect.datatypes.format import clear_all_formats, set_default_formats
 
 
@@ -48,6 +48,26 @@ def test_types_reflection(test_engine: Engine, test_db: str):
         assert table.columns.key.type.__class__ == UInt32
         assert table.columns.pt.type.__class__ == Point
         assert "MergeTree" in table.engine.name
+
+
+def test_variant_reflection(test_engine: Engine, test_db: str):
+    table_name = "sqlalchemy_variant_reflection_test"
+    with test_engine.begin() as conn:
+        conn.execute(text(f"DROP TABLE IF EXISTS {test_db}.{table_name}"))
+        conn.execute(text(f"CREATE TABLE {test_db}.{table_name} (id UInt32, value Variant(UInt32, String)) ENGINE MergeTree ORDER BY id"))
+
+    try:
+        columns = inspect(test_engine).get_columns(table_name, schema=test_db)
+        reflected_type = next(column["type"] for column in columns if column["name"] == "value")
+        assert reflected_type.__class__ is Variant
+        assert reflected_type.name == "Variant(String, UInt32)"
+
+        table = Table(table_name, MetaData(schema=test_db), autoload_with=test_engine)
+        assert table.c.value.type.__class__ is Variant
+        assert table.c.value.type.name == "Variant(String, UInt32)"
+    finally:
+        with test_engine.begin() as conn:
+            conn.execute(text(f"DROP TABLE IF EXISTS {test_db}.{table_name}"))
 
 
 def test_table_exists(test_engine: Engine):

--- a/tests/integration_tests/test_sqlalchemy/test_reflect.py
+++ b/tests/integration_tests/test_sqlalchemy/test_reflect.py
@@ -5,7 +5,8 @@ from sqlalchemy.engine import Connection, Engine
 from sqlalchemy.exc import NoResultFound
 
 from clickhouse_connect import common
-from clickhouse_connect.cc_sqlalchemy.datatypes.sqltypes import Point, SimpleAggregateFunction, UInt32, Variant
+from clickhouse_connect.cc_sqlalchemy.datatypes.base import sqla_type_from_name
+from clickhouse_connect.cc_sqlalchemy.datatypes.sqltypes import Point, SimpleAggregateFunction, UInt32
 from clickhouse_connect.datatypes.format import clear_all_formats, set_default_formats
 
 
@@ -57,13 +58,14 @@ def test_variant_reflection(test_engine: Engine, test_db: str):
         conn.execute(text(f"CREATE TABLE {test_db}.{table_name} (id UInt32, value Variant(UInt32, String)) ENGINE MergeTree ORDER BY id"))
 
     try:
+        variant_type = sqla_type_from_name("Variant(UInt32, String)")
         columns = inspect(test_engine).get_columns(table_name, schema=test_db)
         reflected_type = next(column["type"] for column in columns if column["name"] == "value")
-        assert reflected_type.__class__ is Variant
+        assert reflected_type.__class__ is type(variant_type)
         assert reflected_type.name == "Variant(String, UInt32)"
 
         table = Table(table_name, MetaData(schema=test_db), autoload_with=test_engine)
-        assert table.c.value.type.__class__ is Variant
+        assert table.c.value.type.__class__ is type(variant_type)
         assert table.c.value.type.name == "Variant(String, UInt32)"
     finally:
         with test_engine.begin() as conn:

--- a/tests/unit_tests/test_sqlalchemy/test_alembic.py
+++ b/tests/unit_tests/test_sqlalchemy/test_alembic.py
@@ -333,6 +333,59 @@ def test_render_type_non_enum_containers_use_clickhouse_names():
     assert context.impl.render_type(types.Array(types.DateTime64(3, "UTC")), None) == "Array(DateTime64(3, 'UTC'))"
 
 
+def test_render_and_compare_variant_type():
+    context = MigrationContext.configure(dialect=ClickHouseDialect(), opts={"target_metadata": MetaData()})
+    variant = types.Variant(types.UInt32, types.String, types.UInt32)
+
+    rendered = context.impl.render_type(variant, None)
+    namespace = {}
+    exec("from clickhouse_connect.cc_sqlalchemy.datatypes.sqltypes import *", namespace)
+    rebuilt = eval(rendered, namespace)
+
+    assert rendered == "Variant(String, UInt32)"
+    assert rebuilt.name == variant.name
+
+    inspector_column = Column("value", sqla_type_from_name("Variant(UInt32, String)"), nullable=False)
+    matching_column = Column("value", types.Variant(types.String, types.UInt32, types.UInt32), nullable=False)
+    different_column = Column("value", types.Variant(types.String, types.UInt64), nullable=False)
+    assert context.impl.compare_type(inspector_column, matching_column) is False
+    assert context.impl.compare_type(inspector_column, different_column) is True
+
+
+@pytest.mark.parametrize(
+    "variant_type, expected_fragment",
+    [
+        (
+            types.Variant(types.Enum8(keys=["low", "high"], values=[1, 2]), types.UInt32),
+            "Enum8(keys=['low', 'high'], values=[1, 2])",
+        ),
+        (
+            types.Array(types.Variant(types.Enum8(keys=["low", "high"], values=[1, 2]), types.UInt32)),
+            "Enum8(keys=['low', 'high'], values=[1, 2])",
+        ),
+        (
+            sqla_type_from_name("Variant(Tuple(label String, count UInt32), UInt64)"),
+            "sqla_type_from_name(",
+        ),
+        (
+            sqla_type_from_name("Array(Variant(Tuple(label String, count UInt32), UInt64))"),
+            "sqla_type_from_name(",
+        ),
+    ],
+    ids=["enum", "array-enum", "named-tuple", "array-named-tuple"],
+)
+def test_render_variant_members_emit_lossless_python(variant_type, expected_fragment):
+    context = MigrationContext.configure(dialect=ClickHouseDialect(), opts={"target_metadata": MetaData()})
+
+    rendered = context.impl.render_type(variant_type, None)
+    namespace = {"sqla_type_from_name": sqla_type_from_name}
+    exec("from clickhouse_connect.cc_sqlalchemy.datatypes.sqltypes import *", namespace)
+    rebuilt = eval(compile(rendered, "<migration>", "eval"), namespace)
+
+    assert expected_fragment in rendered
+    assert rebuilt.name == variant_type.name
+
+
 @pytest.mark.parametrize(
     "type_name",
     [

--- a/tests/unit_tests/test_sqlalchemy/test_alembic.py
+++ b/tests/unit_tests/test_sqlalchemy/test_alembic.py
@@ -335,46 +335,52 @@ def test_render_type_non_enum_containers_use_clickhouse_names():
 
 def test_render_and_compare_variant_type():
     context = MigrationContext.configure(dialect=ClickHouseDialect(), opts={"target_metadata": MetaData()})
-    variant = types.Variant(types.UInt32, types.String, types.UInt32)
+    variant = sqla_type_from_name("Variant(UInt32, String, UInt32)")
 
     rendered = context.impl.render_type(variant, None)
-    namespace = {}
-    exec("from clickhouse_connect.cc_sqlalchemy.datatypes.sqltypes import *", namespace)
+    namespace = {"sqla_type_from_name": sqla_type_from_name}
     rebuilt = eval(rendered, namespace)
 
-    assert rendered == "Variant(String, UInt32)"
+    assert rendered == "sqla_type_from_name('Variant(String, UInt32)')"
     assert rebuilt.name == variant.name
 
     inspector_column = Column("value", sqla_type_from_name("Variant(UInt32, String)"), nullable=False)
-    matching_column = Column("value", types.Variant(types.String, types.UInt32, types.UInt32), nullable=False)
-    different_column = Column("value", types.Variant(types.String, types.UInt64), nullable=False)
+    matching_column = Column("value", sqla_type_from_name("Variant(String, UInt32, UInt32)"), nullable=False)
+    different_column = Column("value", sqla_type_from_name("Variant(String, UInt64)"), nullable=False)
     assert context.impl.compare_type(inspector_column, matching_column) is False
     assert context.impl.compare_type(inspector_column, different_column) is True
 
 
 @pytest.mark.parametrize(
-    "variant_type, expected_fragment",
+    "variant_type",
     [
-        (
-            types.Variant(types.Enum8(keys=["low", "high"], values=[1, 2]), types.UInt32),
-            "Enum8(keys=['low', 'high'], values=[1, 2])",
-        ),
-        (
-            types.Array(types.Variant(types.Enum8(keys=["low", "high"], values=[1, 2]), types.UInt32)),
-            "Enum8(keys=['low', 'high'], values=[1, 2])",
-        ),
-        (
-            sqla_type_from_name("Variant(Tuple(label String, count UInt32), UInt64)"),
-            "sqla_type_from_name(",
-        ),
-        (
-            sqla_type_from_name("Array(Variant(Tuple(label String, count UInt32), UInt64))"),
-            "sqla_type_from_name(",
-        ),
+        sqla_type_from_name("Variant(Enum8('low' = 1, 'high' = 2), UInt32)"),
+        sqla_type_from_name("Array(Variant(Enum8('low' = 1, 'high' = 2), UInt32))"),
+        sqla_type_from_name("Map(String, Variant(UInt32, String))"),
+        sqla_type_from_name("Tuple(Variant(UInt32, String), UInt64)"),
+        sqla_type_from_name("Array(Tuple(Variant(UInt32, String), UInt64))"),
+        sqla_type_from_name("Variant(BFloat16, String)"),
+        sqla_type_from_name("Array(Variant(BFloat16, String))"),
+        sqla_type_from_name("Map(String, Variant(BFloat16, String))"),
+        sqla_type_from_name("Tuple(Variant(BFloat16, String), UInt64)"),
+        sqla_type_from_name("Variant(Tuple(label String, count UInt32), UInt64)"),
+        sqla_type_from_name("Array(Variant(Tuple(label String, count UInt32), UInt64))"),
     ],
-    ids=["enum", "array-enum", "named-tuple", "array-named-tuple"],
+    ids=[
+        "enum",
+        "array-enum",
+        "map",
+        "tuple",
+        "array-tuple",
+        "bfloat16",
+        "array-bfloat16",
+        "map-bfloat16",
+        "tuple-bfloat16",
+        "named-tuple",
+        "array-named-tuple",
+    ],
 )
-def test_render_variant_members_emit_lossless_python(variant_type, expected_fragment):
+def test_render_variant_types_use_reflection_factory(variant_type):
     context = MigrationContext.configure(dialect=ClickHouseDialect(), opts={"target_metadata": MetaData()})
 
     rendered = context.impl.render_type(variant_type, None)
@@ -382,7 +388,8 @@ def test_render_variant_members_emit_lossless_python(variant_type, expected_frag
     exec("from clickhouse_connect.cc_sqlalchemy.datatypes.sqltypes import *", namespace)
     rebuilt = eval(compile(rendered, "<migration>", "eval"), namespace)
 
-    assert expected_fragment in rendered
+    assert "sqla_type_from_name(" in rendered
+    assert "Variant(" in rendered
     assert rebuilt.name == variant_type.name
 
 

--- a/tests/unit_tests/test_sqlalchemy/test_types.py
+++ b/tests/unit_tests/test_sqlalchemy/test_types.py
@@ -30,6 +30,7 @@ from clickhouse_connect.cc_sqlalchemy.datatypes.sqltypes import (
     Tuple,
     UInt32,
     UInt64,
+    Variant,
 )
 from clickhouse_connect.cc_sqlalchemy.datatypes.sqltypes import DateTime as ChDateTime
 from clickhouse_connect.cc_sqlalchemy.ddl.tableengine import MergeTree
@@ -173,6 +174,58 @@ def test_tuple_adapt_preserves_type_def():
     adapted = source.adapt(type(source))
     assert adapted.type_def == source.type_def
     assert adapted.name == source.name
+
+
+@pytest.mark.parametrize(
+    "type_name, expected_class, expected_name",
+    [
+        ("Variant(UInt32, String)", Variant, "Variant(String, UInt32)"),
+        ("vArIaNt(UInt64, String)", Variant, "Variant(String, UInt64)"),
+        ("aRrAy(Variant(UInt32, String))", Array, "Array(Variant(String, UInt32))"),
+        ("Tuple(Variant(UInt32, String), UInt64)", Tuple, "Tuple(Variant(String, UInt32), UInt64)"),
+        (
+            "Array(Tuple(Variant(UInt32, String), UInt64))",
+            Array,
+            "Array(Tuple(Variant(String, UInt32), UInt64))",
+        ),
+        ("Nullable(Variant(UInt32, String))", Variant, "Nullable(Variant(String, UInt32))"),
+    ],
+)
+def test_variant_reflection_factory(type_name, expected_class, expected_name):
+    variant = sqla_type_from_name(type_name)
+
+    assert variant.__class__ is expected_class
+    assert variant.name == expected_name
+
+
+def test_variant_constructor_canonicalizes_members():
+    variant = Variant(UInt32, String(), UInt32)
+
+    assert variant.name == "Variant(String, UInt32)"
+    assert variant.type_def.values == ("String", "UInt32")
+    assert variant.python_type is object
+    assert Variant(elements=[UInt64, String]).name == "Variant(String, UInt64)"
+
+
+def test_variant_both_positional_and_kwarg_raises():
+    with pytest.raises(ArgumentError):
+        Variant(UInt32, elements=[String])
+
+
+def test_variant_requires_member_types():
+    with pytest.raises(ArgumentError, match="at least one"):
+        Variant()
+    with pytest.raises(ArgumentError, match="at least one"):
+        Variant(elements=[])
+
+
+def test_variant_copy_adapt_and_dialect_impl_preserve_members():
+    source = Variant(UInt32, String)
+
+    for copied in (source.copy(), source.adapt(Variant), source.dialect_impl(ClickHouseDialect())):
+        assert copied.__class__ is Variant
+        assert copied.name == source.name
+        assert copied.type_def == source.type_def
 
 
 @pytest.mark.parametrize(

--- a/tests/unit_tests/test_sqlalchemy/test_types.py
+++ b/tests/unit_tests/test_sqlalchemy/test_types.py
@@ -30,7 +30,6 @@ from clickhouse_connect.cc_sqlalchemy.datatypes.sqltypes import (
     Tuple,
     UInt32,
     UInt64,
-    Variant,
 )
 from clickhouse_connect.cc_sqlalchemy.datatypes.sqltypes import DateTime as ChDateTime
 from clickhouse_connect.cc_sqlalchemy.ddl.tableengine import MergeTree
@@ -49,7 +48,21 @@ def test_all_matches_schema_types():
     from clickhouse_connect.cc_sqlalchemy.datatypes import sqltypes
     from clickhouse_connect.cc_sqlalchemy.datatypes.base import schema_types
 
-    assert sqltypes.__all__ == sorted(schema_types) + ["LowCardinality", "Nullable"]
+    public_schema_types = [name for name in schema_types if sqla_type_map[name].__name__ == name]
+    private_schema_types = set(schema_types) - set(public_schema_types)
+
+    assert private_schema_types == {"Variant"}
+    assert sqltypes.__all__ == sorted(public_schema_types) + ["LowCardinality", "Nullable"]
+
+
+def test_variant_is_reflection_only():
+    from clickhouse_connect.cc_sqlalchemy import types
+    from clickhouse_connect.cc_sqlalchemy.datatypes import sqltypes
+
+    assert not hasattr(sqltypes, "Variant")
+    assert not hasattr(types, "Variant")
+    with pytest.raises(ImportError):
+        exec("from clickhouse_connect.cc_sqlalchemy.types import Variant")
 
 
 def test_sqla():
@@ -179,8 +192,8 @@ def test_tuple_adapt_preserves_type_def():
 @pytest.mark.parametrize(
     "type_name, expected_class, expected_name",
     [
-        ("Variant(UInt32, String)", Variant, "Variant(String, UInt32)"),
-        ("vArIaNt(UInt64, String)", Variant, "Variant(String, UInt64)"),
+        ("Variant(UInt32, String)", sqla_type_map["Variant"], "Variant(String, UInt32)"),
+        ("vArIaNt(UInt64, String)", sqla_type_map["Variant"], "Variant(String, UInt64)"),
         ("aRrAy(Variant(UInt32, String))", Array, "Array(Variant(String, UInt32))"),
         ("Tuple(Variant(UInt32, String), UInt64)", Tuple, "Tuple(Variant(String, UInt32), UInt64)"),
         (
@@ -188,7 +201,7 @@ def test_tuple_adapt_preserves_type_def():
             Array,
             "Array(Tuple(Variant(String, UInt32), UInt64))",
         ),
-        ("Nullable(Variant(UInt32, String))", Variant, "Nullable(Variant(String, UInt32))"),
+        ("Nullable(Variant(UInt32, String))", sqla_type_map["Variant"], "Nullable(Variant(String, UInt32))"),
     ],
 )
 def test_variant_reflection_factory(type_name, expected_class, expected_name):
@@ -198,32 +211,29 @@ def test_variant_reflection_factory(type_name, expected_class, expected_name):
     assert variant.name == expected_name
 
 
-def test_variant_constructor_canonicalizes_members():
-    variant = Variant(UInt32, String(), UInt32)
+def test_variant_subclass_does_not_replace_schema_registration():
+    from clickhouse_connect.cc_sqlalchemy.datatypes.base import schema_types
 
-    assert variant.name == "Variant(String, UInt32)"
-    assert variant.type_def.values == ("String", "UInt32")
-    assert variant.python_type is object
-    assert Variant(elements=[UInt64, String]).name == "Variant(String, UInt64)"
+    original_variant = sqla_type_map["Variant"]
+    original_schema_types = schema_types.copy()
+    original_type_map = dict(sqla_type_map)
 
-
-def test_variant_both_positional_and_kwarg_raises():
-    with pytest.raises(ArgumentError):
-        Variant(UInt32, elements=[String])
-
-
-def test_variant_requires_member_types():
-    with pytest.raises(ArgumentError, match="at least one"):
-        Variant()
-    with pytest.raises(ArgumentError, match="at least one"):
-        Variant(elements=[])
+    try:
+        type("_DerivedVariant", (original_variant,), {})
+        assert sqla_type_map["Variant"] is original_variant
+        assert schema_types.count("Variant") == original_schema_types.count("Variant")
+    finally:
+        schema_types[:] = original_schema_types
+        sqla_type_map.clear()
+        sqla_type_map.update(original_type_map)
 
 
 def test_variant_copy_adapt_and_dialect_impl_preserve_members():
-    source = Variant(UInt32, String)
+    source = sqla_type_from_name("Variant(UInt32, String)")
+    variant_class = type(source)
 
-    for copied in (source.copy(), source.adapt(Variant), source.dialect_impl(ClickHouseDialect())):
-        assert copied.__class__ is Variant
+    for copied in (source.copy(), source.adapt(variant_class), source.dialect_impl(ClickHouseDialect())):
+        assert copied.__class__ is variant_class
         assert copied.name == source.name
         assert copied.type_def == source.type_def
 


### PR DESCRIPTION
## Summary

- Fix Inspector and Table reflection for standalone `Variant` columns
- Render standalone and composed `Variant` types losslessly in Alembic
- Keep the reflection implementation private so the public typing surface remains unchanged

Closes #989

## Checklist
Delete items not relevant to your PR:
- [X] Unit and integration tests covering the common scenarios were added
- [X] A human-readable description of the changes was provided to include in CHANGELOG
- [X] For significant changes, documentation in https://github.com/ClickHouse/clickhouse-docs was updated with further explanations or tutorials
