### PR TITLE
fix: guard parse_columns against phantom empty column for Tuple()

### DIFF
--- a/clickhouse_connect/driver/parser.py
+++ b/clickhouse_connect/driver/parser.py
@@ -170,7 +170,8 @@ def parse_columns(expr: str, preserve_names: bool = False):
                     label = ""
                     continue
                 elif char == ")":
-                    columns.append(label.rstrip() if preserve_names and named and names[-1].upper() == "SKIP" else label)
+                    if label:
+                        columns.append(label.rstrip() if preserve_names and named and names[-1].upper() == "SKIP" else label)
                     break
             if char in ("'", '"', "`"):
                 quote = char

--- a/tests/unit_tests/test_chtypes.py
+++ b/tests/unit_tests/test_chtypes.py
@@ -84,6 +84,13 @@ def test_named_tuple():
     assert tuple_type.name == "Tuple(`key` Int64, `value` String)"
 
 
+def test_empty_tuple():
+    # Tuple() is a valid ClickHouse type; parse_columns("()") must not produce a
+    # phantom empty-string element that causes InternalError on get_from_name("").
+    tuple_type = gfn("Tuple()")
+    assert tuple_type.name == "Tuple()"
+
+
 def test_datetime_fixed_offset_timezone():
     """DateTime('Fixed/UTC+05:30:00') is emitted by ClickHouse servers without IANA tzdb."""
     dt_type = gfn("DateTime('Fixed/UTC+05:30:00')")


### PR DESCRIPTION
## Summary

`Tuple()` is a valid ClickHouse column type (an empty tuple), but `parse_columns("()")` appended an empty string `""` as a column label when the argument list was empty. That phantom column caused `get_from_name("")` to raise `InternalError` when ClickHouse returns a schema containing `Tuple()`.

**Root cause** — in `parse_columns`, the `char == ")"` branch at level 0 appended `label` unconditionally even when `label` was `""` (the empty-argument case):

```python
# before
elif char == ")":
    columns.append(label.rstrip() if ... else label)
    break
```

**Fix** — guard the append with `if label:`:

```python
# after
elif char == ")":
    if label:
        columns.append(label.rstrip() if ... else label)
    break
```

This is a one-line change; all other branches are unaffected.

## Testing

Added `test_empty_tuple` regression test to `tests/unit_tests/test_chtypes.py`:

```python
def test_empty_tuple():
    tuple_type = gfn("Tuple()")
    assert tuple_type.name == "Tuple()"
```

All existing `test_named_tuple` and `test_chtypes` tests continue to pass.

Closes #971