### PR TITLE
centralize ClickHouse type argument metadata

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Improvements
 
+- SQLAlchemy JSON typed-path validation now reads ClickHouse type arity and numeric bounds from shared driver metadata. Invalid hints that combine a wrong outer argument count with a malformed surplus nested argument now report the outer arity error instead of the nested parsing error. Accepted hints and canonical type names are unchanged. Closes [#990](https://github.com/ClickHouse/clickhouse-connect/issues/990).
 - SQLAlchemy `JSON` columns can now declare ClickHouse typed paths with `typed_paths={...}` or simple keyword shorthand, plus dynamic path and type limits and plain and regular expression skip rules. JSON arguments use the same canonical ordering as server reflection. Alembic autogeneration renders configured JSON types as valid Python and round-trips them without a follow-up type migration. Closes [#981](https://github.com/ClickHouse/clickhouse-connect/issues/981).
 - Driver `JSON` type names now use the server's canonical argument ordering, omit explicit default limits, and expose decoded `skip_paths` and `skip_regexps`. This changes the `.name` and skips values reflected to all driver users.
 - `Time64` now accepts every server-valid precision from 0 through 9 for parsing, reflection, native queries, and DataFrame inserts. NumPy and Pandas queries remain limited to precisions 0, 3, 6, and 9 and raise `ProgrammingError` otherwise.

--- a/clickhouse_connect/cc_sqlalchemy/datatypes/sqltypes.py
+++ b/clickhouse_connect/cc_sqlalchemy/datatypes/sqltypes.py
@@ -843,8 +843,9 @@ class JSON(ChSqlaType, UserDefinedType):  # type: ignore[misc]
             return
         elif type_base in ("decimal32", "decimal64", "decimal128", "decimal256"):
             assert type_args is not None
-            _, maximum = _integer_bounds(type_args, 0)
-            if not _has_valid_arity(type_args, len(args)) or not _is_integer_in_bounds(args[0], _integer_bounds(type_args, 0)):
+            bounds = _integer_bounds(type_args, 0)
+            _, maximum = bounds
+            if not _has_valid_arity(type_args, len(args)) or not _is_integer_in_bounds(args[0], bounds):
                 raise ArgumentError(f"{base} requires one scale from 0 through {maximum}")
             return
         elif type_base == "qbit":

--- a/clickhouse_connect/cc_sqlalchemy/datatypes/sqltypes.py
+++ b/clickhouse_connect/cc_sqlalchemy/datatypes/sqltypes.py
@@ -30,53 +30,44 @@ from sqlalchemy.types import (
 
 from clickhouse_connect.cc_sqlalchemy.datatypes.base import ChSqlaType, sqla_type_from_name
 from clickhouse_connect.cc_sqlalchemy.sql.clauses import json_subcolumn
-from clickhouse_connect.datatypes.base import EMPTY_TYPE_DEF, LC_TYPE_DEF, NULLABLE_TYPE_DEF, TypeDef
+from clickhouse_connect.datatypes.base import EMPTY_TYPE_DEF, LC_TYPE_DEF, NULLABLE_TYPE_DEF, TypeDef, _TypeArgs
 from clickhouse_connect.datatypes.dynamic import Variant as ChVariant
 from clickhouse_connect.datatypes.numeric import Enum8 as ChEnum8
 from clickhouse_connect.datatypes.numeric import Enum16 as ChEnum16
-from clickhouse_connect.datatypes.registry import get_from_name, type_map
+from clickhouse_connect.datatypes.registry import _WRAPPER_TYPE_ARGS, get_from_name, type_map
+from clickhouse_connect.datatypes.vector import QBit as ChQBit
 from clickhouse_connect.driver import tzutil
 from clickhouse_connect.driver.binding import _format_identifier, format_str
 from clickhouse_connect.driver.common import decimal_prec, unescape_identifier
-from clickhouse_connect.driver.exceptions import ClickHouseError
+from clickhouse_connect.driver.exceptions import ClickHouseError, InternalError
 from clickhouse_connect.driver.parser import parse_callable, parse_columns, parse_enum
 
 _T = TypeVar("_T")
 
-_PARAMETERIZED_TYPE_NAMES = frozenset(
-    {
-        "aggregatefunction",
-        "array",
-        "datetime",
-        "datetime64",
-        "decimal",
-        "decimal32",
-        "decimal64",
-        "decimal128",
-        "decimal256",
-        "dynamic",
-        "enum",
-        "enum8",
-        "enum16",
-        "fixedstring",
-        "json",
-        "lowcardinality",
-        "map",
-        "nested",
-        "nullable",
-        "qbit",
-        "simpleaggregatefunction",
-        "time64",
-        "tuple",
-        "variant",
-    }
-)
-_ZERO_ARGUMENT_TYPE_NAMES = frozenset(name.lower() for name in type_map) - _PARAMETERIZED_TYPE_NAMES
+_TYPE_ARGS = {name.lower(): ch_type._type_args for name, ch_type in type_map.items()}
+_TYPE_ARGS.update({name.lower(): type_args for name, type_args in _WRAPPER_TYPE_ARGS.items()})
+_ZERO_ARGUMENT_TYPE_NAMES = frozenset(name for name, type_args in _TYPE_ARGS.items() if type_args.min_args == 0 and type_args.max_args == 0)
 _CANONICAL_TYPE_NAMES = {name.lower(): name for name in type_map}
 _CANONICAL_TYPE_NAMES.update({"boolean": "Bool", "enum": "Enum", "lowcardinality": "LowCardinality", "nullable": "Nullable"})
 _INTERNAL_CODEC_TYPE_NAMES = frozenset({"shareddatastring", "sharedvariant"})
-_EMPTY_PARENTHESES_TYPE_NAMES = _ZERO_ARGUMENT_TYPE_NAMES | frozenset({"datetime", "dynamic", "json", "time", "tuple"})
-_DECIMAL_SCALE_MAX = {32: 9, 64: 18, 128: 38, 256: 76}
+
+
+def _has_valid_arity(type_args: _TypeArgs, arg_count: int) -> bool:
+    return arg_count >= type_args.min_args and (type_args.max_args is None or arg_count <= type_args.max_args)
+
+
+def _integer_bounds(type_args: _TypeArgs, index: int | str) -> tuple[int | None, int | None]:
+    bounds = type_args.bounds_for(index)
+    if bounds is None:
+        raise InternalError(f"Missing integer bounds for type argument {index!r}")
+    return bounds
+
+
+def _is_integer_in_bounds(value: object, bounds: tuple[int | None, int | None]) -> bool:
+    if not isinstance(value, int):
+        return False
+    minimum, maximum = bounds
+    return (minimum is None or value >= minimum) and (maximum is None or value <= maximum)
 
 
 class Int8(ChSqlaType, Integer):  # type: ignore[misc]
@@ -669,7 +660,8 @@ class JSON(ChSqlaType, UserDefinedType):  # type: ignore[misc]
             return "Tuple()"
         if type_base == "decimal" and not args:
             return "Decimal(10, 0)"
-        if not args and type_base in _EMPTY_PARENTHESES_TYPE_NAMES:
+        type_args = _TYPE_ARGS.get(type_base)
+        if not args and type_args is not None and type_args.min_args == 0:
             return canonical_base
         if type_base == "datetime" and args and isinstance(args[0], int):
             if args[0] == 0:
@@ -688,9 +680,9 @@ class JSON(ChSqlaType, UserDefinedType):  # type: ignore[misc]
                 canonical_base = "Time64"
                 type_base = "time64"
 
-        if type_base in ("array", "nullable", "lowcardinality", "map", "variant"):
-            values = [JSON._canonicalize_type_spelling(str(value)) for value in args]
-        elif type_base in ("tuple", "nested"):
+        type_args = _TYPE_ARGS.get(type_base)
+
+        if type_base in ("tuple", "nested"):
             names, raw_values = parse_columns(type_name[opening:], preserve_names=True)
             if names and len(names) != len(raw_values):
                 if type_base == "nested":
@@ -714,24 +706,23 @@ class JSON(ChSqlaType, UserDefinedType):  # type: ignore[misc]
                 if not quoted_name and path.upper() == "SKIP":
                     if JSON._starts_regexp_directive(value):
                         value = f"REGEXP {value[6:].lstrip()}"
-                elif not quoted_name and path in ("max_dynamic_paths", "max_dynamic_types"):
+                elif not quoted_name and type_args is not None and type_args.bounds_for(path) is not None:
                     pass
                 else:
                     value = JSON._canonicalize_type_spelling(value)
                 values.append(f"{name} {value}")
-        elif type_base in ("simpleaggregatefunction", "aggregatefunction"):
-            values = [str(args[0])] if args else []
-            values.extend(JSON._canonicalize_type_spelling(str(value)) for value in args[1:])
-        elif type_base == "qbit" and args:
-            values = [JSON._canonicalize_type_spelling(str(args[0]))]
-            values.extend(str(value) for value in args[1:])
         elif type_base in ("decimal32", "decimal64", "decimal128", "decimal256") and len(args) == 1:
-            size = int(type_base[7:])
-            return f"Decimal({_DECIMAL_SCALE_MAX[size]}, {args[0]})"
+            _, max_scale = _integer_bounds(_TYPE_ARGS[type_base], 0)
+            return f"Decimal({max_scale}, {args[0]})"
         elif type_base in ("enum", "enum8", "enum16"):
             return canonical_base + type_name[opening:]
         elif type_base == "decimal" and len(args) == 1:
             values = [str(args[0]), "0"]
+        elif type_args is not None:
+            nested_indexes = type_args.nested_indexes(len(args))
+            values = [
+                JSON._canonicalize_type_spelling(str(value)) if index in nested_indexes else str(value) for index, value in enumerate(args)
+            ]
         else:
             values = [str(value) for value in args]
         return f"{canonical_base}({', '.join(values)})"
@@ -746,6 +737,7 @@ class JSON(ChSqlaType, UserDefinedType):  # type: ignore[misc]
 
         type_base = base.lower()
         opening = type_name.find("(")
+        type_args = _TYPE_ARGS.get(type_base)
         if type_base in _INTERNAL_CODEC_TYPE_NAMES:
             raise ArgumentError(f"{base} is an internal codec type and cannot be used in DDL")
         if type_base in _ZERO_ARGUMENT_TYPE_NAMES:
@@ -753,16 +745,17 @@ class JSON(ChSqlaType, UserDefinedType):  # type: ignore[misc]
                 return
             raise ArgumentError(f"{base} does not accept these constructor arguments")
         nested_types: Sequence[str | int]
-        expected_arity = {"array": 1, "nullable": 1, "lowcardinality": 1, "map": 2}.get(type_base)
-        if expected_arity is not None:
-            if len(args) != expected_arity:
+        if type_args is not None and type_args.min_args == type_args.max_args and type_args.nested == tuple(range(type_args.min_args)):
+            expected_arity = type_args.min_args
+            if not _has_valid_arity(type_args, len(args)):
                 argument = "argument" if expected_arity == 1 else "arguments"
                 raise ArgumentError(f"{base} requires exactly {expected_arity} type {argument}")
-            nested_types = args
+            nested_types = tuple(args[index] for index in type_args.nested_indexes(len(args)))
         elif type_base in ("tuple", "variant", "nested"):
             if type_base == "tuple" and not args:
                 raise ArgumentError("Tuple() is not supported as a JSON typed path")
-            if opening == -1 or not args:
+            assert type_args is not None
+            if opening == -1 or not _has_valid_arity(type_args, len(args)):
                 raise ArgumentError(f"{base} requires constructor arguments")
             names, nested_types = parse_columns(type_name[opening:])
             if type_base == "tuple" and names and len(names) != len(nested_types):
@@ -771,9 +764,11 @@ class JSON(ChSqlaType, UserDefinedType):  # type: ignore[misc]
                 raise ArgumentError("Nested requires a name for every element")
             if type_base == "variant" and names:
                 raise ArgumentError("Variant members cannot be named")
+            nested_types = tuple(nested_types[index] for index in type_args.nested_indexes(len(nested_types)))
         elif type_base == "json":
             if opening == -1 or not args:
                 return
+            assert type_args is not None
             names, values = parse_columns(type_name[opening:], preserve_names=True)
             if len(names) != len(values):
                 raise ArgumentError("JSON type arguments must be named")
@@ -797,12 +792,14 @@ class JSON(ChSqlaType, UserDefinedType):  # type: ignore[misc]
                     if unescaped_skip_path.lower() == "regexp":
                         raise ArgumentError("JSON skip path 'REGEXP' conflicts with the SKIP REGEXP syntax")
                     continue
-                if not quoted_name and path in ("max_dynamic_paths", "max_dynamic_types"):
+                bounds = type_args.bounds_for(path)
+                if not quoted_name and bounds is not None:
                     try:
                         limit = int(value)
                     except (TypeError, ValueError):
                         raise ArgumentError(f"{path} must be an integer") from None
-                    maximum = 10000 if path == "max_dynamic_paths" else 254
+                    _, maximum = bounds
+                    assert maximum is not None
                     JSON._validate_limit(path, limit, maximum)
                     continue
                 json_nested_types.append(value)
@@ -810,42 +807,57 @@ class JSON(ChSqlaType, UserDefinedType):  # type: ignore[misc]
         elif type_base == "datetime":
             if opening == -1:
                 return
-            if len(args) != 1 or not isinstance(args[0], str) or not JSON._is_string_literal(args[0]):
+            assert type_args is not None
+            if len(args) != type_args.max_args or not isinstance(args[0], str) or not JSON._is_string_literal(args[0]):
                 raise ArgumentError("DateTime accepts one quoted timezone name")
             return
         elif type_base == "datetime64":
-            if len(args) not in (1, 2):
+            assert type_args is not None
+            if not _has_valid_arity(type_args, len(args)):
                 raise ArgumentError("DateTime64 requires a precision and optional quoted timezone name")
             precision = args[0]
-            if not isinstance(precision, int) or precision < 0 or precision > 9:
+            if not _is_integer_in_bounds(precision, _integer_bounds(type_args, 0)):
                 raise ArgumentError("DateTime64 precision must be an integer from 0 through 9")
             if len(args) == 2 and (not isinstance(args[1], str) or not JSON._is_string_literal(args[1])):
                 raise ArgumentError("DateTime64 timezone must be a quoted string literal")
             return
         elif type_base == "time64":
-            if len(args) != 1 or not isinstance(args[0], int) or args[0] < 0 or args[0] > 9:
+            assert type_args is not None
+            if not _has_valid_arity(type_args, len(args)) or not _is_integer_in_bounds(args[0], _integer_bounds(type_args, 0)):
                 raise ArgumentError("Time64 requires one precision value from 0 through 9")
             return
         elif type_base == "decimal":
-            if len(args) != 2 or any(not isinstance(arg, int) for arg in args):
+            assert type_args is not None
+            if not _has_valid_arity(type_args, len(args)) or any(not isinstance(arg, int) for arg in args):
                 raise ArgumentError("Decimal requires integer precision and scale arguments")
             precision = args[0]
             scale = args[1]
             assert isinstance(precision, int)
             assert isinstance(scale, int)
-            if precision < 1 or precision > 76 or scale < 0 or scale > precision:
+            if (
+                not _is_integer_in_bounds(precision, _integer_bounds(type_args, 0))
+                or not _is_integer_in_bounds(scale, _integer_bounds(type_args, 1))
+                or scale > precision
+            ):
                 raise ArgumentError("Decimal precision and scale are out of range")
             return
         elif type_base in ("decimal32", "decimal64", "decimal128", "decimal256"):
-            size = int(type_base[7:])
-            if len(args) != 1 or not isinstance(args[0], int) or args[0] < 0 or args[0] > _DECIMAL_SCALE_MAX[size]:
-                raise ArgumentError(f"{base} requires one scale from 0 through {_DECIMAL_SCALE_MAX[size]}")
+            assert type_args is not None
+            _, maximum = _integer_bounds(type_args, 0)
+            if not _has_valid_arity(type_args, len(args)) or not _is_integer_in_bounds(args[0], _integer_bounds(type_args, 0)):
+                raise ArgumentError(f"{base} requires one scale from 0 through {maximum}")
             return
         elif type_base == "qbit":
-            if len(args) != 2 or args[0] not in ("BFloat16", "Float32", "Float64") or not isinstance(args[1], int) or args[1] <= 0:
+            assert type_args is not None
+            if (
+                not _has_valid_arity(type_args, len(args))
+                or args[0] not in ChQBit._ELEMENT_BITS
+                or not _is_integer_in_bounds(args[1], _integer_bounds(type_args, 1))
+            ):
                 raise ArgumentError("QBit requires a supported floating-point type and positive integer dimension")
             return
         elif type_base in ("enum", "enum8", "enum16"):
+            assert type_args is not None
             try:
                 enum_keys, enum_values = parse_enum(type_name)
             except (IndexError, TypeError, ValueError):
@@ -854,33 +866,42 @@ class JSON(ChSqlaType, UserDefinedType):  # type: ignore[misc]
                 raise ArgumentError(f"{base} requires one or more name and integer value pairs")
             if len(set(enum_keys)) != len(enum_keys) or len(set(enum_values)) != len(enum_values):
                 raise ArgumentError(f"{base} names and values must be unique")
-            minimum, maximum = (-128, 127) if type_base == "enum8" else (-32768, 32767)
-            if any(value < minimum or value > maximum for value in enum_values):
+            minimum, maximum = _integer_bounds(type_args, "value")
+            if any(not _is_integer_in_bounds(value, (minimum, maximum)) for value in enum_values):
                 raise ArgumentError(f"{base} values must be from {minimum} through {maximum}")
             return
         elif type_base == "dynamic":
             if opening == -1:
                 return
-            if len(args) != 1 or not isinstance(args[0], str):
+            assert type_args is not None
+            if len(args) != type_args.max_args or not isinstance(args[0], str):
                 raise ArgumentError("Dynamic accepts one max_types setting")
             setting, separator, value = args[0].partition("=")
-            if separator != "=" or setting.strip() != "max_types":
+            bounds = type_args.bounds_for(setting.strip())
+            if separator != "=" or bounds is None:
                 raise ArgumentError("Dynamic accepts one max_types setting")
             try:
                 max_types = int(value.strip())
             except ValueError:
                 raise ArgumentError("Dynamic max_types must be an integer") from None
-            if max_types < 0 or max_types > 254:
-                raise ArgumentError("Dynamic max_types must be from 0 through 254")
+            minimum, maximum = bounds
+            if not _is_integer_in_bounds(max_types, (minimum, maximum)):
+                raise ArgumentError(f"Dynamic max_types must be from {minimum} through {maximum}")
             return
         elif type_base == "simpleaggregatefunction":
-            if len(args) != 2 or not isinstance(args[0], str) or not args[0]:
+            assert type_args is not None
+            if not _has_valid_arity(type_args, len(args)) or not isinstance(args[0], str) or not args[0]:
                 raise ArgumentError("SimpleAggregateFunction requires one function and one result type")
-            nested_types = args[1:]
+            nested_types = tuple(args[index] for index in type_args.nested_indexes(len(args)))
         elif type_base == "aggregatefunction":
             raise ArgumentError("AggregateFunction is not supported as a JSON typed path")
         elif type_base == "fixedstring":
-            if len(args) != 1 or isinstance(args[0], bool) or not isinstance(args[0], int) or args[0] <= 0:
+            assert type_args is not None
+            if (
+                not _has_valid_arity(type_args, len(args))
+                or isinstance(args[0], bool)
+                or not _is_integer_in_bounds(args[0], _integer_bounds(type_args, 0))
+            ):
                 raise ArgumentError("FixedString requires a positive integer size")
             return
         else:

--- a/clickhouse_connect/datatypes/base.py
+++ b/clickhouse_connect/datatypes/base.py
@@ -2,6 +2,7 @@ import array
 import logging
 from abc import ABC
 from collections.abc import Collection, MutableSequence, Sequence
+from dataclasses import dataclass
 from math import log
 from typing import Any, NamedTuple
 
@@ -18,6 +19,31 @@ from clickhouse_connect.driver.types import ByteSource
 logger = logging.getLogger(__name__)
 ch_read_formats: dict[type, str] = {}
 ch_write_formats: dict[type, str] = {}
+
+
+@dataclass(frozen=True)
+class _TypeArgs:
+    """Models the strict type-hint validator contract, not the full server grammar.
+
+    The default describes a zero-argument type.
+    """
+
+    min_args: int = 0
+    max_args: int | None = 0
+    nested: tuple[int, ...] = ()
+    variadic_nested: int | None = None
+    integer_bounds: tuple[tuple[int | str, int | None, int | None], ...] = ()
+
+    def bounds_for(self, index: int | str) -> tuple[int | None, int | None] | None:
+        for bound_index, minimum, maximum in self.integer_bounds:
+            if bound_index == index:
+                return minimum, maximum
+        return None
+
+    def nested_indexes(self, arg_count: int) -> tuple[int, ...]:
+        if self.variadic_nested is None:
+            return self.nested
+        return self.nested + tuple(range(self.variadic_nested, arg_count))
 
 
 class TypeDef(NamedTuple):
@@ -46,6 +72,7 @@ class ClickHouseType(ABC):  # noqa: B024
     nano_divisor = 0  # Only relevant for date like objects
     byte_size = 0
     valid_formats: str | tuple[str, ...] = "native"
+    _type_args = _TypeArgs()
 
     python_type: type | None = None
     base_type: str | None = None

--- a/clickhouse_connect/datatypes/container.py
+++ b/clickhouse_connect/datatypes/container.py
@@ -3,7 +3,7 @@ import logging
 from collections.abc import Collection, Sequence
 from typing import Any
 
-from clickhouse_connect.datatypes.base import ClickHouseType, TypeDef
+from clickhouse_connect.datatypes.base import ClickHouseType, TypeDef, _TypeArgs
 from clickhouse_connect.datatypes.registry import _canonicalize_variant_name, get_from_name
 from clickhouse_connect.driver.binding import _format_identifier
 from clickhouse_connect.driver.common import first_value, must_swap
@@ -26,6 +26,7 @@ def _nested_identifier(name: str) -> str:
 class Array(ClickHouseType):
     __slots__ = ("element_type", "_insert_name")
     python_type = list
+    _type_args = _TypeArgs(1, 1, nested=(0,))
 
     @property
     def insert_name(self):
@@ -102,6 +103,7 @@ class Array(ClickHouseType):
 class Tuple(ClickHouseType):
     _slots = "element_names", "element_types", "_insert_name"
     python_type = tuple
+    _type_args = _TypeArgs(0, None, variadic_nested=0)
     valid_formats = "tuple", "dict", "json", "native"  # native is 'tuple' for unnamed tuples, and dict for named tuples
 
     @property
@@ -190,6 +192,7 @@ class Tuple(ClickHouseType):
 class Map(ClickHouseType):
     _slots = "key_type", "value_type", "_insert_name"
     python_type = dict
+    _type_args = _TypeArgs(2, 2, nested=(0, 1))
 
     @property
     def insert_name(self):
@@ -245,6 +248,7 @@ class Map(ClickHouseType):
 class Nested(ClickHouseType):
     __slots__ = "tuple_array", "element_names", "element_types"
     python_type = Sequence[dict]
+    _type_args = _TypeArgs(1, None, variadic_nested=0)
 
     def __init__(self, type_def):
         self.element_names = type_def.keys

--- a/clickhouse_connect/datatypes/dynamic.py
+++ b/clickhouse_connect/datatypes/dynamic.py
@@ -4,7 +4,7 @@ from collections.abc import Collection, Sequence
 from typing import Any
 from urllib.parse import unquote
 
-from clickhouse_connect.datatypes.base import ClickHouseType, TypeDef
+from clickhouse_connect.datatypes.base import ClickHouseType, TypeDef, _TypeArgs
 from clickhouse_connect.datatypes.binary_value import _decode_binary_value
 from clickhouse_connect.datatypes.registry import get_from_name
 from clickhouse_connect.datatypes.string import String
@@ -97,6 +97,7 @@ class Variant(ClickHouseType):
     __slots__ = ("element_types", "_python_map", "_name_index")
     python_type = object
     valid_formats = "typed", "native"
+    _type_args = _TypeArgs(1, None, variadic_nested=0)
 
     def __init__(self, type_def: TypeDef):
         elements_by_name = {ch_type.name: ch_type for ch_type in (get_from_name(name) for name in type_def.values)}
@@ -251,6 +252,7 @@ def read_dynamic_prefix(_, source: ByteSource, ctx: QueryContext) -> DynamicStat
 
 class Dynamic(ClickHouseType):
     python_type = object
+    _type_args = _TypeArgs(0, 1, integer_bounds=(("max_types", 0, 254),))
 
     def read_column_prefix(self, source: ByteSource, ctx: QueryContext) -> DynamicState:
         return read_dynamic_prefix(self, source, ctx)
@@ -539,6 +541,11 @@ class JSON(ClickHouseType):
     skips: list[str]
     skip_paths: list[str]
     skip_regexps: list[str]
+    _type_args = _TypeArgs(
+        0,
+        None,
+        integer_bounds=(("max_dynamic_paths", 0, 10000), ("max_dynamic_types", 0, 254)),
+    )
 
     def __init__(self, type_def: TypeDef):
         limits: dict[str, int] = {}

--- a/clickhouse_connect/datatypes/numeric.py
+++ b/clickhouse_connect/datatypes/numeric.py
@@ -5,7 +5,7 @@ from collections.abc import MutableSequence, Sequence
 from math import isinf, isnan, nan
 from typing import Any
 
-from clickhouse_connect.datatypes.base import ArrayType, ClickHouseType, TypeDef
+from clickhouse_connect.datatypes.base import ArrayType, ClickHouseType, TypeDef, _TypeArgs
 from clickhouse_connect.driver import ctypes as driver_ctypes
 from clickhouse_connect.driver import options
 from clickhouse_connect.driver.common import array_type, decimal_prec, decimal_size, first_value, write_array
@@ -314,6 +314,7 @@ class Enum(ClickHouseType):
     _array_type = "b"
     valid_formats = "native", "int"
     python_type = str
+    _type_args = _TypeArgs(1, None, integer_bounds=(("value", -32768, 32767),))
 
     def __init__(self, type_def: TypeDef):
         super().__init__(type_def)
@@ -344,6 +345,7 @@ class Enum(ClickHouseType):
 class Enum8(Enum):
     _array_type = "b"
     byte_size = 1
+    _type_args = _TypeArgs(1, None, integer_bounds=(("value", -128, 127),))
 
 
 class Enum16(Enum):
@@ -355,6 +357,7 @@ class Decimal(ClickHouseType):
     __slots__ = "prec", "scale", "_mult", "_zeros", "byte_size", "_array_type"
     python_type = decimal.Decimal
     dec_size = 0
+    _type_args = _TypeArgs(2, 2, integer_bounds=((0, 1, 76), (1, 0, 76)))
 
     @classmethod
     def build(cls: type["Decimal"], type_def: TypeDef):
@@ -443,18 +446,22 @@ class BigDecimal(Decimal, registered=False):
 
 class Decimal32(Decimal):
     dec_size = 32
+    _type_args = _TypeArgs(1, 1, integer_bounds=((0, 0, 9),))
 
 
 class Decimal64(Decimal):
     dec_size = 64
+    _type_args = _TypeArgs(1, 1, integer_bounds=((0, 0, 18),))
 
 
 class Decimal128(BigDecimal):
     dec_size = 128
+    _type_args = _TypeArgs(1, 1, integer_bounds=((0, 0, 38),))
 
 
 class Decimal256(BigDecimal):
     dec_size = 256
+    _type_args = _TypeArgs(1, 1, integer_bounds=((0, 0, 76),))
 
 
 class IntervalNanosecond(Int32):

--- a/clickhouse_connect/datatypes/registry.py
+++ b/clickhouse_connect/datatypes/registry.py
@@ -1,12 +1,16 @@
 import logging
 from typing import Any
 
-from clickhouse_connect.datatypes.base import ClickHouseType, TypeDef, type_map
+from clickhouse_connect.datatypes.base import ClickHouseType, TypeDef, _TypeArgs, type_map
 from clickhouse_connect.driver.exceptions import InternalError
 from clickhouse_connect.driver.parser import parse_callable, parse_columns, parse_enum
 
 logger = logging.getLogger(__name__)
 type_cache: dict[str, ClickHouseType] = {}
+_WRAPPER_TYPE_ARGS = {
+    "LowCardinality": _TypeArgs(1, 1, nested=(0,)),
+    "Nullable": _TypeArgs(1, 1, nested=(0,)),
+}
 
 
 def _canonicalize_variant_name(type_name: str, ch_type: ClickHouseType) -> str:

--- a/clickhouse_connect/datatypes/special.py
+++ b/clickhouse_connect/datatypes/special.py
@@ -2,7 +2,7 @@ from collections.abc import Collection, MutableSequence, Sequence
 from typing import Any
 from uuid import UUID as PYUUID
 
-from clickhouse_connect.datatypes.base import ArrayType, ClickHouseType, TypeDef, UnsupportedType
+from clickhouse_connect.datatypes.base import ArrayType, ClickHouseType, TypeDef, UnsupportedType, _TypeArgs
 from clickhouse_connect.datatypes.registry import _canonicalize_variant_name, get_from_name
 from clickhouse_connect.driver.common import first_value
 from clickhouse_connect.driver.ctypes import data_conv
@@ -84,6 +84,7 @@ class Nothing(ArrayType):
 
 class SimpleAggregateFunction(ClickHouseType):
     _slots = ("element_type",)
+    _type_args = _TypeArgs(2, 2, nested=(1,))
 
     def __init__(self, type_def: TypeDef):
         self.element_type: ClickHouseType = get_from_name(type_def.values[1])
@@ -116,6 +117,8 @@ class SimpleAggregateFunction(ClickHouseType):
 
 
 class AggregateFunction(UnsupportedType):
+    _type_args = _TypeArgs(1, None, variadic_nested=1)
+
     def __init__(self, type_def: TypeDef):
         values = tuple(_canonicalize_argument(value) for value in type_def.values)
         super().__init__(TypeDef(type_def.wrappers, type_def.keys, values) if values != type_def.values else type_def)

--- a/clickhouse_connect/datatypes/string.py
+++ b/clickhouse_connect/datatypes/string.py
@@ -1,7 +1,7 @@
 from collections.abc import Collection, MutableSequence, Sequence
 from typing import Any
 
-from clickhouse_connect.datatypes.base import ClickHouseType, TypeDef
+from clickhouse_connect.datatypes.base import ClickHouseType, TypeDef, _TypeArgs
 from clickhouse_connect.driver import options
 from clickhouse_connect.driver.common import first_value
 from clickhouse_connect.driver.ctypes import data_conv
@@ -61,6 +61,7 @@ class String(ClickHouseType):
 class FixedString(ClickHouseType):
     python_type = str
     valid_formats = "string", "native"
+    _type_args = _TypeArgs(1, 1, integer_bounds=((0, 1, None),))
 
     def __init__(self, type_def: TypeDef):
         super().__init__(type_def)

--- a/clickhouse_connect/datatypes/temporal.py
+++ b/clickhouse_connect/datatypes/temporal.py
@@ -13,7 +13,7 @@ if TYPE_CHECKING:
     import numpy
 
 from clickhouse_connect import common
-from clickhouse_connect.datatypes.base import ClickHouseType, TypeDef
+from clickhouse_connect.datatypes.base import ClickHouseType, TypeDef, _TypeArgs
 from clickhouse_connect.driver import ctypes as driver_ctypes
 from clickhouse_connect.driver import options, tzutil
 from clickhouse_connect.driver.common import first_value, int_size, np_date_types, write_array
@@ -187,6 +187,7 @@ class DateTime(DateTimeBase):
     np_type = "datetime64[s]"
     nano_divisor = 1000000000
     byte_size = 4
+    _type_args = _TypeArgs(0, 1)
 
     def __init__(self, type_def: TypeDef):
         super().__init__(type_def)
@@ -233,6 +234,7 @@ class DateTime(DateTimeBase):
 class DateTime64(DateTimeBase):
     __slots__ = "scale", "prec", "unit"
     byte_size = 8
+    _type_args = _TypeArgs(1, 2, integer_bounds=((0, 0, 9),))
 
     def __init__(self, type_def: TypeDef):
         super().__init__(type_def)
@@ -669,6 +671,7 @@ class Time64(TimeBase):
     scale: int
     precision: int
     unit: str | None
+    _type_args = _TypeArgs(1, 1, integer_bounds=((0, 0, 9),))
 
     def __init__(self, type_def):
         super().__init__(type_def)

--- a/clickhouse_connect/datatypes/vector.py
+++ b/clickhouse_connect/datatypes/vector.py
@@ -9,7 +9,7 @@ from typing import TYPE_CHECKING, Any, cast
 if TYPE_CHECKING:
     import numpy
 
-from clickhouse_connect.datatypes.base import ClickHouseType, TypeDef
+from clickhouse_connect.datatypes.base import ClickHouseType, TypeDef, _TypeArgs
 from clickhouse_connect.datatypes.registry import get_from_name
 from clickhouse_connect.driver import options
 from clickhouse_connect.driver.ctypes import data_conv
@@ -47,6 +47,7 @@ class QBit(ClickHouseType):
     _BIT_SHIFTS = [1 << i for i in range(8)]
     _ELEMENT_BITS = {"BFloat16": 16, "Float32": 32, "Float64": 64}
     _numpy_warned = False
+    _type_args = _TypeArgs(2, 2, nested=(0,), integer_bounds=((1, 1, None),))
 
     def __init__(self, type_def: TypeDef):
         super().__init__(type_def)

--- a/tests/unit_tests/test_chtypes.py
+++ b/tests/unit_tests/test_chtypes.py
@@ -1,7 +1,47 @@
 from datetime import timedelta, timezone
 
+from clickhouse_connect.datatypes.base import _TypeArgs, type_map
 from clickhouse_connect.datatypes.container import Nested
+from clickhouse_connect.datatypes.registry import _WRAPPER_TYPE_ARGS
 from clickhouse_connect.datatypes.registry import get_from_name as gfn
+
+
+def test_type_argument_metadata():
+    expected = {
+        "AggregateFunction": _TypeArgs(1, None, variadic_nested=1),
+        "Array": _TypeArgs(1, 1, nested=(0,)),
+        "DateTime": _TypeArgs(0, 1),
+        "DateTime64": _TypeArgs(1, 2, integer_bounds=((0, 0, 9),)),
+        "Decimal": _TypeArgs(2, 2, integer_bounds=((0, 1, 76), (1, 0, 76))),
+        "Decimal32": _TypeArgs(1, 1, integer_bounds=((0, 0, 9),)),
+        "Decimal64": _TypeArgs(1, 1, integer_bounds=((0, 0, 18),)),
+        "Decimal128": _TypeArgs(1, 1, integer_bounds=((0, 0, 38),)),
+        "Decimal256": _TypeArgs(1, 1, integer_bounds=((0, 0, 76),)),
+        "Dynamic": _TypeArgs(0, 1, integer_bounds=(("max_types", 0, 254),)),
+        "Enum": _TypeArgs(1, None, integer_bounds=(("value", -32768, 32767),)),
+        "Enum8": _TypeArgs(1, None, integer_bounds=(("value", -128, 127),)),
+        "Enum16": _TypeArgs(1, None, integer_bounds=(("value", -32768, 32767),)),
+        "FixedString": _TypeArgs(1, 1, integer_bounds=((0, 1, None),)),
+        "JSON": _TypeArgs(
+            0,
+            None,
+            integer_bounds=(("max_dynamic_paths", 0, 10000), ("max_dynamic_types", 0, 254)),
+        ),
+        "Map": _TypeArgs(2, 2, nested=(0, 1)),
+        "Nested": _TypeArgs(1, None, variadic_nested=0),
+        "QBit": _TypeArgs(2, 2, nested=(0,), integer_bounds=((1, 1, None),)),
+        "SimpleAggregateFunction": _TypeArgs(2, 2, nested=(1,)),
+        "Time64": _TypeArgs(1, 1, integer_bounds=((0, 0, 9),)),
+        "Tuple": _TypeArgs(0, None, variadic_nested=0),
+        "Variant": _TypeArgs(1, None, variadic_nested=0),
+    }
+
+    assert {name: type_map[name]._type_args for name in expected} == expected
+    assert _WRAPPER_TYPE_ARGS == {
+        "LowCardinality": _TypeArgs(1, 1, nested=(0,)),
+        "Nullable": _TypeArgs(1, 1, nested=(0,)),
+    }
+    assert type_map["String"]._type_args == _TypeArgs()
 
 
 def test_enum_parse():

--- a/tests/unit_tests/test_sqlalchemy/test_types.py
+++ b/tests/unit_tests/test_sqlalchemy/test_types.py
@@ -44,6 +44,21 @@ def test_mapping():
     assert issubclass(sqla_type_map["DateTime"], DateTime)
 
 
+def test_type_argument_metadata_drives_sqlalchemy_classification():
+    from clickhouse_connect.cc_sqlalchemy.datatypes import sqltypes
+    from clickhouse_connect.datatypes.registry import _WRAPPER_TYPE_ARGS, type_map
+
+    for name, ch_type in type_map.items():
+        assert sqltypes._TYPE_ARGS[name.lower()] is ch_type._type_args
+    for name, type_args in _WRAPPER_TYPE_ARGS.items():
+        assert sqltypes._TYPE_ARGS[name.lower()] is type_args
+
+    expected_zero_argument_names = {
+        name.lower() for name, ch_type in type_map.items() if ch_type._type_args.min_args == 0 and ch_type._type_args.max_args == 0
+    }
+    assert sqltypes._ZERO_ARGUMENT_TYPE_NAMES == expected_zero_argument_names
+
+
 def test_all_matches_schema_types():
     from clickhouse_connect.cc_sqlalchemy.datatypes import sqltypes
     from clickhouse_connect.cc_sqlalchemy.datatypes.base import schema_types
@@ -331,6 +346,7 @@ def test_json_typed_path_type_hints(type_hint, expected):
         ("Enum('low' = -129, 'high' = 128)", "Enum16('low' = -129, 'high' = 128)"),
         ("Enum('low' = -32768, 'high' = 32767)", "Enum16('low' = -32768, 'high' = 32767)"),
         ("QBit(Float32, 13)", "QBit(Float32, 13)"),
+        ("qBiT(fLoAt32, 13)", "QBit(Float32, 13)"),
         ("Dynamic()", "Dynamic"),
         ("Dynamic(max_types=0)", "Dynamic(max_types=0)"),
         ("Dynamic(max_types=13)", "Dynamic(max_types=13)"),
@@ -339,6 +355,23 @@ def test_json_typed_path_type_hints(type_hint, expected):
 )
 def test_json_typed_path_accepts_valid_parameterized_scalars(type_hint, expected):
     assert JSON(typed_paths={"value": type_hint}).name == f"JSON(`value` {expected})"
+
+
+@pytest.mark.parametrize(
+    "type_hint, expected",
+    [
+        ("Decimal64(18)", "Decimal(18, 18)"),
+        ("Dynamic(max_types=254)", "Dynamic(max_types=254)"),
+    ],
+)
+def test_json_type_argument_metadata_accepts_boundary_values(type_hint, expected):
+    assert JSON(typed_paths={"value": type_hint}).name == f"JSON(`value` {expected})"
+
+
+@pytest.mark.parametrize("type_hint", ["Decimal64(19)", "Dynamic(max_types=255)"])
+def test_json_type_argument_metadata_rejects_out_of_range_values(type_hint):
+    with pytest.raises(ArgumentError):
+        JSON(typed_paths={"value": type_hint})
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
## Summary

- Centralize ClickHouse type arity, nested argument positions, and numeric bounds on driver datatype classes.
- Use that metadata for SQLAlchemy JSON typed-path canonicalization and validation.
- Remove remaining duplicated JSON limit, Dynamic setting, and QBit type knowledge.
- Add focused public boundary coverage for Decimal64 and Dynamic.
- Document the accepted error-message change: invalid hints containing both a wrong outer argument count and a malformed surplus argument now report the more accurate outer arity error.

Closes #990

## Checklist
Delete items not relevant to your PR:
- [X] Unit and integration tests covering the common scenarios were added
- [X] A human-readable description of the changes was provided to include in CHANGELOG
- [X] For significant changes, documentation in https://github.com/ClickHouse/clickhouse-docs was updated with further explanations or tutorials
