### PR TITLE
fix Alembic aggregate function rendering

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@
 
 ### Bug Fixes
 
+- Alembic autogenerate now emits valid Python for `SimpleAggregateFunction` and `AggregateFunction` columns, including aggregate names that collide with Python builtins and arguments containing named `Tuple` types. Closes [#992](https://github.com/ClickHouse/clickhouse-connect/issues/992).
 - SQLAlchemy can now reflect standalone `Variant` columns, and Alembic autogeneration can compare and round-trip them. Closes [#989](https://github.com/ClickHouse/clickhouse-connect/issues/989).
 - Alembic autogenerate now emits valid, lossless Python for `Nested` and named `Tuple` columns, including when they are inside another container. Generated upgrades preserve field names and no longer produce repeated type migrations. Closes [#988](https://github.com/ClickHouse/clickhouse-connect/issues/988).
 - The client now sorts and deduplicates `Variant` members to the server's canonical order. Previously a client-declared `Variant` type with non-canonical member order wrote native insert data under the wrong member types.

--- a/clickhouse_connect/cc_sqlalchemy/alembic/impl.py
+++ b/clickhouse_connect/cc_sqlalchemy/alembic/impl.py
@@ -11,11 +11,13 @@ from sqlalchemy.sql.elements import quoted_name
 
 from clickhouse_connect.cc_sqlalchemy.datatypes.base import ChSqlaType, sqla_type_from_name
 from clickhouse_connect.cc_sqlalchemy.datatypes.sqltypes import JSON as ChSqlaJSON  # noqa: N811
+from clickhouse_connect.cc_sqlalchemy.datatypes.sqltypes import AggregateFunction as ChSqlaAggregateFunction
 from clickhouse_connect.cc_sqlalchemy.datatypes.sqltypes import Array as ChSqlaArray
 from clickhouse_connect.cc_sqlalchemy.datatypes.sqltypes import Enum as ChSqlaEnum
 from clickhouse_connect.cc_sqlalchemy.datatypes.sqltypes import Map as ChSqlaMap
 from clickhouse_connect.cc_sqlalchemy.datatypes.sqltypes import Nested as ChSqlaNested
 from clickhouse_connect.cc_sqlalchemy.datatypes.sqltypes import Nullable
+from clickhouse_connect.cc_sqlalchemy.datatypes.sqltypes import SimpleAggregateFunction as ChSqlaSimpleAggregateFunction
 from clickhouse_connect.cc_sqlalchemy.datatypes.sqltypes import Tuple as ChSqlaTuple
 from clickhouse_connect.cc_sqlalchemy.datatypes.sqltypes import _Variant as ChSqlaVariant
 from clickhouse_connect.cc_sqlalchemy.ddl.tableengine import MergeTree
@@ -60,7 +62,7 @@ def _contains_named_container(type_obj: ChSqlaType) -> bool:
 
 def _render_ch_type(type_obj):
     """Render a ChSqlaType as valid Python source for autogen migrations"""
-    if isinstance(type_obj, ChSqlaVariant):
+    if isinstance(type_obj, (ChSqlaAggregateFunction, ChSqlaSimpleAggregateFunction, ChSqlaVariant)):
         return f"sqla_type_from_name({type_obj.name!r})"
     if _contains_named_container(type_obj):
         return f"sqla_type_from_name({type_obj.name!r})"

--- a/tests/integration_tests/test_sqlalchemy/test_alembic.py
+++ b/tests/integration_tests/test_sqlalchemy/test_alembic.py
@@ -524,6 +524,44 @@ def test_alembic_named_container_types_round_trip_live(test_engine: Engine, test
         assert "alter_column" not in noop_contents
 
 
+def test_alembic_aggregate_function_types_round_trip_live(test_engine: Engine, test_db: str, tmp_path: Path, ch_name):
+    table_name = ch_name("alembic_aggregate_functions")
+    aggregate_types = {
+        "last_value": sqla_type_from_name("SimpleAggregateFunction(anyLast, UInt32)"),
+        "unique_state": sqla_type_from_name("AggregateFunction(uniq, UInt32)"),
+        "sum_state": sqla_type_from_name("AggregateFunction(sum, UInt64)"),
+        "latest_state": sqla_type_from_name("AggregateFunction(argMax, Tuple(value String, score UInt32), UInt32)"),
+    }
+    metadata = MetaData(schema=test_db)
+    Table(
+        table_name,
+        metadata,
+        Column("id", UInt32, nullable=False),
+        *(Column(name, type_obj, nullable=False) for name, type_obj in aggregate_types.items()),
+        MergeTree(order_by="id"),
+    )
+
+    with test_engine.connect() as conn:
+        config = _alembic_config(tmp_path, conn, metadata, frozenset({table_name}))
+        revision = command.revision(config, message="create aggregate functions", autogenerate=True)
+        assert revision is not None
+        assert not isinstance(revision, list)
+        contents = Path(revision.path).read_text(encoding="utf-8")
+        assert contents.count("sqla_type_from_name(") == len(aggregate_types)
+        command.upgrade(config, "head")
+
+        reflected = Table(table_name, MetaData(schema=test_db), autoload_with=conn)
+        for name, type_obj in aggregate_types.items():
+            assert reflected.c[name].type.name == type_obj.name
+
+        noop_revision = command.revision(config, message="aggregate functions noop", autogenerate=True)
+        assert noop_revision is not None
+        assert not isinstance(noop_revision, list)
+        noop_contents = Path(noop_revision.path).read_text(encoding="utf-8")
+        assert "pass" in noop_contents
+        assert "alter_column" not in noop_contents
+
+
 def test_alembic_variant_type_round_trip_live(test_engine: Engine, test_db: str, tmp_path: Path, ch_name):
     table_name = ch_name("alembic_variant")
     variant_type = sqla_type_from_name("Variant(UInt32, String, UInt32)")

--- a/tests/unit_tests/test_sqlalchemy/test_alembic.py
+++ b/tests/unit_tests/test_sqlalchemy/test_alembic.py
@@ -421,6 +421,36 @@ def test_render_type_named_containers_emit_lossless_python(type_name):
     assert rebuilt.name == type_obj.name
 
 
+@pytest.mark.parametrize(
+    "type_name",
+    [
+        "SimpleAggregateFunction(anyLast, UInt32)",
+        "simpleaggregatefunction(anyLast, UInt32)",
+        "AggregateFunction(uniq, UInt32)",
+        "AGGREGATEFUNCTION(uniq, UInt32)",
+        "Array(SimpleAggregateFunction(anyLast, UInt32))",
+        "Map(String, AggregateFunction(uniq, UInt32))",
+        "Tuple(SimpleAggregateFunction(anyLast, UInt32), AggregateFunction(uniq, UInt32))",
+        "Array(Tuple(SimpleAggregateFunction(sum, UInt64), AggregateFunction(max, UInt32)))",
+        "Nullable(SimpleAggregateFunction(anyLast, UInt32))",
+        "Nullable(AggregateFunction(uniq, UInt32))",
+        "AggregateFunction(argMax, Tuple(value String, score UInt32), UInt32)",
+        "SimpleAggregateFunction(min, UInt32)",
+    ],
+)
+def test_render_type_aggregate_functions_emit_lossless_python(type_name):
+    context = MigrationContext.configure(dialect=ClickHouseDialect(), opts={"target_metadata": MetaData()})
+    type_obj = sqla_type_from_name(type_name)
+
+    rendered = context.impl.render_type(type_obj, None)
+
+    namespace = {"sqla_type_from_name": sqla_type_from_name}
+    exec("from clickhouse_connect.cc_sqlalchemy.datatypes.sqltypes import *", namespace)
+    rebuilt = eval(compile(rendered, "<migration>", "eval"), namespace)
+    assert "sqla_type_from_name(" in rendered
+    assert rebuilt.name == type_obj.name
+
+
 def test_render_type_json_emits_valid_round_trip_python():
     context = MigrationContext.configure(dialect=ClickHouseDialect(), opts={"target_metadata": MetaData()})
     json_types = [


### PR DESCRIPTION
## Summary

- Render `SimpleAggregateFunction` and `AggregateFunction` migrations through `sqla_type_from_name`
- Prevent invalid Python, unresolved aggregate names, and Python builtin collisions
- Cover nested, wrapped, parameterized, and named Tuple forms

Closes #992

## Checklist
Delete items not relevant to your PR:
- [X] Unit and integration tests covering the common scenarios were added
- [X] A human-readable description of the changes was provided to include in CHANGELOG
