### PR TITLE
Do not bulk insert a VALUES list holding expressions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@
 - `Time64` negative timedelta inserts previously stored incorrect values. `Time64` NumPy timedelta inserts previously stored wrong magnitudes. Both now store correct tick values, and out-of-range NumPy values are rejected instead of incorrectly wrapping.
 - Pandas `Timedelta` values in `Time` and `Time64` row inserts now convert like `timedelta`. Nullable timedelta DataFrame columns now insert missing values as `NULL` on Pandas 3 instead of raising `TypeError`.
 - SQLAlchemy column DDL now compiles `TypeDecorator` and `with_variant()` types through the active ClickHouse dialect. Dialect-aware types such as a decorator that selects `DateTime64(6, 'UTC')` no longer fall back to generic `DATETIME` in `CREATE TABLE` and related column DDL. Closes [#984](https://github.com/ClickHouse/clickhouse-connect/issues/984).
+- The DB-API `executemany` bulk insert path no longer takes a `VALUES` list holding anything but parameter slots. `VALUES (%s, hex(%s))` previously wrote the raw parameter into the column and dropped the function with no error. Such statements now fall back to the row by row path so the server evaluates them. Closes [#934](https://github.com/ClickHouse/clickhouse-connect/issues/934).
 
 ### Compatibility
 

--- a/clickhouse_connect/dbapi/cursor.py
+++ b/clickhouse_connect/dbapi/cursor.py
@@ -14,6 +14,12 @@ from clickhouse_connect.driver.query import remove_sql_comments
 logger = logging.getLogger(__name__)
 
 insert_re = re.compile(r"^\s*INSERT\s+INTO\s+(.*$)", re.IGNORECASE)
+# The block writer carries one value per named column, so it can only take a
+# values list of bare parameter slots: pyformat placeholders or a server side
+# {name:Type} binding. Anything else in there, a function call or a literal,
+# has to be evaluated by the server.
+_PLACEHOLDER = r"%s|%\([^)]*\)s|\{[^{}]*\}"
+placeholders_only_re = re.compile(rf"\(\s*(?:{_PLACEHOLDER})\s*(?:,\s*(?:{_PLACEHOLDER})\s*)*\)\s*;?\s*")
 str_type = get_from_name("String")
 int_type = get_from_name("Int32")
 _IMPLICIT_NULLABLE_BASE_TYPES = frozenset(("Dynamic", "Variant"))
@@ -164,7 +170,15 @@ class Cursor:
             _, op_columns, temp = parse_callable(temp)
         else:
             op_columns = None
-        if "VALUES" not in temp.upper():
+        values_idx = temp.upper().find("VALUES")
+        if values_idx < 0:
+            return False
+        # A values list that is not placeholders-only must keep the original
+        # statement so the server evaluates it, which is what the row by row
+        # path in executemany already does. A bare VALUES with no list at all
+        # is what the SQLAlchemy dialect emits, and carries nothing to lose.
+        values_text = temp[values_idx + len("VALUES") :].strip()
+        if values_text and not placeholders_only_re.fullmatch(values_text):
             return False
         if not isinstance(data, Sequence) or len(data) == 0:
             return False

--- a/tests/unit_tests/test_driver/test_cursor.py
+++ b/tests/unit_tests/test_driver/test_cursor.py
@@ -637,3 +637,44 @@ def test_executemany_generator_falls_through_to_row_by_row():
 
     client.insert.assert_not_called()
     assert client.query.call_count == 2
+
+
+@pytest.mark.parametrize(
+    "values_list",
+    [
+        "(%s, hex(%s))",  # function wrapping a placeholder, counts still match
+        "(%s, hex(unhex('AB')))",  # expression consuming no placeholder
+        "(%s, now())",
+        "(%s, 'literal')",
+        "(1, 2)",
+    ],
+)
+def test_executemany_expression_values_skip_bulk_insert(values_list):
+    """A values list holding anything but placeholders has to reach the server
+    as SQL, otherwise the expression is dropped and the raw parameter is
+    written straight into the column.
+    """
+    client = Mock()
+    client.query.return_value = create_mock_query_result([])
+    cursor = Cursor(client)
+
+    cursor.executemany(f"INSERT INTO test_table (v1, v2) VALUES {values_list}", [(1, "AB")])
+
+    client.insert.assert_not_called()
+    client.query.assert_called()
+
+
+@pytest.mark.parametrize(
+    "values_list",
+    ["(%s, %s)", "(%s,%s)", "( %s , %s )", "(%(v1)s, %(v2)s)", "(%s, %s);"],
+)
+def test_executemany_placeholder_values_still_bulk_insert(values_list):
+    """Placeholders-only values lists keep the fast path."""
+    client = Mock()
+    cursor = Cursor(client)
+    rows = [{"v1": 13, "v2": "user_1"}] if "%(" in values_list else [(13, "user_1")]
+
+    cursor.executemany(f"INSERT INTO test_table (v1, v2) VALUES {values_list}", rows)
+
+    client.insert.assert_called_once()
+    client.query.assert_not_called()


### PR DESCRIPTION
Closes #934.

`_try_bulk_insert` checked only that the statement contained `VALUES`, never what
the values list held. The block writer carries one value per named column, so an
expression in there is lost:

| statement | before | after |
| --- | --- | --- |
| `VALUES (%s, hex(%s))` | raw parameter written to the column, no error | row by row, server evaluates `hex` |
| `VALUES (%s, hex(unhex('AB')))` | `Insert data column count does not match column names` | row by row, inserts correctly |

The first case is the bad one: wrong data, silently.

A values list now has to be parameter slots only. That means pyformat
placeholders and also server side `{name:Type}` bindings, which the existing
`test_executemany_bulk_insert_keeps_percents_for_server_side_statements` covers
and which my first attempt broke. Anything else falls through to the row by row
path, which already substitutes and lets the server evaluate the expression.

One case worth calling out: a bare `VALUES` with no list at all keeps the fast
path, because that is what the SQLAlchemy dialect emits and there is no
expression to lose. `test_cursor_bulk_insert_forwards_settings` caught that.

Ten parametrized tests added, five for the fallback and five pinning the fast
path. `pytest tests/unit_tests` goes from 1453 to 1463 passing with the 37
pre-existing failures unchanged.
