### PR TITLE
fix empty Tuple parsing and serialization

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,11 +10,11 @@
 - `Time64` now accepts every server-valid precision from 0 through 9 for parsing, reflection, native queries, and DataFrame inserts. NumPy and Pandas queries remain limited to precisions 0, 3, 6, and 9 and raise `ProgrammingError` otherwise.
 - `Dynamic` type names now preserve the `max_types` argument.
 - Generic `Enum` definitions are accepted and canonicalized to `Enum8` or `Enum16` by value range.
-- Root `Tuple()` query results now decode as empty tuples.
 - Type name parsing now handles double quoted identifiers and quoted string literals uniformly. Some type names that previously failed to parse now parse.
 
 ### Bug Fixes
 
+- Empty `Tuple()` definitions no longer parse as if they contain a phantom element, and their columns now consume and emit the Native format's per-row marker bytes. Root, nested, named, array-wrapped, and nullable empty tuples now query and insert without misaligning adjacent columns, corrupting values, or failing insert block sizing. Closes [#971](https://github.com/ClickHouse/clickhouse-connect/issues/971).
 - Alembic autogenerate now emits valid Python for `SimpleAggregateFunction` and `AggregateFunction` columns, including aggregate names that collide with Python builtins and arguments containing named `Tuple` types. Closes [#992](https://github.com/ClickHouse/clickhouse-connect/issues/992).
 - SQLAlchemy can now reflect standalone `Variant` columns, and Alembic autogeneration can compare and round-trip them. Closes [#989](https://github.com/ClickHouse/clickhouse-connect/issues/989).
 - Alembic autogenerate now emits valid, lossless Python for `Nested` and named `Tuple` columns, including when they are inside another container. Generated upgrades preserve field names and no longer produce repeated type migrations. Closes [#988](https://github.com/ClickHouse/clickhouse-connect/issues/988).

--- a/clickhouse_connect/datatypes/container.py
+++ b/clickhouse_connect/datatypes/container.py
@@ -193,6 +193,7 @@ class Tuple(ClickHouseType):
                     raise ctx.data_error("Tuple() values must be empty tuples")
             if self.nullable:
                 dest += bytes([1 if x is None else 0 for x in column])
+            # ClickHouse SerializationTuple uses ASCII '0' per row, not a NUL byte.
             dest += b"0" * len(column)
             return
         if self.element_names and isinstance(first_value(column, self.nullable), dict):

--- a/clickhouse_connect/datatypes/container.py
+++ b/clickhouse_connect/datatypes/container.py
@@ -108,7 +108,12 @@ class Tuple(ClickHouseType):
 
     @property
     def insert_name(self):
-        return self._insert_name
+        name = self._insert_name
+        # Empty Tuple handles nullable framing below; non-empty Tuple keeps the legacy unwrapped insert name.
+        if not self.element_types:
+            for wrapper in reversed(self.wrappers):
+                name = f"{wrapper}({name})"
+        return name
 
     def __init__(self, type_def: TypeDef):
         self.element_names = type_def.keys
@@ -133,6 +138,8 @@ class Tuple(ClickHouseType):
             self._insert_name = "Tuple()"
 
     def _data_size(self, sample: Collection) -> int:
+        if not self.element_types:
+            return 1
         if len(sample) == 0:
             return 0
         elem_size = 0
@@ -151,7 +158,12 @@ class Tuple(ClickHouseType):
 
     def read_column_data(self, source: ByteSource, num_rows: int, ctx: QueryContext, read_state: Any):
         if not self.element_types:
-            return tuple(() for _ in range(num_rows))
+            null_map = source.read_bytes(num_rows) if self.nullable else None
+            source.read_bytes(num_rows)
+            empty_column = tuple(() for _ in range(num_rows))
+            if null_map is not None:
+                return data_conv.build_nullable_column(empty_column, null_map, self._active_null(ctx))
+            return empty_column
         columns = []
         e_names = self.element_names
         for ix, e_type in enumerate(self.element_types):
@@ -173,6 +185,16 @@ class Tuple(ClickHouseType):
             e_type.write_column_prefix(dest)
 
     def write_column_data(self, column: Sequence, dest: bytearray, ctx: InsertContext):
+        if not self.element_types:
+            for value in column:
+                if value is None and self.nullable:
+                    continue
+                if not isinstance(value, tuple) or value:
+                    raise ctx.data_error("Tuple() values must be empty tuples")
+            if self.nullable:
+                dest += bytes([1 if x is None else 0 for x in column])
+            dest += b"0" * len(column)
+            return
         if self.element_names and isinstance(first_value(column, self.nullable), dict):
             columns = self.convert_dict_insert(column)
         else:

--- a/clickhouse_connect/datatypes/registry.py
+++ b/clickhouse_connect/datatypes/registry.py
@@ -79,13 +79,17 @@ def parse_name(name: str) -> tuple[str, str, TypeDef]:
                 raise InternalError("Generic Enum values must fit in Enum16")
     elif base.startswith("Nested"):
         keys, values = parse_columns(base[6:])
+        if not values:
+            raise InternalError("Nested must contain at least one type")
         base = "Nested"
     elif base.startswith("Tuple"):
-        if base not in ("Tuple", "Tuple()"):
+        if base != "Tuple":
             keys, values = parse_columns(base[5:])
         base = "Tuple"
     elif base.startswith("Variant"):
         keys, values = parse_columns(base[7:])
+        if not values:
+            raise InternalError("Variant must contain at least one type")
         base = "Variant"
     elif base.startswith("Dynamic") and len(base) > 7 and base[7] == "(":
         keys, values = parse_columns(base[7:])

--- a/clickhouse_connect/driver/parser.py
+++ b/clickhouse_connect/driver/parser.py
@@ -170,7 +170,8 @@ def parse_columns(expr: str, preserve_names: bool = False):
                     label = ""
                     continue
                 elif char == ")":
-                    columns.append(label.rstrip() if preserve_names and named and names[-1].upper() == "SKIP" else label)
+                    if label or named or columns:
+                        columns.append(label.rstrip() if preserve_names and named and names[-1].upper() == "SKIP" else label)
                     break
             if char in ("'", '"', "`"):
                 quote = char

--- a/docs/advanced-inserting.mdx
+++ b/docs/advanced-inserting.mdx
@@ -58,7 +58,7 @@ It is normally unnecessary to override a write format, but the methods in `click
 | Time64                | datetime.timedelta      | int, string, time | Scales 0 through 9 are supported. Integer values are interpreted as ticks at the column precision. NumPy timedelta values and DataFrame inserts work at every scale. Python time types are limited to microseconds. |
 | IPv4                  | `ipaddress.IPv4Address` | string            | Properly formatted strings can be inserted as IPv4 addresses                                                |
 | IPv6                  | `ipaddress.IPv6Address` | string            | Properly formatted strings can be inserted as IPv6 addresses                                                |
-| Tuple                 | dict or tuple           |                   |                                                                                                             |
+| Tuple                 | dict or tuple           |                   | Use `()` for `Tuple()`.                                                                                    |
 | Map                   | dict                    |                   |                                                                                                             |
 | Nested                | Sequence[dict]          |                   |                                                                                                             |
 | UUID                  | uuid.UUID               | string            | Properly formatted strings can be inserted as ClickHouse UUIDs                                              |

--- a/docs/advanced-querying.mdx
+++ b/docs/advanced-querying.mdx
@@ -371,7 +371,7 @@ client.query(
 | Time64                | datetime.timedelta      | int, string, time | Scales 0 through 9 are supported. The integer format returns ticks at the column precision. Python `timedelta` is limited to microseconds. |
 | IPv4                  | `ipaddress.IPv4Address` | string, int       | IP addresses can be read as strings or integers.                                                                  |
 | IPv6                  | `ipaddress.IPv6Address` | string            | IP addresses can be read as strings and properly formatted can be inserted as IP addresses                        |
-| Tuple                 | dict or tuple           | tuple, dict, json | Named tuples return dictionaries by default; unnamed tuples return tuples. A root `Tuple()` value returns `()`.    |
+| Tuple                 | dict or tuple           | tuple, dict, json | Named tuples return dictionaries by default; unnamed tuples return tuples. A `Tuple()` value returns `()`.         |
 | Map                   | dict                    | -                 |                                                                                                                   |
 | Nested                | Sequence[dict]          | -                 |                                                                                                                   |
 | UUID                  | uuid.UUID               | string            | UUIDs can be read as strings formatted as per RFC 4122<br/>                                                       |

--- a/docs/sqlalchemy.mdx
+++ b/docs/sqlalchemy.mdx
@@ -125,7 +125,7 @@ Declare typed JSON paths with the `typed_paths` mapping. A path type can be a Cl
 
 Type name strings can contain configured nested JSON types such as ``Array(JSON(`child` UInt32))``. Recognized ClickHouse type names are case-insensitive in these strings and are emitted with their canonical capitalization. A string must contain one complete type expression. Trailing text and malformed nested JSON arguments are rejected.
 
-An empty `Tuple()` is not supported as a JSON typed path because ClickHouse cannot serialize it through a JSON column's Native format. Root `Tuple()` query columns are supported by the core driver.
+An empty `Tuple()` is not supported as a JSON typed path because ClickHouse cannot serialize it through a JSON column's Native format. The core driver supports `Tuple()` in query and insert columns at any position, including nested in positional or named tuples, inside `Array`, and as `Nullable(Tuple())` where enabled by the server.
 
 ```python
 from sqlalchemy import Column, MetaData, Table

--- a/tests/integration_tests/test_native.py
+++ b/tests/integration_tests/test_native.py
@@ -4,8 +4,11 @@ from collections.abc import Callable
 from datetime import date, datetime
 from ipaddress import IPv4Address, IPv6Address
 
+import pytest
+
 from clickhouse_connect.datatypes.format import clear_default_format, set_default_formats, set_read_format
 from clickhouse_connect.driver import Client
+from clickhouse_connect.driver.exceptions import DataError
 
 
 def test_low_card(param_client: Client, call, table_context: Callable):
@@ -133,6 +136,84 @@ def test_tuple_inserts(param_client: Client, call, table_context: Callable):
         assert len(query_result) == 4
         assert query_result[0] == query_result[1]
         assert query_result[2] == query_result[3]
+
+
+@pytest.mark.parametrize(
+    "expression, expected_values",
+    [
+        ("tuple()", [(), (), ()]),
+        ("(tuple(), toUInt8(number + 13))", [((), 13), ((), 14), ((), 15)]),
+        (
+            "CAST((tuple(), toUInt8(number + 13)), 'Tuple(empty_value Tuple(), number UInt8)')",
+            [
+                {"empty_value": (), "number": 13},
+                {"empty_value": (), "number": 14},
+                {"empty_value": (), "number": 15},
+            ],
+        ),
+        ("[tuple(), tuple()]", [[(), ()], [(), ()], [(), ()]]),
+    ],
+)
+def test_empty_tuple_queries(param_client: Client, call, expression, expected_values):
+    rows = call(
+        param_client.query,
+        f"SELECT {expression} AS value, toUInt8(number + 79) AS sentinel FROM numbers(3)",
+    ).result_rows
+
+    assert rows == list(zip(expected_values, (79, 80, 81)))
+
+
+def test_empty_tuple_inserts(param_client: Client, call, table_context: Callable):
+    with table_context("empty_tuple_root", ["value Tuple()"], order_by="tuple()"):
+        call(param_client.insert, "empty_tuple_root", [[()], [()], [()]])
+        assert call(param_client.query, "SELECT value FROM empty_tuple_root").result_rows == [((),), ((),), ((),)]
+        with pytest.raises(DataError, match=r"Tuple\(\) values must be empty tuples"):
+            call(param_client.insert, "empty_tuple_root", [[(13,)]])
+
+    columns = [
+        "key UInt8",
+        "empty_value Tuple()",
+        "outer_value Tuple(Tuple(), UInt8)",
+        "named_value Tuple(empty_value Tuple(), number UInt8)",
+        "array_value Array(Tuple())",
+    ]
+    data = [
+        [13, (), ((), 80), ((), 81), [(), ()]],
+        [79, (), ((), 82), ((), 83), []],
+    ]
+    with table_context("empty_tuple_composed", columns):
+        call(param_client.insert, "empty_tuple_composed", data)
+        rows = call(param_client.query, "SELECT * FROM empty_tuple_composed ORDER BY key").result_rows
+
+    assert rows == [
+        (13, (), ((), 80), {"empty_value": (), "number": 81}, [(), ()]),
+        (79, (), ((), 82), {"empty_value": (), "number": 83}, []),
+    ]
+
+
+def test_nullable_empty_tuple(param_client: Client, call, test_config):
+    if test_config.cloud:
+        pytest.skip("Cloud does not allow the experimental Nullable(Tuple(...)) setting")
+    setting = call(
+        param_client.query,
+        "SELECT name FROM system.settings WHERE name = 'allow_experimental_nullable_tuple_type'",
+    ).first_row
+    if setting is None:
+        pytest.skip("Server does not support Nullable(Tuple(...))")
+
+    table = "nullable_empty_tuple"
+    call(param_client.command, f"DROP TABLE IF EXISTS {table}")
+    try:
+        call(
+            param_client.command,
+            f"CREATE TABLE {table} (value Nullable(Tuple()), sentinel UInt8) ENGINE MergeTree ORDER BY sentinel",
+            settings={"allow_experimental_nullable_tuple_type": 1},
+        )
+        call(param_client.insert, table, [[None, 13], [(), 79], [None, 80]])
+        rows = call(param_client.query, f"SELECT value, sentinel FROM {table} ORDER BY sentinel").result_rows
+        assert rows == [(None, 13), ((), 79), (None, 80)]
+    finally:
+        call(param_client.command, f"DROP TABLE IF EXISTS {table}")
 
 
 def test_agg_function(param_client: Client, call, table_context: Callable):

--- a/tests/unit_tests/test_driver/test_chdb.py
+++ b/tests/unit_tests/test_driver/test_chdb.py
@@ -354,6 +354,12 @@ class TestChdbInsert:
         result = client.query("SELECT * FROM ins_basic ORDER BY a")
         assert result.result_rows == [(1, "x"), (2, "y")]
 
+    def test_empty_tuple_query_and_insert(self, client):
+        assert client.query("SELECT tuple(), toUInt8(79)").result_rows == [((), 79)]
+        client.command("CREATE TABLE ins_empty_tuple (v Tuple()) ENGINE MergeTree ORDER BY tuple()")
+        client.insert("ins_empty_tuple", [[()], [()], [()]])
+        assert client.query("SELECT v FROM ins_empty_tuple").result_rows == [((),), ((),), ((),)]
+
     def test_insert_values_query_with_settings(self, client):
         client.command("CREATE TABLE ins_values (a UInt32) ENGINE MergeTree ORDER BY a")
         client.query("INSERT INTO ins_values VALUES (1), (2)", settings={"max_block_size": 1234})

--- a/tests/unit_tests/test_driver/test_native_read.py
+++ b/tests/unit_tests/test_driver/test_native_read.py
@@ -1,7 +1,12 @@
 from ipaddress import IPv4Address
 from uuid import UUID
 
+import pytest
+from clickhouse_connect.driverc.buffer import ResponseBuffer as CResponseBuffer
+
 from clickhouse_connect.datatypes import registry
+from clickhouse_connect.driver.buffer import ResponseBuffer as PyResponseBuffer
+from clickhouse_connect.driver.exceptions import DataError
 from clickhouse_connect.driver.insert import InsertContext
 from clickhouse_connect.driver.query import QueryContext, QueryResult
 from clickhouse_connect.driver.transform import NativeTransform
@@ -104,6 +109,83 @@ def test_point():
     point_type.write_column(points, dest, InsertContext("", [], []))
     python = point_type.read_column_data(bytes_source(bytes(dest)), 3, QueryContext(), [None, None])
     assert tuple(python) == tuple(point for point in points)
+
+
+@pytest.mark.parametrize("buffer_cls", [CResponseBuffer, PyResponseBuffer], ids=["cython", "python"])
+def test_empty_tuple_native_markers_and_stream_alignment(buffer_cls):
+    tuple_type = registry.get_from_name("Tuple()")
+    uint8_type = registry.get_from_name("UInt8")
+    source = bytes_source(b"000" + bytes((13, 79, 80)), cls=buffer_cls)
+
+    assert tuple_type.read_column_data(source, 3, QueryContext(), []) == ((), (), ())
+    assert list(uint8_type.read_column_data(source, 3, QueryContext(), None)) == [13, 79, 80]
+
+
+def test_empty_tuple_native_write_and_size():
+    tuple_type = registry.get_from_name("Tuple()")
+    dest = bytearray()
+
+    tuple_type.write_column_data([(), (), ()], dest, InsertContext("", [], []))
+
+    assert dest == b"000"
+    assert tuple_type.data_size([(), (), ()]) == 1
+
+
+@pytest.mark.parametrize("buffer_cls", [CResponseBuffer, PyResponseBuffer], ids=["cython", "python"])
+def test_nullable_empty_tuple_native_markers(buffer_cls):
+    tuple_type = registry.get_from_name("Nullable(Tuple())")
+    source = bytes_source(b"\x01\x00\x01" + b"000" + bytes((13, 79, 80)), cls=buffer_cls)
+    ctx = QueryContext()
+
+    assert tuple_type.read_column_data(source, 3, ctx, []) == [None, (), None]
+    assert list(registry.get_from_name("UInt8").read_column_data(source, 3, ctx, None)) == [13, 79, 80]
+
+    dest = bytearray()
+    tuple_type.write_column_data([None, (), None], dest, InsertContext("", [], []))
+    assert dest == b"\x01\x00\x01" + b"000"
+    assert tuple_type.data_size([None, (), None]) == 2
+    assert tuple_type.insert_name == "Nullable(Tuple())"
+
+
+@pytest.mark.parametrize(
+    "type_name, values, expected",
+    [
+        ("Array(Nullable(Tuple()))", [[None, ()], [], [()]], [[None, ()], [], [()]]),
+        (
+            "Tuple(Nullable(Tuple()), UInt8)",
+            [(None, 13), ((), 79), (None, 80)],
+            ((None, 13), ((), 79), (None, 80)),
+        ),
+    ],
+)
+@pytest.mark.parametrize("buffer_cls", [CResponseBuffer, PyResponseBuffer], ids=["cython", "python"])
+def test_nullable_empty_tuple_composes_in_containers(type_name, values, expected, buffer_cls):
+    ch_type = registry.get_from_name(type_name)
+    dest = bytearray()
+    ch_type.write_column(values, dest, InsertContext("", [], []))
+    source = bytes_source(bytes(dest) + bytes((13, 79, 80)), cls=buffer_cls)
+
+    assert ch_type.read_column(source, 3, QueryContext()) == expected
+    assert list(registry.get_from_name("UInt8").read_column(source, 3, QueryContext())) == [13, 79, 80]
+    assert ch_type.insert_name == type_name
+
+
+@pytest.mark.parametrize(
+    "type_name, value",
+    [
+        ("Tuple()", 13),
+        ("Tuple()", (13,)),
+        ("Tuple()", {}),
+        ("Tuple()", []),
+        ("Tuple()", None),
+        ("Nullable(Tuple())", (13,)),
+    ],
+)
+def test_empty_tuple_native_write_rejects_invalid_values(type_name, value):
+    tuple_type = registry.get_from_name(type_name)
+
+    with pytest.raises(DataError, match=r"Tuple\(\) values must be empty tuples"):
+        tuple_type.write_column_data([value], bytearray(), InsertContext("", [], []))
 
 
 def test_nested():

--- a/tests/unit_tests/test_driver/test_parser.py
+++ b/tests/unit_tests/test_driver/test_parser.py
@@ -4,7 +4,7 @@ from clickhouse_connect.datatypes.dynamic import typed_variant
 from clickhouse_connect.datatypes.registry import get_from_name
 from clickhouse_connect.driver.binding import _format_identifier, format_str, quote_identifier
 from clickhouse_connect.driver.common import unescape_identifier
-from clickhouse_connect.driver.exceptions import ProgrammingError
+from clickhouse_connect.driver.exceptions import InternalError, ProgrammingError
 from clickhouse_connect.driver.parser import parse_callable, parse_columns, parse_enum
 from clickhouse_connect.driver.query import remove_sql_comments
 
@@ -185,7 +185,23 @@ def test_empty_tuple_uses_server_canonical_name():
 
     assert get_from_name("Tuple").name == "Tuple()"
     assert tuple_type.name == "Tuple()"
-    assert tuple_type.read_column_data(None, 3, None, []) == ((), (), ())
+
+
+@pytest.mark.parametrize("preserve_names", [False, True])
+def test_parse_columns_empty_parentheses(preserve_names):
+    assert parse_columns("()", preserve_names=preserve_names) == ((), ())
+
+
+@pytest.mark.parametrize("expression", ["(value )", "(UInt8,)"])
+def test_parse_columns_preserves_malformed_empty_final_column(expression):
+    _, columns = parse_columns(expression)
+    assert columns[-1] == ""
+
+
+@pytest.mark.parametrize("type_name", ["Nested", "Variant"])
+def test_empty_container_type_is_rejected(type_name):
+    with pytest.raises(InternalError, match=rf"{type_name} must contain at least one type"):
+        get_from_name(f"{type_name}()")
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
## Summary

- Parse `Tuple()` without creating a phantom element while preserving rejection of invalid `Nested()` and `Variant()` types
- Match ClickHouse Native serialization by consuming and emitting one `0` marker per empty tuple row
- Fix insert sizing, nullable framing, type metadata, and invalid-value handling

Closes #971

## Checklist
Delete items not relevant to your PR:
- [X] Unit and integration tests covering the common scenarios were added
- [X] A human-readable description of the changes was provided to include in CHANGELOG
- [X] For significant changes, documentation in https://github.com/ClickHouse/clickhouse-docs was updated with further explanations or tutorials
