### PR TITLE
Handle overlapping JSON paths in _nest_value

### DIFF
--- a/clickhouse_connect/datatypes/dynamic.py
+++ b/clickhouse_connect/datatypes/dynamic.py
@@ -50,7 +50,12 @@ def _nest_value(target: dict, path: str, value) -> None:
     item = target
     for key in chain[:-1]:
         child = item.get(key)
-        if child is None:
+        if not isinstance(child, dict):
+            if child is not None and value is None:
+                # A shallower path already holds a scalar here and this deeper
+                # path holds nothing, so there is nothing to nest.  Keep the
+                # scalar instead of replacing it with an all-null container.
+                return
             child = {}
             item[key] = child
         item = child

--- a/tests/unit_tests/test_dynamic.py
+++ b/tests/unit_tests/test_dynamic.py
@@ -89,3 +89,32 @@ def test_dynamic_prefix_sorts_shared_variant():
 
     column = read_variant_column(source, 1, ctx, state.variant_types, state.variant_states)
     assert column == [100]
+
+
+def _nest_all(pairs):
+    target = {}
+    for path, value in pairs:
+        dynamic._nest_value(target, path, value)
+    return target
+
+
+def test_nest_value_overlapping_path_deeper_holds_nothing():
+    # JSON(a Int64, a.b Nullable(Int64)) with the row {"a":5}.  typed_paths is
+    # sorted, so "a" is written before "a.b" and the walk used to hit the int.
+    assert _nest_all([("a", 5), ("a.b", None)]) == {"a": 5}
+
+
+def test_nest_value_overlapping_path_deeper_holds_value():
+    # Same column with {"a":5,"a.b":7}.  A scalar and an object cannot share a
+    # key, so the deeper path wins, matching the later-write-wins order below.
+    assert _nest_all([("a", 5), ("a.b", 7)]) == {"a": {"b": 7}}
+
+
+def test_nest_value_scalar_written_last_still_wins():
+    assert _nest_all([("a.b", None), ("a", 5)]) == {"a": 5}
+    assert _nest_all([("a.b", 7), ("a", 5)]) == {"a": 5}
+
+
+def test_nest_value_non_overlapping_paths_unchanged():
+    assert _nest_all([("a.b", None)]) == {"a": {"b": None}}
+    assert _nest_all([("a.b.c", 1), ("a.b.d", 2)]) == {"a": {"b": {"c": 1, "d": 2}}}


### PR DESCRIPTION
Closes #997.

`JSON(a Int64, a.b Nullable(Int64))` declares `a` both as a value and as the
parent of `a.b`. `JSON._build_from_name` sorts `typed_paths`, so `a` is always
written before `a.b`, and `_nest_value`'s parent walk only handled
`child is None`. Walking through the int raised:

```
TypeError: 'int' object does not support item assignment
```

That escaped the codec through `transform.parse_response` and aborted the whole
query, including columns unrelated to the JSON value.

Behavior now:

| paths written | result |
| --- | --- |
| `a=5`, then `a.b=None` | `{'a': 5}` |
| `a=5`, then `a.b=7` | `{'a': {'b': 7}}` |
| `a.b=None`, then `a=5` | `{'a': 5}` (unchanged) |

A deeper path that holds nothing gives way to the scalar, which is what the
issue's server row asserts. When it does hold a value the deeper path wins,
since a scalar and an object cannot share a key, and that is the same
later-write-wins rule the already-working reverse order produces.

Four regression tests added; two fail without the change. No change to the 17
pre-existing failures (missing optional `pyarrow` and `alembic`).
