### PR TITLE
add MultiPoint and Geometry support for ClickHouse 26.8

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,11 @@
 
 ## 1.8.0, 2026-08-31
 
-No code changes since `1.8.0rc3`. See the `1.8.0rc1`, `1.8.0rc2`, and `1.8.0rc3` entries below for the full set of changes included in 1.8.0.
+### Improvements
+
+- Added native query and insert support for the ClickHouse `MultiPoint` type in the Python and Rust codecs, including containers and SQLAlchemy reflection. Inserting `MultiPoint` values requires ClickHouse 26.8 or later. `Geometry` now supports the `MultiPoint` member added in ClickHouse 26.8 at Native discriminator 6 while preserving the original discriminators 0 through 5. `Geometry` also supports the `typed` query format when selected with the `Geometry` type key. `Variant` format settings do not apply to `Geometry`. The Rust extra now requires `clickhouse-connect-core>=0.2.0,<0.3`.
+
+See the `1.8.0rc1`, `1.8.0rc2`, and `1.8.0rc3` entries below for the other changes included in 1.8.0.
 
 ## 1.8.0rc3, 2026-08-27
 

--- a/clickhouse_connect/cc_sqlalchemy/datatypes/sqltypes.py
+++ b/clickhouse_connect/cc_sqlalchemy/datatypes/sqltypes.py
@@ -290,6 +290,10 @@ class MultiLineString(ChSqlaType, UserDefinedType):  # type: ignore[misc]
     python_type = list
 
 
+class MultiPoint(ChSqlaType, UserDefinedType):  # type: ignore[misc]
+    python_type = list
+
+
 class Geometry(ChSqlaType, UserDefinedType):  # type: ignore[misc]
     python_type = object
 
@@ -1155,6 +1159,7 @@ __all__ = [
     "LineString",
     "Map",
     "MultiLineString",
+    "MultiPoint",
     "MultiPolygon",
     "Nested",
     "Nothing",

--- a/clickhouse_connect/datatypes/dynamic.py
+++ b/clickhouse_connect/datatypes/dynamic.py
@@ -95,8 +95,8 @@ def typed_variant(value: Any, type_name: str) -> TypedVariant:
 
 class Variant(ClickHouseType):
     __slots__ = ("element_types", "_python_map", "_name_index")
-    python_type = object
-    valid_formats = "typed", "native"
+    python_type: type | None = object
+    valid_formats: str | tuple[str, ...] = "typed", "native"
     _type_args = _TypeArgs(1, None, variadic_nested=0)
 
     def __init__(self, type_def: TypeDef):
@@ -200,8 +200,13 @@ def read_variant_column(
     # We have to count up how many of each discriminator there are in the block to read the sub columns correctly
     disc_rows = [0] * v_count
     for disc in discriminators:
-        if disc != 255:
+        if disc < v_count:
             disc_rows[disc] += 1
+        elif disc != 255:
+            raise DataError(
+                f"Column '{ctx.column_name or '<unknown>'}' has Variant discriminator {disc}, but the type definition has "
+                f"{v_count} alternatives. The server sent an unknown type member or the Native stream is corrupt."
+            )
     sub_columns: list[Sequence] = [[]] * v_count
     # Read all the sub-columns
     for ix in range(v_count):

--- a/clickhouse_connect/datatypes/geometric.py
+++ b/clickhouse_connect/datatypes/geometric.py
@@ -1,7 +1,9 @@
 from collections.abc import Collection, Sequence
 from typing import Any
 
-from clickhouse_connect.datatypes.base import ClickHouseType
+from clickhouse_connect.datatypes.base import ClickHouseType, TypeDef, _TypeArgs
+from clickhouse_connect.datatypes.dynamic import Variant
+from clickhouse_connect.datatypes.registry import get_from_name
 from clickhouse_connect.driver.insert import InsertContext
 from clickhouse_connect.driver.query import QueryContext
 from clickhouse_connect.driver.types import ByteSource
@@ -10,7 +12,6 @@ POINT_DATA_TYPE: ClickHouseType
 RING_DATA_TYPE: ClickHouseType
 POLYGON_DATA_TYPE: ClickHouseType
 MULTI_POLYGON_DATA_TYPE: ClickHouseType
-GEOMETRY_DATA_TYPE: ClickHouseType
 
 # ruff: noqa: F821 (Undefine name)
 
@@ -91,20 +92,27 @@ class MultiLineString(Polygon):
     pass
 
 
-class Geometry(ClickHouseType):
-    """ClickHouse Geometry, a fixed Variant over the six geo types."""
+class MultiPoint(Ring):
+    pass
 
-    def data_size(self, sample: Collection[Any]) -> int:
-        return GEOMETRY_DATA_TYPE.data_size(sample)
 
-    def write_column_prefix(self, dest: bytearray) -> None:
-        return GEOMETRY_DATA_TYPE.write_column_prefix(dest)
+class Geometry(Variant):
+    """ClickHouse Geometry with its fixed Native discriminator order."""
 
-    def write_column_data(self, column: Sequence, dest: bytearray, ctx: InsertContext):
-        return GEOMETRY_DATA_TYPE.write_column_data(column, dest, ctx)
+    python_type = None
+    valid_formats = "typed", "native"
+    _type_args = _TypeArgs()
+    _alternative_names = (
+        "LineString",
+        "MultiLineString",
+        "MultiPolygon",
+        "Point",
+        "Polygon",
+        "Ring",
+        "MultiPoint",
+    )
 
-    def read_column_prefix(self, source: ByteSource, ctx: QueryContext):
-        return GEOMETRY_DATA_TYPE.read_column_prefix(source, ctx)
-
-    def read_column_data(self, source: ByteSource, num_rows: int, ctx: QueryContext, read_state: Any) -> Sequence:
-        return GEOMETRY_DATA_TYPE.read_column_data(source, num_rows, ctx, read_state)
+    def __init__(self, type_def: TypeDef):
+        ClickHouseType.__init__(self, type_def)
+        self.element_types = [get_from_name(name) for name in self._alternative_names]
+        self._build_dispatch()

--- a/clickhouse_connect/datatypes/postinit.py
+++ b/clickhouse_connect/datatypes/postinit.py
@@ -18,10 +18,8 @@ point = "Tuple(Float64, Float64)"
 ring = f"Array({point})"
 polygon = f"Array({ring})"
 multi_polygon = f"Array({polygon})"
-geometry = "Variant(LineString, MultiLineString, MultiPolygon, Point, Polygon, Ring)"
 
 geometric.POINT_DATA_TYPE = registry.get_from_name(point)
 geometric.RING_DATA_TYPE = registry.get_from_name(ring)
 geometric.POLYGON_DATA_TYPE = registry.get_from_name(polygon)
 geometric.MULTI_POLYGON_DATA_TYPE = registry.get_from_name(multi_polygon)
-geometric.GEOMETRY_DATA_TYPE = registry.get_from_name(geometry)

--- a/clickhouse_connect/driver/rustcodec.py
+++ b/clickhouse_connect/driver/rustcodec.py
@@ -32,7 +32,7 @@ NativeCodec = Literal["python", "rust", "rust_strict"]
 
 _VALID_CODECS = ("python", "rust", "rust_strict")
 
-REQUIRED_BINDING_API_VERSION = 2
+REQUIRED_BINDING_API_VERSION = 3
 
 _versions_logged = False
 

--- a/docs/advanced-inserting.mdx
+++ b/docs/advanced-inserting.mdx
@@ -66,7 +66,8 @@ It is normally unnecessary to override a write format, but the methods in `click
 | JSON                  | dict                    | string            | Dictionaries and JSON object strings are supported. The legacy `Object('json')` type is not supported.      |
 | Variant               | object                  |                   | Values use native member serialization. Use `clickhouse_connect.datatypes.dynamic.typed_variant` when Python types are ambiguous. |
 | Dynamic               | object                  |                   | Values are currently inserted through their String representation.                                          |
-| Geometry              | tuple or list           |                   | Point values are 2-tuples. Wrap list-based values with `typed_variant` to select a geometry member.          |
+| MultiPoint            | Sequence[tuple]         |                   | Each point is a 2-tuple. Inserting MultiPoint values requires ClickHouse 26.8 or later.                       |
+| Geometry              | tuple or list           |                   | Point values are 2-tuples. Wrap list-based values, including MultiPoint, with `typed_variant` to select a geometry member. |
 | QBit                  | Sequence[float]         |                   | NumPy is used automatically for faster bit transposition when installed.                                    |
 
 ### Specialized insert methods {#specialized-insert-methods}

--- a/docs/advanced-querying.mdx
+++ b/docs/advanced-querying.mdx
@@ -379,7 +379,8 @@ client.query(
 | JSON                  | dict                    | string            | A python dictionary is returned by default. The `string` format will return a JSON string                         |
 | Variant               | object                  | typed             | `typed` returns `TypedVariant(value, type_name)` so the originating member type is preserved.                     |
 | Dynamic               | object                  | -                 | Returns the matching Python type for the ClickHouse datatype stored for the value                                 |
-| Geometry              | tuple or list           | -                 | Point values are 2-tuples. Other geometry members use nested lists.                                               |
+| MultiPoint            | list[tuple]             | -                 | Each point is returned as a 2-tuple.                                                                               |
+| Geometry              | tuple or list           | typed             | Point values are 2-tuples. Other members, including MultiPoint, use nested lists. Select `typed` with the `Geometry` key to preserve the member type. `Variant` format settings do not apply. |
 | QBit                  | list[float]             | -                 | NumPy is used automatically for faster bit transposition when installed.                                          |
 
 `query_np`, `query_np_stream`, `query_df`, and `query_df_stream` support `Time64` scales 0, 3, 6, and 9. Other scales raise `ProgrammingError` because they do not have a matching NumPy time unit. Use a standard Python query with the `int` or `string` read format to preserve those precisions. The experimental [Rust codec](/integrations/language-clients/python/rust-codec#known-behavior-differences) documents an exception for `Time64` stored inside `Dynamic`.

--- a/docs/sqlalchemy.mdx
+++ b/docs/sqlalchemy.mdx
@@ -328,7 +328,7 @@ ClickHouse does not support recursive materialized CTEs. The SQLAlchemy helpers 
 
 ClickHouse Connect provides ClickHouse data types, table engines, dictionary constructs, database DDL, and table reflection.
 
-Standalone `Variant` columns reflect through an internal SQLAlchemy type, and Alembic autogenerate preserves their canonical raw type names without repeated type changes. `Geometry` columns reflect as the public `Geometry` SQLAlchemy type.
+Standalone `Variant` columns reflect through an internal SQLAlchemy type, and Alembic autogenerate preserves their canonical raw type names without repeated type changes. `Geometry` and `MultiPoint` columns reflect as public SQLAlchemy types.
 
 ```python
 import sqlalchemy as db

--- a/rust/COMPLETENESS.md
+++ b/rust/COMPLETENESS.md
@@ -27,7 +27,7 @@ handoff for Python integration work.
   running the Rust query path against a stale `.so` will hit `AttributeError` on
   `.gen`.
 - **Upstream pin:** `ch-core-rs` currently tracks encode against
-  ClickHouse `v26.6.1.1193-stable`, protocol revision `54485`. HTTP Native
+  ClickHouse `v26.8.1.2041-lts`, protocol revision `54485`. HTTP Native
   inserts use `EncodeOptions { protocol_revision: 0 }`, so there is no
   `BlockInfo` preamble and no per-column custom-serialization marker.
 - **Current type scope:** the first binding encoder targets the upstream
@@ -38,8 +38,8 @@ handoff for Python integration work.
   `Dynamic`, `JSON`, `Nullable(T)`, and `LowCardinality(T)` where the upstream
   core permits it. It also covers the three
   name-decoration alias families the core resolves through `ChType::physical_delegate`:
-  `SimpleAggregateFunction(func, T)`, the six geo types (`Point`, `Ring`, `LineString`,
-  `MultiLineString`, `Polygon`, `MultiPolygon`), and `Nested(...)`. Registered
+  `SimpleAggregateFunction(func, T)`, the seven geo types (`Point`, `Ring`, `LineString`,
+  `MultiLineString`, `MultiPoint`, `Polygon`, `MultiPolygon`), and `Nested(...)`. Registered
   `AggregateFunction(...)` signatures use the core's function-specific state
   framing and validation.
 - **numpy/pandas:** `query_np`, `query_df`, and their block and row stream variants

--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -4,7 +4,7 @@ version = 4
 
 [[package]]
 name = "ch-core-py"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "ch-core-rs",
  "pyo3",
@@ -13,8 +13,8 @@ dependencies = [
 
 [[package]]
 name = "ch-core-rs"
-version = "0.1.1"
-source = "git+https://github.com/ClickHouse/ch-core-rs?tag=v0.1.1#303c09fc5c064505ade7e2c7bd5a12cd308de549"
+version = "0.2.0"
+source = "git+https://github.com/ClickHouse/ch-core-rs?tag=v0.2.0#fe1c9fa981ed0844470f4ba59a968cf47ac23349"
 
 [[package]]
 name = "heck"

--- a/rust/README.md
+++ b/rust/README.md
@@ -90,7 +90,7 @@ The binding depends on `ch-core-rs`, pinned by release tag in
 `ch-core-py/Cargo.toml`:
 
 ```toml
-ch-core-rs = { git = "https://github.com/ClickHouse/ch-core-rs", tag = "v0.1.0" }
+ch-core-rs = { git = "https://github.com/ClickHouse/ch-core-rs", tag = "v0.2.0" }
 ```
 
 Release and CI builds resolve the tag directly, so the repository must be

--- a/rust/ch-core-py/Cargo.toml
+++ b/rust/ch-core-py/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ch-core-py"
-version = "0.1.0"
+version = "0.2.0"
 edition = "2021"
 description = "PyO3 binding crate for the clickhouse-connect-core wheel"
 license = "Apache-2.0"
@@ -11,7 +11,7 @@ name = "_ch_core"
 crate-type = ["cdylib"]
 
 [dependencies]
-ch-core-rs = { git = "https://github.com/ClickHouse/ch-core-rs", tag = "v0.1.1" }
+ch-core-rs = { git = "https://github.com/ClickHouse/ch-core-rs", tag = "v0.2.0" }
 # generate-import-lib synthesizes the CPython import library when
 # cross-compiling to Windows targets with no local interpreter
 pyo3 = { version = "0.29", features = ["extension-module", "generate-import-lib"] }

--- a/rust/ch-core-py/src/insert/containers.rs
+++ b/rust/ch-core-py/src/insert/containers.rs
@@ -293,6 +293,14 @@ pub(super) fn build_element_column(
 ) -> PyResult<Column> {
     let row_count = ptrs.len();
     let seq = PtrSeq(ptrs);
+    if matches!(ch_type, ChType::Geometry) {
+        let Some(ChType::Variant(alternatives)) = ch_type.physical_delegate() else {
+            return Err(PyRuntimeError::new_err(
+                "internal error: Geometry must delegate to Variant",
+            ));
+        };
+        return geometry_column_from_seq(py, name, &alternatives, &seq, row_count);
+    }
     // Expand SimpleAggregateFunction/geo/Nested aliases before dispatch so a
     // nested alias (e.g. Array(Point)) builds its physical element column.
     if let Some(delegate) = ch_type.physical_delegate() {

--- a/rust/ch-core-py/src/insert/mod.rs
+++ b/rust/ch-core-py/src/insert/mod.rs
@@ -294,6 +294,14 @@ fn build_column(
     values: &Bound<'_, PyAny>,
     row_count: usize,
 ) -> PyResult<Column> {
+    if matches!(ch_type, ChType::Geometry) {
+        let Some(ChType::Variant(alternatives)) = ch_type.physical_delegate() else {
+            return Err(PyRuntimeError::new_err(
+                "internal error: Geometry must delegate to Variant",
+            ));
+        };
+        return build_geometry_column(py, name, &alternatives, values, row_count);
+    }
     // Expand SimpleAggregateFunction/geo/Nested aliases to the physical type
     // whose column the encoder actually builds; the block header still renders
     // the alias spelling from the Field's ChType.

--- a/rust/ch-core-py/src/insert/variant.rs
+++ b/rust/ch-core-py/src/insert/variant.rs
@@ -10,16 +10,51 @@ pub(super) fn build_variant_column(
     values: &Bound<'_, PyAny>,
     row_count: usize,
 ) -> PyResult<Column> {
+    build_variant_column_with_name(py, name, alternatives, values, row_count, None)
+}
+
+pub(super) fn build_geometry_column(
+    py: Python<'_>,
+    name: &str,
+    alternatives: &[ChType],
+    values: &Bound<'_, PyAny>,
+    row_count: usize,
+) -> PyResult<Column> {
+    build_variant_column_with_name(py, name, alternatives, values, row_count, Some("Geometry"))
+}
+
+fn build_variant_column_with_name(
+    py: Python<'_>,
+    name: &str,
+    alternatives: &[ChType],
+    values: &Bound<'_, PyAny>,
+    row_count: usize,
+    dispatch_type_name: Option<&str>,
+) -> PyResult<Column> {
     let column_values = ColumnValues::new(values, name)?;
     check_row_count(name, &column_values, row_count)?;
     if let Ok(list) = values.cast_exact::<PyList>() {
-        return variant_column_from_seq(py, name, alternatives, &ListSeq(list), row_count);
+        return variant_column_from_seq_with_name(
+            py,
+            name,
+            alternatives,
+            &ListSeq(list),
+            row_count,
+            dispatch_type_name,
+        );
     }
     if let Ok(tuple) = values.cast_exact::<PyTuple>() {
-        return variant_column_from_seq(py, name, alternatives, &TupleSeq(tuple), row_count);
+        return variant_column_from_seq_with_name(
+            py,
+            name,
+            alternatives,
+            &TupleSeq(tuple),
+            row_count,
+            dispatch_type_name,
+        );
     }
 
-    let mut builder = VariantBuilder::new(py, name, alternatives, row_count)?;
+    let mut builder = VariantBuilder::new(py, name, alternatives, row_count, dispatch_type_name)?;
     for row in 0..row_count {
         let value = column_values.get_item(row)?;
         builder.push_row(&value, row)?;
@@ -35,7 +70,28 @@ pub(super) fn variant_column_from_seq<S: FastSeq>(
     seq: &S,
     row_count: usize,
 ) -> PyResult<Column> {
-    let mut builder = VariantBuilder::new(py, name, alternatives, row_count)?;
+    variant_column_from_seq_with_name(py, name, alternatives, seq, row_count, None)
+}
+
+pub(super) fn geometry_column_from_seq<S: FastSeq>(
+    py: Python<'_>,
+    name: &str,
+    alternatives: &[ChType],
+    seq: &S,
+    row_count: usize,
+) -> PyResult<Column> {
+    variant_column_from_seq_with_name(py, name, alternatives, seq, row_count, Some("Geometry"))
+}
+
+fn variant_column_from_seq_with_name<S: FastSeq>(
+    py: Python<'_>,
+    name: &str,
+    alternatives: &[ChType],
+    seq: &S,
+    row_count: usize,
+    dispatch_type_name: Option<&str>,
+) -> PyResult<Column> {
+    let mut builder = VariantBuilder::new(py, name, alternatives, row_count, dispatch_type_name)?;
     for row in 0..row_count {
         // SAFETY: row < row_count, which the caller checked against seq.size().
         // A strong reference protects the value while the builder retains its
@@ -90,8 +146,11 @@ impl<'a, 'py> VariantBuilder<'a, 'py> {
         name: &'a str,
         alternatives: &'a [ChType],
         row_count: usize,
+        dispatch_type_name: Option<&str>,
     ) -> PyResult<Self> {
-        let type_name = ChType::Variant(alternatives.to_vec()).to_string();
+        let type_name = dispatch_type_name
+            .map(str::to_owned)
+            .unwrap_or_else(|| ChType::Variant(alternatives.to_vec()).to_string());
         // Any driver-interop failure becomes NotImplementedError so the
         // insert probe falls back to the Python codec.
         let dispatch =

--- a/rust/ch-core-py/src/lib.rs
+++ b/rust/ch-core-py/src/lib.rs
@@ -10,7 +10,7 @@ fn _ch_core(m: &Bound<'_, PyModule>) -> PyResult<()> {
     m.add("__version__", env!("CARGO_PKG_VERSION"))?;
     // Binding API contract number checked by clickhouse_connect/driver/rustcodec.py
     // at import; bump when the Python-visible binding surface changes incompatibly.
-    m.add("BINDING_API_VERSION", 2)?;
+    m.add("BINDING_API_VERSION", 3)?;
     m.add_class::<batch::ColBatch>()?;
     m.add_class::<decoder::BlockDecoder>()?;
     m.add_class::<decoder::StreamDecoder>()?;

--- a/rust/ch-core-py/tests/helpers.py
+++ b/rust/ch-core-py/tests/helpers.py
@@ -382,6 +382,7 @@ _GEO_PHYSICAL = {
     "Point": _POINT_PHYSICAL,
     "Ring": f"Array({_POINT_PHYSICAL})",
     "LineString": f"Array({_POINT_PHYSICAL})",
+    "MultiPoint": f"Array({_POINT_PHYSICAL})",
     "Polygon": f"Array(Array({_POINT_PHYSICAL}))",
     "MultiLineString": f"Array(Array({_POINT_PHYSICAL}))",
     "MultiPolygon": f"Array(Array(Array({_POINT_PHYSICAL})))",
@@ -391,7 +392,7 @@ _GEO_PHYSICAL = {
 def _expand_alias(type_name):
     """Physical type string of a name-decoration alias, else the input unchanged.
 
-    SimpleAggregateFunction, the six geo aliases, and Nested carry a custom name
+    SimpleAggregateFunction, the seven geo aliases, and Nested carry a custom name
     over a physical type whose wire body is byte-identical, so the helper emits
     the alias header but the physical body. Recurses through Nullable
     (Nullable(Point) is legal); container recursion is left to the body helpers,

--- a/rust/ch-core-py/tests/test_containers.py
+++ b/rust/ch-core-py/tests/test_containers.py
@@ -1003,10 +1003,10 @@ class TestMap:
 # ---------------------------------------------------------------------------
 
 
-def _geometry_block():
-    """Independent Native Geometry fixture with every alternative and NULL."""
+def _geometry_body():
+    """Independent Native Geometry body with every alternative and NULL."""
     body = bytearray(struct.pack("<Q", 0))
-    body.extend(bytes([0, 1, 2, 3, 4, 5, 255]))
+    body.extend(bytes([0, 1, 2, 3, 4, 5, 6, 255]))
 
     # LineString: two points.
     body.extend(struct.pack("<Q", 2))
@@ -1035,7 +1035,15 @@ def _geometry_block():
     body.extend(struct.pack("<Q", 1))
     body.extend(struct.pack("<d", 111.0))
     body.extend(struct.pack("<d", 121.0))
-    return build_native_block_from_bodies([("g", "Geometry", bytes(body))], 7)
+    # MultiPoint: two points.
+    body.extend(struct.pack("<Q", 2))
+    body.extend(struct.pack("<2d", 131.0, 132.0))
+    body.extend(struct.pack("<2d", 141.0, 142.0))
+    return bytes(body)
+
+
+def _geometry_block():
+    return build_native_block_from_bodies([("g", "Geometry", _geometry_body())], 8)
 
 
 class TestGeometry:
@@ -1046,6 +1054,7 @@ class TestGeometry:
         (71.0, 81.0),
         [[(91.0, 101.0), (92.0, 102.0)]],
         [(111.0, 121.0)],
+        [(131.0, 141.0), (132.0, 142.0)],
         None,
     ]
     expected_arrow = [
@@ -1055,6 +1064,7 @@ class TestGeometry:
         {"1": 71.0, "2": 81.0},
         [[{"1": 91.0, "2": 101.0}, {"1": 92.0, "2": 102.0}]],
         [{"1": 111.0, "2": 121.0}],
+        [{"1": 131.0, "2": 141.0}, {"1": 132.0, "2": 142.0}],
         None,
     ]
 
@@ -1069,6 +1079,7 @@ class TestGeometry:
             "Point",
             "Polygon",
             "Ring",
+            "MultiPoint",
         )
         return [typed_variant(value, name) for value, name in zip(values, names)] + [None]
 
@@ -1084,12 +1095,16 @@ class TestGeometry:
         pa = pytest.importorskip("pyarrow")
         column = pa.RecordBatchReader.from_stream(batch).read_all().column("g")
         assert pa.types.is_union(column.type)
+        assert column.type.num_fields == 8
+        assert column.type.type_codes == list(range(8))
+        assert column.type.field(6).name == "MultiPoint"
         assert column.to_pylist() == self.expected_arrow
 
     @pytest.mark.parametrize("type_name", ["Geometry", "GEOMETRY"])
     def test_encode_matches_golden_and_requires_explicit_geo_name(self, type_name):
-        values = self.tagged(self.expected[:6])
-        assert _ch_core.encode_native_block(["g"], [type_name], [values], 7) == _geometry_block()
+        values = self.tagged(self.expected[:7])
+        assert _geometry_body()[8:16] == bytes([0, 1, 2, 3, 4, 5, 6, 255])
+        assert _ch_core.encode_native_block(["g"], [type_name], [values], 8) == _geometry_block()
 
         with pytest.raises(ValueError, match="cannot map Python type"):
             _ch_core.encode_native_block(["g"], [type_name], [[self.expected[3]]], 1)
@@ -1111,7 +1126,7 @@ class TestGeometry:
         [
             (
                 "Array(Geometry)",
-                lambda tag: [[tag((13.0, 23.0), "Point"), None], [], [tag([(31.0, 41.0)], "Ring")]],
+                lambda tag: [[tag((13.0, 23.0), "Point"), None], [], [tag([(31.0, 41.0)], "MultiPoint")]],
                 [[(13.0, 23.0), None], [], [[(31.0, 41.0)]],],
             ),
             (
@@ -1121,13 +1136,13 @@ class TestGeometry:
             ),
             (
                 "Array(Tuple(Geometry, UInt8))",
-                lambda tag: [[(tag((13.0, 23.0), "Point"), 1)], [], [(tag([(31.0, 41.0)], "Ring"), 2)]],
+                lambda tag: [[(tag((13.0, 23.0), "Point"), 1)], [], [(tag([(31.0, 41.0)], "MultiPoint"), 2)]],
                 [[((13.0, 23.0), 1)], [], [([(31.0, 41.0)], 2)]],
             ),
             (
                 "Map(String, Geometry)",
-                lambda tag: [{"point": tag((13.0, 23.0), "Point")}, {}, {"ring": tag([(31.0, 41.0)], "Ring")}],
-                [{"point": (13.0, 23.0)}, {}, {"ring": [(31.0, 41.0)]}],
+                lambda tag: [{"point": tag((13.0, 23.0), "Point")}, {}, {"multi": tag([(31.0, 41.0)], "MultiPoint")}],
+                [{"point": (13.0, 23.0)}, {}, {"multi": [(31.0, 41.0)]}],
             ),
         ],
     )
@@ -1156,14 +1171,14 @@ class TestGeometry:
         assert list(batch.column_data(0)) == self.expected
 
     def test_invalid_discriminator_is_value_error(self):
-        body = struct.pack("<Q", 0) + b"\x06"
+        body = struct.pack("<Q", 0) + b"\x07"
         block = build_native_block_from_bodies([("g", "Geometry", body)], 1)
         with pytest.raises(ValueError, match="Invalid Variant layout"):
             _ch_core.ColBatch.decode_native(block)
 
 
 # ---------------------------------------------------------------------------
-# Geo aliases (Point/Ring/LineString/Polygon/MultiLineString/MultiPolygon)
+# Geo aliases (Point/Ring/LineString/Polygon/MultiLineString/MultiPolygon/MultiPoint)
 # ---------------------------------------------------------------------------
 
 # A Point decodes to an (x, y) tuple; each array-based kind wraps it in one more
@@ -1172,6 +1187,7 @@ _GEO_DECODE = [
     ("Point", [(1.5, 2.5), (-3.25, 4.0), (0.0, 0.0)]),
     ("Ring", [[(1.0, 2.0), (3.0, 4.0)], [], [(5.5, 6.5)]]),
     ("LineString", [[(0.0, 0.0), (1.0, 1.0), (2.0, 2.0)], [], [(7.5, 8.5)]]),
+    ("MultiPoint", [[(1.0, 2.0), (3.0, 4.0)], [], [(5.5, 6.5)]]),
     ("Polygon", [[[(0.0, 0.0), (1.0, 0.0), (1.0, 1.0)], [(0.25, 0.25)]], []]),
     ("MultiLineString", [[[(0.0, 0.0), (1.0, 1.0)], [(2.0, 2.0)]], []]),
     ("MultiPolygon", [[[[(0.0, 0.0), (1.0, 0.0)]], [[(2.0, 2.0)], [(3.0, 3.0)]]], []]),
@@ -1226,6 +1242,20 @@ class TestGeo:
         encoded = _ch_core.encode_native_block(["g"], ["Nullable(Point)"], [rows], len(rows))
         assert encoded == build_native_block([("g", "Nullable(Point)", rows)])
         assert list(_ch_core.ColBatch.decode_native(encoded).column_data(0)) == rows
+
+    def test_nullable_multi_point_is_rejected(self):
+        with pytest.raises(NotImplementedError, match="unsupported ClickHouse type"):
+            _ch_core.encode_native_block(["g"], ["Nullable(MultiPoint)"], [[]], 0)
+
+    def test_multi_point_arrow_exit(self):
+        pa = pytest.importorskip("pyarrow")
+        rows = [[(13.0, 23.0), (14.0, 24.0)], []]
+        batch = _ch_core.ColBatch.decode_native(build_native_block([("g", "MultiPoint", rows)]))
+        column = pa.RecordBatchReader.from_stream(batch).read_all().column("g")
+        assert column.to_pylist() == [
+            [{"1": 13.0, "2": 23.0}, {"1": 14.0, "2": 24.0}],
+            [],
+        ]
 
 
 # ---------------------------------------------------------------------------

--- a/setup.py
+++ b/setup.py
@@ -103,7 +103,7 @@ def run_setup():
             "tzdata": ["tzdata"],
             "async": ["aiohttp>=3.9.0"],
             "chdb": ["chdb>=4.1.7"],
-            "rust": ["clickhouse-connect-core>=0.1.0,<0.2"],
+            "rust": ["clickhouse-connect-core>=0.2.0,<0.3"],
         },
         tests_require=["pytest"],
         entry_points={

--- a/tests/integration_tests/conftest.py
+++ b/tests/integration_tests/conftest.py
@@ -15,7 +15,7 @@ from pytest import fixture
 from clickhouse_connect import common, get_async_client
 from clickhouse_connect.driver import AsyncClient, Client, create_client
 from clickhouse_connect.driver.common import coerce_bool
-from clickhouse_connect.driver.exceptions import OperationalError
+from clickhouse_connect.driver.exceptions import DatabaseError, OperationalError
 from clickhouse_connect.driver.httpclient import HttpClient
 from clickhouse_connect.tools.testing import TableContext
 from tests.helpers import PROJECT_ROOT_DIR
@@ -47,6 +47,19 @@ def type_available(client: Client | AsyncClient, data_type: str) -> None:
     if setting_def is not None and setting_def.value == "1":
         return
     pytest.skip(f"New {data_type.upper()} type not available in this version: {client.server_version}")
+
+
+def supports_multi_point(client: Client | AsyncClient, call: Callable | None = None) -> bool:
+    if call is None and isinstance(client, AsyncClient):
+        raise TypeError("call is required when checking MultiPoint support with AsyncClient")
+    try:
+        query = "SELECT toTypeName(defaultValueOfTypeName('MultiPoint'))"
+        result = call(client.command, query) if call else client.command(query)
+        return result == "MultiPoint"
+    except DatabaseError as ex:
+        if ex.name != "UNKNOWN_TYPE":
+            raise
+        return False
 
 
 def make_client_config(test_config: TestConfig, **kwargs):

--- a/tests/integration_tests/test_geometric.py
+++ b/tests/integration_tests/test_geometric.py
@@ -3,8 +3,22 @@ from collections.abc import Callable
 import pytest
 
 from clickhouse_connect.datatypes.dynamic import typed_variant
-from clickhouse_connect.driver import Client
+from clickhouse_connect.datatypes.geometric import Geometry
+from clickhouse_connect.driver import AsyncClient, Client
 from clickhouse_connect.driver.exceptions import DatabaseError, DataError
+from clickhouse_connect.driver.parser import parse_callable
+from tests.integration_tests.conftest import supports_multi_point
+
+_POINT_COLUMN_TYPE = "Tuple(Float64, Float64)"
+_GEOMETRY_PHYSICAL_TYPES = {
+    "LineString": f"Array({_POINT_COLUMN_TYPE})",
+    "MultiLineString": f"Array(Array({_POINT_COLUMN_TYPE}))",
+    "MultiPolygon": f"Array(Array(Array({_POINT_COLUMN_TYPE})))",
+    "Point": _POINT_COLUMN_TYPE,
+    "Polygon": f"Array(Array({_POINT_COLUMN_TYPE}))",
+    "Ring": f"Array({_POINT_COLUMN_TYPE})",
+    "MultiPoint": f"Array({_POINT_COLUMN_TYPE})",
+}
 
 
 def _require_geometry(client: Client, call) -> None:
@@ -16,6 +30,34 @@ def _require_geometry(client: Client, call) -> None:
         pytest.skip(f"Geometry is not supported by server {client.server_version}")
     if resolved_type != "Geometry":
         pytest.skip(f"Geometry is not supported by server {client.server_version}")
+
+
+def _parse_geometry_column_members(column_type_name: str) -> tuple[str, ...]:
+    wrapper, wrapper_args, remaining = parse_callable(column_type_name)
+    assert wrapper == "Const" and len(wrapper_args) == 1 and not remaining
+    variant, members, remaining = parse_callable(str(wrapper_args[0]))
+    assert variant == "Variant" and not remaining
+    return tuple(str(member) for member in members)
+
+
+def test_supports_multi_point_requires_async_call():
+    client = AsyncClient.__new__(AsyncClient)
+    with pytest.raises(TypeError, match="call is required when checking MultiPoint support with AsyncClient"):
+        supports_multi_point(client)
+
+
+def test_geometry_server_members_are_known_prefix(param_client: Client, call):
+    _require_geometry(param_client, call)
+    column_type_name = call(param_client.command, "SELECT toColumnTypeName(defaultValueOfTypeName('Geometry'))")
+    server_members = _parse_geometry_column_members(column_type_name)
+    known_names = Geometry._alternative_names
+    message = (
+        f"Server {param_client.server_version} Geometry layout is not a known prefix of {known_names}. "
+        "When ClickHouse adds a Geometry member, append it at the END of Geometry._alternative_names."
+    )
+    assert len(server_members) <= len(known_names), message
+    known_prefix = tuple(_GEOMETRY_PHYSICAL_TYPES[name] for name in known_names[: len(server_members)])
+    assert server_members == known_prefix, message
 
 
 def test_point_column(param_client: Client, call, table_context: Callable):
@@ -49,6 +91,36 @@ def test_polygon_column(param_client: Client, call, table_context: Callable):
         assert query_result.first_row[1] == pg
 
 
+def test_multi_point_python_codec_round_trip(client_factory, call, client_mode):
+    client = client_factory(native_codec="python")
+    if not supports_multi_point(client, call):
+        pytest.skip(f"MultiPoint is not supported by server {client.server_version}")
+    table = f"multi_point_python_codec_{client_mode}"
+    rows = [
+        [
+            0,
+            [(13.0, 23.0), (14.0, 24.0)],
+            [[(31.0, 41.0)], []],
+            ([(51.0, 61.0)], 7),
+            [([(71.0, 81.0)], 13)],
+            {"value": [(91.0, 101.0)]},
+        ],
+        [1, [], [], ([], 79), [], {}],
+    ]
+    schema = (
+        "id UInt8, mp MultiPoint, a Array(MultiPoint), t Tuple(MultiPoint, UInt8), "
+        "at Array(Tuple(MultiPoint, UInt8)), m Map(String, MultiPoint)"
+    )
+
+    try:
+        call(client.command, f"DROP TABLE IF EXISTS {table}")
+        call(client.command, f"CREATE TABLE {table} ({schema}) ENGINE MergeTree ORDER BY id")
+        call(client.insert, table, rows, column_names=["id", "mp", "a", "t", "at", "m"])
+        assert call(client.query, f"SELECT * FROM {table} ORDER BY id").result_rows == [tuple(row) for row in rows]
+    finally:
+        call(client.command, f"DROP TABLE IF EXISTS {table}")
+
+
 def test_geometry_python_codec_round_trip(client_factory, call, client_mode):
     client = client_factory(native_codec="python")
     _require_geometry(client, call)
@@ -61,6 +133,8 @@ def test_geometry_python_codec_round_trip(client_factory, call, client_mode):
         ("Polygon", [[(91.0, 101.0), (92.0, 102.0)]]),
         ("Ring", [(111.0, 121.0)]),
     ]
+    if supports_multi_point(client, call):
+        values.append(("MultiPoint", [(131.0, 141.0), (132.0, 142.0)]))
     rows = []
     expected = []
     for index, (type_name, value) in enumerate(values):

--- a/tests/integration_tests/test_rust_codec.py
+++ b/tests/integration_tests/test_rust_codec.py
@@ -17,7 +17,7 @@ from clickhouse_connect.driver.exceptions import (
     StreamFailureError,
 )
 from clickhouse_connect.driver.insert import InsertContext
-from tests.integration_tests.conftest import type_available
+from tests.integration_tests.conftest import supports_multi_point, type_available
 
 pytest.importorskip("_ch_core")
 
@@ -1938,6 +1938,45 @@ def test_rust_codec_geo_insert_parity(client_factory, call, client_mode):
         call(python_client.command, f"DROP TABLE IF EXISTS {py_table}")
 
 
+def test_rust_codec_multi_point_round_trip_parity(client_factory, call, client_mode):
+    rust_client = client_factory(native_codec="rust_strict")
+    python_client = client_factory(native_codec="python")
+    if not supports_multi_point(python_client, call):
+        pytest.skip(f"MultiPoint is not supported by server {python_client.server_version}")
+
+    schema = (
+        "id UInt8, mp MultiPoint, a Array(MultiPoint), t Tuple(MultiPoint, UInt8), "
+        "at Array(Tuple(MultiPoint, UInt8)), m Map(String, MultiPoint)"
+    )
+    rows = [
+        [
+            0,
+            [(13.0, 23.0), (14.0, 24.0)],
+            [[(31.0, 41.0)], []],
+            ([(51.0, 61.0)], 7),
+            [([(71.0, 81.0)], 13)],
+            {"value": [(91.0, 101.0)]},
+        ],
+        [1, [], [], ([], 79), [], {}],
+    ]
+    expected = [tuple(row) for row in rows]
+    rust_table = f"rc_multi_point_rust_{client_mode}"
+    python_table = f"rc_multi_point_python_{client_mode}"
+
+    def create_insert_query(write_client, read_client, table):
+        call(write_client.command, f"DROP TABLE IF EXISTS {table}")
+        call(write_client.command, f"CREATE TABLE {table} ({schema}) ENGINE MergeTree ORDER BY id")
+        call(write_client.insert, table, rows, column_names=["id", "mp", "a", "t", "at", "m"])
+        return call(read_client.query, f"SELECT * FROM {table} ORDER BY id").result_rows
+
+    try:
+        assert create_insert_query(rust_client, python_client, rust_table) == expected
+        assert create_insert_query(python_client, rust_client, python_table) == expected
+    finally:
+        call(python_client.command, f"DROP TABLE IF EXISTS {rust_table}")
+        call(python_client.command, f"DROP TABLE IF EXISTS {python_table}")
+
+
 def test_rust_codec_geometry_round_trip_parity(client_factory, call, client_mode):
     probe = client_factory(native_codec="python")
     try:
@@ -1953,6 +1992,7 @@ def test_rust_codec_geometry_round_trip_parity(client_factory, call, client_mode
     python_client = client_factory(native_codec="python")
     rust_table = f"rc_geometry_rust_{client_mode}"
     python_table = f"rc_geometry_python_{client_mode}"
+    has_multi_point = supports_multi_point(python_client, call)
     tagged = [
         typed_variant([(13.0, 23.0), (14.0, 24.0)], "LineString"),
         typed_variant([[(31.0, 41.0), (32.0, 42.0)]], "MultiLineString"),
@@ -1960,11 +2000,17 @@ def test_rust_codec_geometry_round_trip_parity(client_factory, call, client_mode
         typed_variant((71.0, 81.0), "Point"),
         typed_variant([[(91.0, 101.0), (92.0, 102.0)]], "Polygon"),
         typed_variant([(111.0, 121.0)], "Ring"),
-        None,
     ]
+    if has_multi_point:
+        tagged.append(typed_variant([(131.0, 141.0), (132.0, 142.0)], "MultiPoint"))
+    tagged.append(None)
     rows = [[index, value] for index, value in enumerate(tagged)]
     expected = [(index, value.value if value is not None else None) for index, value in enumerate(tagged)]
-    expanded_geometry = "Variant(LineString, MultiLineString, MultiPolygon, Point, Polygon, Ring)"
+    expanded_geometry = (
+        "Variant(LineString, MultiLineString, MultiPoint, MultiPolygon, Point, Polygon, Ring)"
+        if has_multi_point
+        else "Variant(LineString, MultiLineString, MultiPolygon, Point, Polygon, Ring)"
+    )
     expected_variant_types = [
         ("LineString",),
         ("MultiLineString",),
@@ -1972,8 +2018,10 @@ def test_rust_codec_geometry_round_trip_parity(client_factory, call, client_mode
         ("Point",),
         ("Polygon",),
         ("Ring",),
-        ("None",),
     ]
+    if has_multi_point:
+        expected_variant_types.append(("MultiPoint",))
+    expected_variant_types.append(("None",))
 
     def create_and_insert(client, table):
         call(client.command, f"DROP TABLE IF EXISTS {table}")

--- a/tests/integration_tests/test_sqlalchemy/test_reflect.py
+++ b/tests/integration_tests/test_sqlalchemy/test_reflect.py
@@ -6,9 +6,10 @@ from sqlalchemy.exc import NoResultFound
 
 from clickhouse_connect import common
 from clickhouse_connect.cc_sqlalchemy.datatypes.base import sqla_type_from_name
-from clickhouse_connect.cc_sqlalchemy.datatypes.sqltypes import Geometry, Point, SimpleAggregateFunction, UInt32
+from clickhouse_connect.cc_sqlalchemy.datatypes.sqltypes import Geometry, MultiPoint, Point, SimpleAggregateFunction, UInt32
 from clickhouse_connect.datatypes.format import clear_all_formats, set_default_formats
 from clickhouse_connect.driver.exceptions import DatabaseError
+from tests.integration_tests.conftest import supports_multi_point
 
 
 def test_basic_reflection(test_engine: Engine):
@@ -75,6 +76,27 @@ def test_geometry_reflection(test_engine: Engine, test_db: str, test_client):
             assert table.columns.geometry.type.name == "Geometry"
         finally:
             conn.execute(text(f"DROP TABLE IF EXISTS {test_db}.sqlalchemy_geometry_test"))
+
+
+def test_multi_point_reflection(test_engine: Engine, test_db: str, test_client):
+    if not supports_multi_point(test_client):
+        pytest.skip(f"MultiPoint is not supported by server {test_client.server_version}")
+
+    common.set_setting("invalid_setting_action", "drop")
+    with test_engine.begin() as conn:
+        try:
+            conn.execute(text(f"DROP TABLE IF EXISTS {test_db}.sqlalchemy_multi_point_test"))
+            conn.execute(
+                text(
+                    f"CREATE TABLE {test_db}.sqlalchemy_multi_point_test (key UInt32, multi_point MultiPoint) ENGINE MergeTree ORDER BY key"
+                )
+            )
+            metadata = db.MetaData(schema=test_db)
+            table = db.Table("sqlalchemy_multi_point_test", metadata, autoload_with=test_engine)
+            assert table.columns.multi_point.type.__class__ == MultiPoint
+            assert table.columns.multi_point.type.name == "MultiPoint"
+        finally:
+            conn.execute(text(f"DROP TABLE IF EXISTS {test_db}.sqlalchemy_multi_point_test"))
 
 
 def test_variant_reflection(test_engine: Engine, test_db: str):

--- a/tests/unit_tests/test_driver/test_native_read.py
+++ b/tests/unit_tests/test_driver/test_native_read.py
@@ -1,3 +1,4 @@
+import struct
 from ipaddress import IPv4Address
 from uuid import UUID
 
@@ -7,7 +8,7 @@ from clickhouse_connect.driverc.buffer import ResponseBuffer as CResponseBuffer
 from clickhouse_connect.datatypes import registry
 from clickhouse_connect.datatypes.dynamic import typed_variant
 from clickhouse_connect.driver.buffer import ResponseBuffer as PyResponseBuffer
-from clickhouse_connect.driver.exceptions import DataError
+from clickhouse_connect.driver.exceptions import DataError, InternalError
 from clickhouse_connect.driver.insert import InsertContext
 from clickhouse_connect.driver.query import QueryContext, QueryResult
 from clickhouse_connect.driver.transform import NativeTransform
@@ -112,6 +113,51 @@ def test_point():
     assert tuple(python) == tuple(point for point in points)
 
 
+@pytest.mark.parametrize(
+    ("type_name", "values"),
+    [
+        (
+            "MultiPoint",
+            [[(13.0, 23.0), (14.0, 24.0)], [], [(15.0, 25.0)]],
+        ),
+        (
+            "Array(MultiPoint)",
+            [[[(13.0, 23.0)], []], [], [[(14.0, 24.0), (15.0, 25.0)]]],
+        ),
+        (
+            "Tuple(MultiPoint, UInt8)",
+            [([(13.0, 23.0)], 7), ([], 13), ([(14.0, 24.0)], 79)],
+        ),
+        (
+            "Array(Tuple(MultiPoint, UInt8))",
+            [[([(13.0, 23.0)], 7)], [], [([], 13), ([(14.0, 24.0)], 79)]],
+        ),
+        (
+            "Map(String, MultiPoint)",
+            [
+                {"first": [(13.0, 23.0)]},
+                {},
+                {"second": [(14.0, 24.0), (15.0, 25.0)]},
+            ],
+        ),
+    ],
+)
+def test_multi_point_native_container_matrix(type_name, values):
+    ch_type = registry.get_from_name(type_name)
+    dest = bytearray()
+    ch_type.write_column(values, dest, InsertContext("", [], []))
+
+    source = bytes_source(bytes(dest))
+    assert list(ch_type.read_column(source, len(values), QueryContext())) == values
+
+
+def test_multi_point_registry_case_behavior():
+    assert registry.get_from_name("MultiPoint").name == "MultiPoint"
+    for spelling in ("multipoint", "MULTIPOINT"):
+        with pytest.raises(InternalError, match="Unrecognized ClickHouse type base"):
+            registry.get_from_name(spelling)
+
+
 def test_geometry():
     tagged = [
         typed_variant([(13.0, 23.0), (14.0, 24.0)], "LineString"),
@@ -120,19 +166,52 @@ def test_geometry():
         typed_variant((71.0, 81.0), "Point"),
         typed_variant([[(91.0, 101.0), (92.0, 102.0)]], "Polygon"),
         typed_variant([(111.0, 121.0)], "Ring"),
+        typed_variant([(131.0, 141.0), (132.0, 142.0)], "MultiPoint"),
         None,
     ]
     expected = [value.value if value is not None else None for value in tagged]
+    expected_body = b"".join(
+        [
+            struct.pack("<Q", 0),
+            bytes([0, 1, 2, 3, 4, 5, 6, 255]),
+            struct.pack("<Q2d2d", 2, 13.0, 14.0, 23.0, 24.0),
+            struct.pack("<QQ2d2d", 1, 2, 31.0, 32.0, 41.0, 42.0),
+            struct.pack("<QQQdd", 1, 1, 1, 51.0, 61.0),
+            struct.pack("<dd", 71.0, 81.0),
+            struct.pack("<QQ2d2d", 1, 2, 91.0, 92.0, 101.0, 102.0),
+            struct.pack("<Qdd", 1, 111.0, 121.0),
+            struct.pack("<Q2d2d", 2, 131.0, 132.0, 141.0, 142.0),
+        ]
+    )
     geometry_type = registry.get_from_name("Geometry")
     dest = bytearray()
     geometry_type.write_column(tagged, dest, InsertContext("", [], []))
+    assert bytes(dest) == expected_body
 
-    source = bytes_source(bytes(dest))
-    ctx = QueryContext()
-    read_state = geometry_type.read_column_prefix(source, ctx)
     assert geometry_type.name == "Geometry"
+    assert geometry_type.python_type is None
+    assert geometry_type.valid_formats == ("typed", "native")
     assert registry.get_from_name("GEOMETRY").name == "Geometry"
-    assert geometry_type.read_column_data(source, len(tagged), ctx, read_state) == expected
+    assert geometry_type.read_column(bytes_source(expected_body), len(tagged), QueryContext()) == expected
+    assert geometry_type.read_column(bytes_source(expected_body), len(tagged), QueryContext(query_formats={"Variant": "typed"})) == expected
+    assert geometry_type.read_column(bytes_source(expected_body), len(tagged), QueryContext(query_formats={"Geometry": "typed"})) == tagged
+
+
+@pytest.mark.parametrize("buffer_cls", [CResponseBuffer, PyResponseBuffer], ids=["cython", "python"])
+def test_geometry_unknown_discriminator_is_data_error(buffer_cls):
+    geometry_type = registry.get_from_name("Geometry")
+    source = bytes_source(struct.pack("<Q", 0) + b"\x07", cls=buffer_cls)
+    ctx = QueryContext()
+    ctx.start_column("geometry_value")
+
+    with pytest.raises(
+        DataError,
+        match=(
+            r"Column 'geometry_value' has Variant discriminator 7, but the type definition has 7 alternatives\. "
+            r"The server sent an unknown type member or the Native stream is corrupt\."
+        ),
+    ):
+        geometry_type.read_column(source, 1, ctx)
 
 
 @pytest.mark.parametrize("buffer_cls", [CResponseBuffer, PyResponseBuffer], ids=["cython", "python"])

--- a/tests/unit_tests/test_sqlalchemy/test_types.py
+++ b/tests/unit_tests/test_sqlalchemy/test_types.py
@@ -21,6 +21,7 @@ from clickhouse_connect.cc_sqlalchemy.datatypes.sqltypes import (
     Int64,
     LowCardinality,
     Map,
+    MultiPoint,
     Nested,
     Nullable,
     QBit,
@@ -95,6 +96,15 @@ def test_geometry():
     assert geometry.name == "Geometry"
     assert geometry._compiler_dispatch(None) == "Geometry"
     assert sqla_type_from_name("GEOMETRY").name == "Geometry"
+
+
+def test_multi_point():
+    multi_point = sqla_type_from_name("MultiPoint")
+    assert multi_point.__class__ == MultiPoint
+    assert multi_point.python_type is list
+    assert multi_point.name == "MultiPoint"
+    assert multi_point._compiler_dispatch(None) == "MultiPoint"
+    assert sqla_type_from_name("MULTIPOINT").name == "MultiPoint"
 
 
 def test_nullable():


### PR DESCRIPTION
## Summary
- Add MultiPoint support across Python, Rust, SQLAlchemy, and containers
- Update Geometry for ClickHouse 26.8 but preserve existing discriminators
- Fail cleanly on unknown future Geometry members
- Require `clickhouse-connect-core` 0.2.0 and document the ClickHouse 26.8 insert floor

## Checklist
Delete items not relevant to your PR:
- [X] Unit and integration tests covering the common scenarios were added
- [X] A human-readable description of the changes was provided to include in CHANGELOG