### PR TITLE
Bracket IPv6 hosts when building the connection URI

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@
 - `Time64` negative timedelta inserts previously stored incorrect values. `Time64` NumPy timedelta inserts previously stored wrong magnitudes. Both now store correct tick values, and out-of-range NumPy values are rejected instead of incorrectly wrapping.
 - Pandas `Timedelta` values in `Time` and `Time64` row inserts now convert like `timedelta`. Nullable timedelta DataFrame columns now insert missing values as `NULL` on Pandas 3 instead of raising `TypeError`.
 - SQLAlchemy column DDL now compiles `TypeDecorator` and `with_variant()` types through the active ClickHouse dialect. Dialect-aware types such as a decorator that selects `DateTime64(6, 'UTC')` no longer fall back to generic `DATETIME` in `CREATE TABLE` and related column DDL. Closes [#984](https://github.com/ClickHouse/clickhouse-connect/issues/984).
+- IPv6 hosts are now bracketed when building the connection URI, so `get_client(host="2001:db8::1")` connects instead of producing an unusable URI where the first colon of the address reads as the port separator. Applies to both the sync and async clients. Closes [#998](https://github.com/ClickHouse/clickhouse-connect/issues/998).
 
 ### Compatibility
 

--- a/clickhouse_connect/driver/asyncclient.py
+++ b/clickhouse_connect/driver/asyncclient.py
@@ -54,6 +54,7 @@ from clickhouse_connect.driver.common import (
     coerce_bool,
     coerce_show_clickhouse_errors,
     dict_copy,  # noqa: F401  (compatibility re-export)
+    format_uri_host,
 )
 from clickhouse_connect.driver.ctypes import RespBuffCls
 from clickhouse_connect.driver.exceptions import DataError, ProgrammingError
@@ -163,7 +164,7 @@ class AsyncClient(Client):
         proxy_path = proxy_path.lstrip("/")
         if proxy_path:
             proxy_path = "/" + proxy_path
-        self.uri = f"{interface}://{host}:{port}{proxy_path}"
+        self.uri = f"{interface}://{format_uri_host(host)}:{port}{proxy_path}"
         self.url = self.uri
         self._rename_response_column = rename_response_column
         self._initial_settings = settings

--- a/clickhouse_connect/driver/common.py
+++ b/clickhouse_connect/driver/common.py
@@ -1,5 +1,6 @@
 import array
 import asyncio
+import ipaddress
 import logging
 import struct
 import sys
@@ -11,6 +12,23 @@ from clickhouse_connect.driver.exceptions import DataError, ProgrammingError, St
 from clickhouse_connect.driver.types import Closable
 
 logger = logging.getLogger(__name__)
+
+
+def format_uri_host(host: str) -> str:
+    """Bracket a bare IPv6 literal so it can be used in a URI authority.
+
+    RFC 3986 3.2.2 requires the brackets, without them the first colon of the
+    address reads as the port separator.  Host names, IPv4 literals and hosts
+    that are already bracketed are returned unchanged, since ip_address
+    rejects all three.
+    """
+    try:
+        if isinstance(ipaddress.ip_address(host), ipaddress.IPv6Address):
+            return f"[{host}]"
+    except ValueError:
+        pass
+    return host
+
 
 must_swap = sys.byteorder == "big"
 int_size = array.array("i").itemsize

--- a/clickhouse_connect/driver/common.py
+++ b/clickhouse_connect/driver/common.py
@@ -18,9 +18,10 @@ def format_uri_host(host: str) -> str:
     """Bracket a bare IPv6 literal so it can be used in a URI authority.
 
     RFC 3986 3.2.2 requires the brackets, without them the first colon of the
-    address reads as the port separator.  Host names, IPv4 literals and hosts
-    that are already bracketed are returned unchanged, since ip_address
-    rejects all three.
+    address reads as the port separator.  Host names and already bracketed
+    hosts are not valid arguments to ip_address, and an IPv4 literal parses but
+    is not an IPv6Address, so all three are returned unchanged.  A zone id such
+    as fe80::1%lo0 does parse as an IPv6Address and is bracketed.
     """
     try:
         if isinstance(ipaddress.ip_address(host), ipaddress.IPv6Address):

--- a/clickhouse_connect/driver/httpclient.py
+++ b/clickhouse_connect/driver/httpclient.py
@@ -31,6 +31,7 @@ from clickhouse_connect.driver.common import (
     coerce_show_clickhouse_errors,
     dict_add,
     dict_copy,
+    format_uri_host,
 )
 from clickhouse_connect.driver.exceptions import ProgrammingError
 from clickhouse_connect.driver.httputil import (
@@ -114,7 +115,7 @@ class HttpClient(SyncBackendClient):
         proxy_path = proxy_path.lstrip("/")
         if proxy_path:
             proxy_path = "/" + proxy_path
-        self.url = f"{interface}://{host}:{port}{proxy_path}"
+        self.url = f"{interface}://{format_uri_host(host)}:{port}{proxy_path}"
         client_headers: dict[str, str] = {}
         self.params = dict_copy(HttpClient.params)
         ch_settings = dict_copy(settings, self.params)

--- a/tests/unit_tests/test_driver/test_httpclient.py
+++ b/tests/unit_tests/test_driver/test_httpclient.py
@@ -1602,3 +1602,46 @@ class TestInsertArrowTransportSettings:
             await client.insert_arrow("some_table", Mock(), transport_settings=transport)
         assert raw_insert.call_args.kwargs.get("transport_settings") == transport
         assert transport not in raw_insert.call_args.args
+
+
+class TestIPv6HostBrackets:
+    """RFC 3986 3.2.2: an IPv6 literal in a URI authority must be bracketed."""
+
+    @staticmethod
+    def _url(host: str) -> str:
+        with patch.object(Client, "_init_common_settings", autospec=True):
+            client = HttpClient(
+                interface="http",
+                host=host,
+                port=8123,
+                username="default",
+                password="",
+                database="default",
+            )
+        return client.url
+
+    def test_ipv6_host_is_bracketed(self):
+        # Without the brackets the first colon of the address reads as the
+        # port separator, so the client never reaches the server.
+        assert self._url("2001:db8::1") == "http://[2001:db8::1]:8123"
+        assert self._url("::1") == "http://[::1]:8123"
+
+    def test_already_bracketed_host_is_left_alone(self):
+        assert self._url("[2001:db8::1]") == "http://[2001:db8::1]:8123"
+
+    def test_names_and_ipv4_are_unchanged(self):
+        assert self._url("localhost") == "http://localhost:8123"
+        assert self._url("127.0.0.1") == "http://127.0.0.1:8123"
+        assert self._url("play.clickhouse.com") == "http://play.clickhouse.com:8123"
+
+    def test_async_client_uri_is_bracketed_too(self):
+        with patch.object(Client, "_init_common_settings", autospec=True):
+            client = AsyncClient(
+                interface="http",
+                host="2001:db8::1",
+                port=8123,
+                username="default",
+                password="",
+                database="default",
+            )
+        assert client.uri == "http://[2001:db8::1]:8123"


### PR DESCRIPTION
Closes #998.

The connection URI was built by plain concatenation, so `host='2001:db8::1'`
produced `http://2001:db8::1:8123`. RFC 3986 3.2.2 requires an IPv6 literal in
the authority to be bracketed. Without them the first colon of the address reads
as the port separator, so connecting by IPv6 address never worked.

`format_uri_host` in `driver/common.py` brackets a bare IPv6 literal and returns
everything else untouched, since `ipaddress.ip_address` rejects host names, IPv4
literals and already-bracketed hosts alike. That makes it idempotent, so a user
who already passes `[2001:db8::1]` is unaffected.

Applied at both sites the issue asks about:

| | before | after |
| --- | --- | --- |
| `httpclient.py` | `http://2001:db8::1:8123` | `http://[2001:db8::1]:8123` |
| `asyncclient.py` | same | same |

I left the third concatenation, `httputil.check_env_proxy`, alone: it matches a
bare host against `NO_PROXY` entries rather than building a URI, and those
entries are conventionally written unbracketed.

Four regression tests added against both clients; they fail without the change.
`pytest tests/unit_tests` goes from 1444 to 1448 passing with the 37
pre-existing failures unchanged.

Not addressed here: the `encode_basic_auth` suggestion in the issue comments is
a separate concern from URI construction, so it seemed better left to its own PR.
