### PR TITLE
Add a tuple read format for Map columns

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 - Generic `Enum` definitions are accepted and canonicalized to `Enum8` or `Enum16` by value range.
 - Root `Tuple()` query results now decode as empty tuples.
 - Type name parsing now handles double quoted identifiers and quoted string literals uniformly. Some type names that previously failed to parse now parse.
+- `Map` columns accept a `tuple` read format that returns every key/value pair as a list of tuples. ClickHouse stores a `Map` as `Array(Tuple(key, value))` and permits repeated keys, which the default `dict` representation silently collapses. The default read format stays `native` and still returns a `dict`, so existing behavior is unchanged. Enable it per query with `query_formats={'Map': 'tuple'}` or globally with `set_read_format('Map', 'tuple')`. Closes [#949](https://github.com/ClickHouse/clickhouse-connect/issues/949).
 
 ### Bug Fixes
 

--- a/clickhouse_connect/datatypes/container.py
+++ b/clickhouse_connect/datatypes/container.py
@@ -190,6 +190,9 @@ class Tuple(ClickHouseType):
 class Map(ClickHouseType):
     _slots = "key_type", "value_type", "_insert_name"
     python_type = dict
+    # A ClickHouse Map may hold the same key more than once, which a dict cannot
+    # represent. The tuple format returns every pair instead.
+    valid_formats = "tuple", "native"
 
     @property
     def insert_name(self):
@@ -225,10 +228,12 @@ class Map(ClickHouseType):
         total_rows = 0 if len(offsets) == 0 else offsets[-1]
         keys = self.key_type.read_column_data(source, total_rows, ctx, read_state[0])
         values = self.value_type.read_column_data(source, total_rows, ctx, read_state[1])
+        as_tuples = self.read_format(ctx) == "tuple"
         column = []
         prev = 0
         for offset in offsets:
-            column.append(dict(zip(keys[prev:offset], values[prev:offset])))
+            pairs = zip(keys[prev:offset], values[prev:offset])
+            column.append(list(pairs) if as_tuples else dict(pairs))
             prev = offset
         return column
 

--- a/tests/unit_tests/test_chtypes.py
+++ b/tests/unit_tests/test_chtypes.py
@@ -1,7 +1,12 @@
+import struct
 from datetime import timedelta, timezone
+
+import pytest
 
 from clickhouse_connect.datatypes.container import Nested
 from clickhouse_connect.datatypes.registry import get_from_name as gfn
+from clickhouse_connect.driver.buffer import ResponseBuffer
+from clickhouse_connect.driver.query import QueryContext
 
 
 def test_enum_parse():
@@ -58,3 +63,49 @@ def test_datetime_fixed_offset_negative_timezone():
 def test_datetime64_fixed_offset_timezone():
     dt64_type = gfn("DateTime64(3, 'Fixed/UTC+05:30:00')")
     assert dt64_type.tzinfo == timezone(timedelta(hours=5, minutes=30))
+
+
+def _read_column(type_name: str, payload: bytes, query_formats=None):
+    """Read a single row of `type_name` out of its native bytes."""
+    ch_type = gfn(type_name)
+    ctx = QueryContext(query_formats=query_formats)
+    source = ResponseBuffer(type("_Src", (), {"gen": iter([payload])})())
+    state = ch_type.read_column_prefix(source, ctx)
+    return ch_type.read_column_data(source, 1, ctx, state)[0]
+
+
+def _lstr(text: str) -> bytes:
+    encoded = text.encode()
+    return bytes([len(encoded)]) + encoded
+
+
+# One map holding two pairs that share a key, which ClickHouse permits: server
+# side a Map is an Array(Tuple(key, value)) and is never deduplicated.
+_DUP_MAP = struct.pack("Q", 2) + _lstr("k") + _lstr("k") + _lstr("1") + _lstr("2")
+_DUP_PAIRS = [("k", "1"), ("k", "2")]
+
+MAP_SHAPES = [
+    ("Map(String, String)", _DUP_MAP, {"k": "2"}, _DUP_PAIRS),
+    ("Array(Map(String, String))", struct.pack("Q", 1) + _DUP_MAP, [{"k": "2"}], [_DUP_PAIRS]),
+    (
+        "Map(String, Map(String, String))",
+        struct.pack("Q", 1) + _lstr("a") + _DUP_MAP,
+        {"a": {"k": "2"}},
+        [("a", _DUP_PAIRS)],
+    ),
+]
+
+
+@pytest.mark.parametrize("type_name, payload, native, tuples", MAP_SHAPES)
+def test_map_native_format_collapses_duplicate_keys(type_name, payload, native, tuples):
+    """The default stays a dict, so existing behavior is unchanged."""
+    assert _read_column(type_name, payload) == native
+
+
+@pytest.mark.parametrize("type_name, payload, native, tuples", MAP_SHAPES)
+def test_map_tuple_format_keeps_duplicate_keys(type_name, payload, native, tuples):
+    assert _read_column(type_name, payload, {"Map": "tuple"}) == tuples
+
+
+def test_map_tuple_format_is_declared_valid():
+    assert "tuple" in gfn("Map(String, String)").valid_formats


### PR DESCRIPTION
Closes #949.

A ClickHouse `Map` is not a unique-key collection, so materializing every one as
a Python `dict` drops pairs. This adds an opt-in `tuple` read format that returns
the pairs as a list of tuples.

I checked this against the server source rather than inferring it from a JSON
round trip. At `v26.3.21.7-lts`:

- `src/Columns/ColumnMap.h` describes `ColumnMap` as a column that stores a
  nested `Array(Tuple(key, value))` column
- `src/DataTypes/DataTypeMap.cpp` builds that nested type as
  `DataTypeArray(DataTypeTuple({key_type, value_type}, {"keys", "values"}))`
- neither file deduplicates keys anywhere

So a list of `(key, value)` tuples is the server's own representation, not a
convention I picked.

Behavior:

| read format | `map('k','1','k','2')` |
| --- | --- |
| `native` (default, unchanged) | `{'k': '2'}` |
| `tuple` | `[('k', '1'), ('k', '2')]` |

Enable per query with `query_formats={'Map': 'tuple'}` or globally with
`set_read_format('Map', 'tuple')`.

Tests are parametrized over the shapes the issue names: top level `Map`,
`Array(Map(...))`, and a `Map` nested as another map's value. Each shape is
asserted in both formats, so the `native` cases pin that the default did not
move. Four fail without the change. `pytest tests/unit_tests` goes from 1453 to
1460 passing with the 37 pre-existing failures unchanged, `ruff` and `mypy` are
clean on the changed files.

Not included: insert side handling of duplicate keys, and sync/async integration
coverage against a live server, which I could not run here. Happy to add the
integration tests if you want them in this PR.
