### PR TITLE
fix Rust codec release blockers for 1.8.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,15 @@
 
 - Added native query and insert support for the ClickHouse `MultiPoint` type in the Python and Rust codecs, including containers and SQLAlchemy reflection. Inserting `MultiPoint` values requires ClickHouse 26.8 or later. `Geometry` now supports the `MultiPoint` member added in ClickHouse 26.8 at Native discriminator 6 while preserving the original discriminators 0 through 5. `Geometry` also supports the `typed` query format when selected with the `Geometry` type key. `Variant` format settings do not apply to `Geometry`. The Rust extra now requires `clickhouse-connect-core>=0.2.0,<0.3`.
 
+### Bug Fixes
+
+- SQLAlchemy and Alembic now connect and reflect with `native_codec="rust_strict"`. Dialect metadata statements are marked as driver-internal, so they decode with the Python codec in every codec mode instead of tripping the strict `query_formats` check. Compatible ordinary statements still use the Rust codec.
+- Rust codec streaming queries now honor `show_clickhouse_errors`. Mid-stream server errors return the generic message when the setting is `False` and drop the server version trailer when it is `"scrub"`, matching the Python codec on both the sync and async clients.
+
+### Compatibility
+
+- The experimental Rust codec targets Python codec parity, with documented differences in some result cell types, insert validation errors, accepted insert conversions, and `Dynamic` shared-value decoding. See the Rust codec documentation for the full list of known behavior differences.
+
 See the `1.8.0rc1`, `1.8.0rc2`, and `1.8.0rc3` entries below for the other changes included in 1.8.0.
 
 ## 1.8.0rc3, 2026-08-27
@@ -48,7 +57,7 @@ Follow-up release candidate to 1.8.0rc1, rebased on 1.7.2 so all bug fixes from 
 
 ### Improvements
 
-- Added an experimental `native_codec` client option that selects the codec for FORMAT Native query decode and insert encode. `python` is the default and uses the existing codec. `rust` prefers the compiled Rust codec and falls back to the Python codec for unsupported options and types, while `rust_strict` raises instead of falling back. Results and dtypes match the Python codec, and the Arrow methods are unaffected. The compiled codec ships as the separate clickhouse-connect-core wheel, installed with `pip install clickhouse-connect[rust]`. See the rust-codec documentation page for details. This is early access for benchmarking and is not yet a supported path.
+- Added an experimental `native_codec` client option that selects the codec for FORMAT Native query decode and insert encode. `python` is the default and uses the existing codec. `rust` prefers the compiled Rust codec and falls back to the Python codec for unsupported options and types, while `rust_strict` raises instead of falling back. Python codec parity is the target, with known differences documented on the rust-codec page. The Arrow methods are unaffected. The compiled codec ships as the separate clickhouse-connect-core wheel, installed with `pip install clickhouse-connect[rust]`. See the rust-codec documentation page for details. This is early access for benchmarking and is not yet a supported path.
 - Added native query and insert support for the ClickHouse `Geometry` type. Point values use 2-tuples and the other geometry members use nested lists. SQLAlchemy reflection exposes the public `Geometry` type.
 - Added support for all ClickHouse `Interval*` types as signed 64-bit counts in the interval type's unit.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 ### Improvements
 
 - Added native query and insert support for the ClickHouse `MultiPoint` type in the Python and Rust codecs, including containers and SQLAlchemy reflection. Inserting `MultiPoint` values requires ClickHouse 26.8 or later. `Geometry` now supports the `MultiPoint` member added in ClickHouse 26.8 at Native discriminator 6 while preserving the original discriminators 0 through 5. `Geometry` also supports the `typed` query format when selected with the `Geometry` type key. `Variant` format settings do not apply to `Geometry`. The Rust extra now requires `clickhouse-connect-core>=0.2.0,<0.3`.
+- Rust codec setup guidance now recommends `pip install "clickhouse-connect[rust,arrow]"` for evaluation because its NumPy and Pandas output paths require PyArrow in 1.8. The lean `rust` extra remains available for standard Python row queries, block streams, and inserts. A missing PyArrow dependency now logs a warning before `native_codec="rust"` falls back to Python.
 
 ### Bug Fixes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
 
 - SQLAlchemy and Alembic now connect and reflect with `native_codec="rust_strict"`. Dialect metadata statements are marked as driver-internal, so they decode with the Python codec in every codec mode instead of tripping the strict `query_formats` check. Compatible ordinary statements still use the Rust codec.
 - Rust codec streaming queries now honor `show_clickhouse_errors`. Mid-stream server errors return the generic message when the setting is `False` and drop the server version trailer when it is `"scrub"`, matching the Python codec on both the sync and async clients.
+- Rust codec streams that are discarded without entering their context now close their response and stop the read-ahead thread during garbage collection. Previously each abandoned stream retained a thread, socket, and buffered response data.
 
 ### Compatibility
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,7 @@
 
 - SQLAlchemy and Alembic now connect and reflect with `native_codec="rust_strict"`. Dialect metadata statements are marked as driver-internal, so they decode with the Python codec in every codec mode instead of tripping the strict `query_formats` check. Compatible ordinary statements still use the Rust codec.
 - Rust codec streaming queries now honor `show_clickhouse_errors`. Mid-stream server errors return the generic message when the setting is `False` and drop the server version trailer when it is `"scrub"`, matching the Python codec on both the sync and async clients.
-- Rust codec streams that are discarded without entering their context now close their response and stop the read-ahead thread during garbage collection. Previously each abandoned stream retained a thread, socket, and buffered response data.
+- Rust codec streams that are discarded without entering their context now close their response and stop the read-ahead thread as soon as the stream is discarded. Previously each abandoned stream retained a thread, socket, and buffered response data for the life of the process.
 
 ### Compatibility
 

--- a/clickhouse_connect/cc_sqlalchemy/dialect.py
+++ b/clickhouse_connect/cc_sqlalchemy/dialect.py
@@ -8,6 +8,8 @@ from sqlalchemy.exc import NoResultFound, NoSuchTableError
 from clickhouse_connect import dbapi
 from clickhouse_connect.cc_sqlalchemy import dialect_name, ischema_names
 from clickhouse_connect.cc_sqlalchemy.inspector import (
+    _INTERNAL_QUERY_OPTION,
+    _INTERNAL_QUERY_SENTINEL,
     ChInspector,
     get_columns,
     get_table_metadata,
@@ -102,6 +104,16 @@ class ClickHouseDialect(DefaultDialect):
             return dict(stmt_formats)
         return {**stmt_formats, **{k: v for k, v in merged.items() if k not in stmt_formats}}
 
+    @staticmethod
+    def _ch_internal_query(context: Any) -> bool:
+        # Set by inspector.with_internal_query_formats on dialect metadata statements.
+        if context is None:
+            return False
+        if context.execution_options.get(_INTERNAL_QUERY_OPTION) is _INTERNAL_QUERY_SENTINEL:
+            return True
+        stmt = getattr(context, "invoked_statement", None)
+        return bool(stmt is not None and stmt.get_execution_options().get(_INTERNAL_QUERY_OPTION) is _INTERNAL_QUERY_SENTINEL)
+
     def _ch_pyformat_encoded(self, context: Any) -> bool:
         compiled = getattr(context, "compiled", None)
         if compiled is None:
@@ -109,13 +121,25 @@ class ClickHouseDialect(DefaultDialect):
         return bool(getattr(compiled.preparer, "_double_percents", True))
 
     def do_execute(self, cursor, statement, parameters, context=None):
-        cast(Cursor, cursor).execute(
-            statement,
-            parameters,
-            settings=self._ch_query_settings(context),
-            query_formats=self._ch_query_formats(context),
-            pyformat_encoded=self._ch_pyformat_encoded(context),
-        )
+        ch_cursor = cast(Cursor, cursor)
+        if self._ch_internal_query(context):
+            Cursor._execute(
+                ch_cursor,
+                statement,
+                parameters,
+                settings=self._ch_query_settings(context),
+                query_formats=self._ch_query_formats(context),
+                pyformat_encoded=self._ch_pyformat_encoded(context),
+                internal=True,
+            )
+        else:
+            ch_cursor.execute(
+                statement,
+                parameters,
+                settings=self._ch_query_settings(context),
+                query_formats=self._ch_query_formats(context),
+                pyformat_encoded=self._ch_pyformat_encoded(context),
+            )
 
     def do_executemany(self, cursor, statement, parameters, context=None):
         cast(Cursor, cursor).executemany(
@@ -126,12 +150,23 @@ class ClickHouseDialect(DefaultDialect):
         )
 
     def do_execute_no_params(self, cursor, statement, context=None):
-        cast(Cursor, cursor).execute(
-            statement,
-            settings=self._ch_query_settings(context),
-            query_formats=self._ch_query_formats(context),
-            pyformat_encoded=self._ch_pyformat_encoded(context),
-        )
+        ch_cursor = cast(Cursor, cursor)
+        if self._ch_internal_query(context):
+            Cursor._execute(
+                ch_cursor,
+                statement,
+                settings=self._ch_query_settings(context),
+                query_formats=self._ch_query_formats(context),
+                pyformat_encoded=self._ch_pyformat_encoded(context),
+                internal=True,
+            )
+        else:
+            ch_cursor.execute(
+                statement,
+                settings=self._ch_query_settings(context),
+                query_formats=self._ch_query_formats(context),
+                pyformat_encoded=self._ch_pyformat_encoded(context),
+            )
 
     # SQA 1 compatibility
 

--- a/clickhouse_connect/cc_sqlalchemy/inspector.py
+++ b/clickhouse_connect/cc_sqlalchemy/inspector.py
@@ -19,15 +19,22 @@ from clickhouse_connect.cc_sqlalchemy.sql.sqlparse import (
 )
 from clickhouse_connect.driver.client import _INTERNAL_QUERY_FORMATS
 
+_INTERNAL_QUERY_OPTION = "ch_internal_query"
+_INTERNAL_QUERY_SENTINEL = object()
+
 
 def with_internal_query_formats(clause: TextClause) -> TextClause:
     """Force String columns to decode as str for driver metadata introspection.
 
     User-configured global read formats such as set_default_formats("String", "bytes")
     must not affect DESCRIBE / system.tables / SHOW TABLES results used by reflection.
-    Mirrors driver.client._INTERNAL_QUERY_FORMATS on the orchestration path.
+    Mirrors driver.client._INTERNAL_QUERY_FORMATS on the orchestration path and marks the
+    statement internal so every native_codec mode decodes it with the Python codec.
     """
-    return clause.execution_options(query_formats=dict(_INTERNAL_QUERY_FORMATS))
+    return clause.execution_options(
+        query_formats=dict(_INTERNAL_QUERY_FORMATS),
+        **{_INTERNAL_QUERY_OPTION: _INTERNAL_QUERY_SENTINEL},
+    )
 
 
 def _database_name(connection, schema: str | None) -> str:

--- a/clickhouse_connect/dbapi/cursor.py
+++ b/clickhouse_connect/dbapi/cursor.py
@@ -111,6 +111,26 @@ class Cursor:
         *,
         pyformat_encoded: bool = True,
     ) -> None:
+        Cursor._execute(
+            self,
+            operation,
+            parameters,
+            settings,
+            query_formats,
+            pyformat_encoded=pyformat_encoded,
+            internal=False,
+        )
+
+    def _execute(
+        self,
+        operation: str,
+        parameters: Any = None,
+        settings: dict[str, Any] | None = None,
+        query_formats: dict[str, str] | None = None,
+        *,
+        pyformat_encoded: bool = True,
+        internal: bool = False,
+    ) -> None:
         if pyformat_encoded and not parameters and isinstance(operation, str):
             # Per PEP 249 pyformat paramstyle, callers (e.g. SQLAlchemy) escape
             # literal percent signs as %% in operation strings.  When there are
@@ -118,7 +138,21 @@ class Cursor:
             # unescaping automatically.  When there are no parameters,
             # finalize_query short-circuits, so we must unescape here.
             operation = operation.replace("%%", "%")
-        query_result = self.client.query(operation, parameters, settings=settings, query_formats=query_formats)
+        if internal:
+            # Dialect metadata statements decode with the Python codec in every native_codec mode.
+            context = self.client.create_query_context(
+                query=operation, parameters=parameters, settings=settings, query_formats=query_formats
+            )
+            context.internal = True
+            query_result = self.client.query(
+                operation,
+                parameters,
+                settings=settings,
+                query_formats=query_formats,
+                context=context,
+            )
+        else:
+            query_result = self.client.query(operation, parameters, settings=settings, query_formats=query_formats)
         self.data = query_result.result_set
         self._rowcount = len(self.data)
         self._summary.append(query_result.summary)

--- a/clickhouse_connect/driver/query.py
+++ b/clickhouse_connect/driver/query.py
@@ -250,7 +250,7 @@ class QueryContext(BaseQueryContext):
         Creates Query context copy with parameters overridden/updated as appropriate.
         """
         resolved_tz_mode = tz_mode if tz_mode is not None else self.tz_mode
-        return QueryContext(
+        copy = QueryContext(
             query=query or self.query,
             parameters=(
                 dict_copy(self.parameters, parameters if isinstance(parameters, dict) else None)
@@ -277,6 +277,8 @@ class QueryContext(BaseQueryContext):
             transport_settings=self.transport_settings if transport_settings is None else transport_settings,
             rename_response_column=self.rename_response_column if rename_response_column is None else rename_response_column,
         )
+        copy.internal = self.internal
+        return copy
 
     def _update_query(self):
         query = self.query

--- a/clickhouse_connect/driver/rustcodec.py
+++ b/clickhouse_connect/driver/rustcodec.py
@@ -1,6 +1,6 @@
 import logging
 from collections.abc import Generator
-from typing import Any, Literal, cast
+from typing import Any, Literal
 
 from clickhouse_connect import common
 from clickhouse_connect.datatypes import registry
@@ -23,7 +23,13 @@ from clickhouse_connect.driver.rustnumpy import (
     _normalize_json_shared_column,
 )
 from clickhouse_connect.driver.streaming import ReadAheadSource
-from clickhouse_connect.driver.transform import NativeTransform, Transform, extract_error_message, extract_exception_with_tag
+from clickhouse_connect.driver.transform import (
+    NativeTransform,
+    Transform,
+    extract_error_message,
+    extract_exception_with_tag,
+    format_stream_error,
+)
 from clickhouse_connect.driver.types import ByteSource, Closable
 
 logger: logging.Logger = logging.getLogger(__name__)
@@ -287,6 +293,12 @@ class _RustNativeTransform:
         exception_tag = read_source.exception_tag
         scanner = _ExceptionTagScanner(exception_tag) if exception_tag else None
         last_chunk = b""
+        show_clickhouse_errors = context.show_clickhouse_errors
+
+        def server_error(chunk: bytes) -> StreamFailureError:
+            # Tagged text first, as in the Python codec, then the client's show_clickhouse_errors policy.
+            message = extract_exception_with_tag(chunk, exception_tag or "") or extract_error_message(chunk)
+            return StreamFailureError(format_stream_error(message, show_clickhouse_errors))
 
         def raw_blocks() -> Generator[Any, None, None]:
             # Decode blocks lazily so streaming queries keep bounded memory. Errors surface here on the
@@ -299,9 +311,7 @@ class _RustNativeTransform:
                         hit = scanner.push(chunk)
                         if hit is not None:
                             read_source.close()
-                            raise StreamFailureError(
-                                extract_exception_with_tag(hit, cast(str, exception_tag)) or extract_error_message(hit)
-                            )
+                            raise server_error(hit)
                     yield from decoder.feed(chunk)
                 yield from decoder.finish()
             except StreamFailureError:
@@ -309,22 +319,22 @@ class _RustNativeTransform:
             except EOFError as ex:
                 read_source.close()
                 if _chunk_has_server_error(last_chunk, exception_tag):
-                    raise StreamFailureError(extract_error_message(last_chunk)) from ex
+                    raise server_error(last_chunk) from ex
                 raise StreamFailureError("Stream ended unexpectedly (connection closed by server)") from ex
             except NotImplementedError as ex:
                 read_source.close()
                 if _chunk_has_server_error(last_chunk, exception_tag):
-                    raise StreamFailureError(extract_error_message(last_chunk)) from ex
+                    raise server_error(last_chunk) from ex
                 raise _unsupported_decode_error(ex) from ex
             except ValueError as ex:
                 read_source.close()
                 if _chunk_has_server_error(last_chunk, exception_tag):
-                    raise StreamFailureError(extract_error_message(last_chunk)) from ex
+                    raise server_error(last_chunk) from ex
                 raise _binding_value_error(ex) from ex
             except Exception as ex:
                 read_source.close()
                 if _chunk_has_server_error(last_chunk, exception_tag):
-                    raise StreamFailureError(extract_error_message(last_chunk)) from ex
+                    raise server_error(last_chunk) from ex
                 if ex.__class__.__name__ == "ClientPayloadError":
                     raise StreamFailureError("Stream failed during read (connection closed by server)") from ex
                 raise

--- a/clickhouse_connect/driver/rustcodec.py
+++ b/clickhouse_connect/driver/rustcodec.py
@@ -277,7 +277,10 @@ class _RustNativeTransform:
             if self.strict:
                 source.close()
                 raise NotSupportedError(f'native_codec="rust_strict" does not support {reason}; use native_codec="python" or "rust"')
-            logger.info("Native codec fallback to Python for query: %s", reason)
+            if reason == "pyarrow not installed":
+                logger.warning("Native codec fallback to Python for query: %s", reason)
+            else:
+                logger.info("Native codec fallback to Python for query: %s", reason)
             return NativeTransform.parse_response(source, context)
 
         core = _ch_core_module()

--- a/clickhouse_connect/driver/streaming.py
+++ b/clickhouse_connect/driver/streaming.py
@@ -442,6 +442,41 @@ class StreamingInsertSource:
         return False
 
 
+def _read_ahead_producer(
+    source: ByteSource,
+    out: queue.Queue[tuple[str, object]],
+    stop_event: threading.Event,
+) -> None:
+    def put(item: tuple[str, object]) -> bool:
+        while not stop_event.is_set():
+            try:
+                out.put(item, timeout=0.1)
+                return True
+            except queue.Full:
+                continue
+        return False
+
+    try:
+        for chunk in source.gen:
+            if not put(("data", chunk)):
+                return
+    except BaseException as ex:  # noqa: BLE001 - forwarded to the consumer thread verbatim
+        put(("error", ex))
+    finally:
+        put(("eof", None))
+
+
+def _read_ahead_consumer(source_queue: queue.Queue[tuple[str, object]]) -> Iterator[bytes]:
+    while True:
+        tag, payload = source_queue.get()
+        if tag == "data":
+            yield cast(bytes, payload)
+        elif tag == "error":
+            raise cast(BaseException, payload)
+        else:  # eof
+            return
+
+
 class ReadAheadSource(Closable):
     """Reads chunks from a byte source on a daemon thread into a bounded queue so transport overlaps decode.
 
@@ -455,37 +490,26 @@ class ReadAheadSource(Closable):
         self.queue: queue.Queue[tuple[str, object]] = queue.Queue(maxsize=maxsize)
         self._stop_event = threading.Event()
         self._gen_cache: Iterator[bytes] | None = None
-        self._thread = threading.Thread(target=self._producer, name="clickhouse-read-ahead", daemon=True)
+        self._thread = threading.Thread(
+            target=_read_ahead_producer,
+            args=(source, self.queue, self._stop_event),
+            name="clickhouse-read-ahead",
+            daemon=True,
+        )
         self._thread.start()
+
+    def __del__(self) -> None:
+        try:
+            if not self._stop_event.is_set():
+                self.close()
+        except Exception:  # noqa: BLE001 - finalizers must not raise
+            pass
 
     @property
     def gen(self) -> Iterator[bytes]:
         if self._gen_cache is None:
-            self._gen_cache = self._consume()
+            self._gen_cache = _read_ahead_consumer(self.queue)
         return self._gen_cache
-
-    def _consume(self) -> Iterator[bytes]:
-        while True:
-            tag, payload = self.queue.get()
-            if tag == "data":
-                yield cast(bytes, payload)
-            elif tag == "error":
-                raise cast(BaseException, payload)
-            else:  # eof
-                return
-
-    def _producer(self):
-        source = self.source
-        if source is None:
-            return
-        try:
-            for chunk in source.gen:
-                if not self._put(("data", chunk)):
-                    return
-        except BaseException as ex:  # noqa: BLE001 - forwarded to the consumer thread verbatim
-            self._put(("error", ex))
-        finally:
-            self._put(("eof", None))
 
     def _drain(self):
         try:
@@ -519,15 +543,6 @@ class ReadAheadSource(Closable):
         # Release on the loop thread: the async source's close cancels its producer task, which must not
         # run from an executor thread.
         self._release_source()
-
-    def _put(self, item: tuple[str, object]) -> bool:
-        while not self._stop_event.is_set():
-            try:
-                self.queue.put(item, timeout=0.1)
-                return True
-            except queue.Full:
-                continue
-        return False
 
 
 class _SyncStreamingInsertSource:

--- a/clickhouse_connect/driver/streaming.py
+++ b/clickhouse_connect/driver/streaming.py
@@ -477,6 +477,41 @@ def _read_ahead_consumer(source_queue: queue.Queue[tuple[str, object]]) -> Itera
             return
 
 
+def _drain_read_ahead_queue(source_queue: queue.Queue[tuple[str, object]]) -> None:
+    try:
+        while True:
+            source_queue.get_nowait()
+    except queue.Empty:
+        pass
+
+
+def _release_abandoned_read_ahead(source: ByteSource, source_queue: queue.Queue[tuple[str, object]]) -> None:
+    try:
+        _drain_read_ahead_queue(source_queue)
+    finally:
+        try:
+            source.close()
+        except Exception:  # noqa: BLE001 - finalizers must not raise
+            pass
+
+
+def _finalize_read_ahead_off_loop(
+    loop: asyncio.AbstractEventLoop,
+    source: ByteSource,
+    source_queue: queue.Queue[tuple[str, object]],
+    producer_thread: threading.Thread,
+) -> None:
+    try:
+        if producer_thread.is_alive():
+            producer_thread.join(timeout=1.0)
+    except Exception:  # noqa: BLE001 - finalizers must not raise
+        pass
+    try:
+        loop.call_soon_threadsafe(_release_abandoned_read_ahead, source, source_queue)
+    except Exception:  # noqa: BLE001 - a closed loop must not leak the source
+        _release_abandoned_read_ahead(source, source_queue)
+
+
 class ReadAheadSource(Closable):
     """Reads chunks from a byte source on a daemon thread into a bounded queue so transport overlaps decode.
 
@@ -500,8 +535,29 @@ class ReadAheadSource(Closable):
 
     def __del__(self) -> None:
         try:
-            if not self._stop_event.is_set():
+            if self._stop_event.is_set():
+                return
+            try:
+                loop = asyncio.get_running_loop()
+            except RuntimeError:
                 self.close()
+                return
+
+            self._stop_event.set()
+            source, self.source = self.source, None
+            if source is None:
+                return
+            try:
+                loop.run_in_executor(
+                    None,
+                    _finalize_read_ahead_off_loop,
+                    loop,
+                    source,
+                    self.queue,
+                    self._thread,
+                )
+            except Exception:
+                _finalize_read_ahead_off_loop(loop, source, self.queue, self._thread)
         except Exception:  # noqa: BLE001 - finalizers must not raise
             pass
 
@@ -512,11 +568,7 @@ class ReadAheadSource(Closable):
         return self._gen_cache
 
     def _drain(self):
-        try:
-            while True:
-                self.queue.get_nowait()
-        except queue.Empty:
-            pass
+        _drain_read_ahead_queue(self.queue)
 
     def _release_source(self):
         source, self.source = self.source, None
@@ -524,7 +576,7 @@ class ReadAheadSource(Closable):
             source.close()
 
     def close(self) -> None:
-        # Join the producer before closing the source. A _put-blocked producer returns within one _put
+        # Join the producer before closing the source. A queue-blocked producer returns within one put
         # timeout of the stop event; a read-blocked producer exits after its in-flight read returns. Closing
         # the source only after the join keeps the transport single-reader: the sync source drains on close,
         # which would race a producer still reading it.

--- a/clickhouse_connect/driver/transform.py
+++ b/clickhouse_connect/driver/transform.py
@@ -3,7 +3,7 @@ from collections.abc import Generator
 from typing import Protocol
 
 from clickhouse_connect.datatypes import registry
-from clickhouse_connect.driver.common import write_leb128
+from clickhouse_connect.driver.common import ShowClickHouseErrors, write_leb128
 from clickhouse_connect.driver.compression import get_compressor
 from clickhouse_connect.driver.exceptions import (
     GENERIC_CLICKHOUSE_ERROR,
@@ -43,13 +43,6 @@ class NativeTransform:
         renamer = context.column_renamer
         show_clickhouse_errors = context.show_clickhouse_errors
 
-        def format_stream_error(error_msg: str) -> str:
-            if show_clickhouse_errors is False:
-                return GENERIC_CLICKHOUSE_ERROR
-            if show_clickhouse_errors == "scrub":
-                return scrub_error_details(error_msg)
-            return error_msg
-
         def extract_source_error(tagged_only: bool = False) -> str | None:
             if not source.last_message:
                 return None
@@ -75,7 +68,7 @@ class NativeTransform:
                 except StreamCompleteException:
                     error_msg = extract_source_error(tagged_only=True)
                     if error_msg:
-                        raise StreamFailureError(format_stream_error(error_msg)) from None
+                        raise StreamFailureError(format_stream_error(error_msg, show_clickhouse_errors)) from None
                     return None
                 num_rows = source.read_leb128()
                 for col_num in range(num_cols):
@@ -101,7 +94,7 @@ class NativeTransform:
                     # in the response
                     error_msg = extract_source_error()
                     if error_msg:
-                        raise StreamFailureError(format_stream_error(error_msg)) from None
+                        raise StreamFailureError(format_stream_error(error_msg, show_clickhouse_errors)) from None
                     raise StreamFailureError("Stream ended unexpectedly (connection closed by server)") from ex
 
                 # A read failure partway through the stream: OperationalError from the sync reader,
@@ -110,7 +103,7 @@ class NativeTransform:
                 if isinstance(ex, OperationalError) or ex.__class__.__name__ == "ClientPayloadError":
                     error_msg = extract_source_error()
                     if error_msg:
-                        raise StreamFailureError(format_stream_error(error_msg)) from None
+                        raise StreamFailureError(format_stream_error(error_msg, show_clickhouse_errors)) from None
                     raise StreamFailureError("Stream failed during read (connection closed by server)") from ex
 
                 raise
@@ -230,6 +223,15 @@ def extract_exception_with_tag(message: bytes, exception_tag: str) -> str | None
         return error_message.decode("utf-8", errors="replace").strip()
     except Exception:
         return error_message.decode("latin-1", errors="replace").strip()
+
+
+def format_stream_error(error_msg: str, show_clickhouse_errors: ShowClickHouseErrors) -> str:
+    """Apply the client's show_clickhouse_errors policy to a mid-stream server error message."""
+    if show_clickhouse_errors is False:
+        return GENERIC_CLICKHOUSE_ERROR
+    if show_clickhouse_errors == "scrub":
+        return scrub_error_details(error_msg)
+    return error_msg
 
 
 def extract_error_message(message: bytes) -> str:

--- a/docs/index.mdx
+++ b/docs/index.mdx
@@ -60,7 +60,7 @@ pip install "clickhouse-connect[polars]"     # Polars
 pip install "clickhouse-connect[sqlalchemy]" # SQLAlchemy dialect
 pip install "clickhouse-connect[alembic]"    # SQLAlchemy and Alembic
 pip install "clickhouse-connect[chdb]"       # Embedded chDB backend
-pip install "clickhouse-connect[rust]"       # Experimental compiled Rust codec
+pip install "clickhouse-connect[rust,arrow]" # Experimental Rust codec evaluation setup
 pip install "clickhouse-connect[tzdata]"     # IANA time zones on minimal systems
 ```
 

--- a/docs/rust-codec.mdx
+++ b/docs/rust-codec.mdx
@@ -13,13 +13,21 @@ The codec is experimental and opt in. The Python codec remains the default.
 
 ## Installation {#installation}
 
-The compiled codec ships as a separate wheel named `clickhouse-connect-core`, which provides the `_ch_core` extension module. Install it through the `rust` extra:
+The compiled codec ships as a separate wheel named `clickhouse-connect-core`, which provides the `_ch_core` extension module. For evaluation, install the codec and PyArrow together:
+
+```bash
+pip install "clickhouse-connect[rust,arrow]"
+```
+
+In 1.8, every Rust path that produces NumPy or Pandas output requires PyArrow. This includes `query_np`, `query_df`, their streaming variants, and `query(..., use_numpy=True)`. Without PyArrow, `native_codec="rust"` logs a warning and runs those queries with the Python codec. `native_codec="rust_strict"` raises `NotSupportedError` instead.
+
+The `rust` extra alone stays lean for applications that use standard Python row results, row or column block streams, and inserts without requesting NumPy or Pandas output. Those paths do not require PyArrow:
 
 ```bash
 pip install "clickhouse-connect[rust]"
 ```
 
-If a Rust codec is selected and the module is not installed, client creation raises a `NotSupportedError` naming this install command.
+If a Rust codec is selected and the compiled module is not installed, client creation raises a `NotSupportedError` naming this install command.
 
 ## Enabling the codec {#enabling-the-codec}
 
@@ -42,6 +50,16 @@ Accepted values:
 The default can also be seeded with the `native_codec` common setting or the `CLICKHOUSE_CONNECT_NATIVE_CODEC` environment variable. Precedence is the client keyword argument, then the common setting, then the environment variable.
 
 The option is ignored for `interface="chdb"` clients, which always use the Python codec.
+
+## When to use the Rust codec {#when-to-use-the-rust-codec}
+
+The Rust codec is most useful for large DataFrame results with text, container, and complex types such as `String`, `LowCardinality`, `Map`, `Array`, `JSON`, `Decimal`, and `UUID`. It can also help large row and column block streams, concurrent query workloads, and bulk inserts.
+
+Small results and network-bound queries may see little change. Flat numeric results already use efficient bulk paths in the Python codec, so they may also see less benefit.
+
+Buffered `query()` calls on very wide or all-numeric results can currently be slower and use more peak memory with the Rust codec. Prefer `query_df`, `query_row_block_stream`, or `query_column_block_stream` for those workloads. Streaming keeps memory bounded.
+
+Benchmark your own workload before adopting the codec. Use `native_codec="rust_strict"` while measuring so an unsupported option or missing dependency raises instead of silently routing the query to Python.
 
 ## Fallback rules {#fallback-rules}
 

--- a/docs/rust-codec.mdx
+++ b/docs/rust-codec.mdx
@@ -49,7 +49,7 @@ Fallback decisions are made before any bytes are read or sent, so there is never
 
 When `naive_datetime_insert="server"` is active, `rust` routes an insert containing any `DateTime` or `DateTime64` column to the Python codec so the declared column timezone or server timezone is applied. `rust_strict` rejects that combination. The default `naive_datetime_insert="local"` mode continues to use the Rust encoder.
 
-Driver-internal metadata queries always use the Python codec, silently, in every mode.
+Driver-internal metadata queries, including SQLAlchemy dialect reflection statements, always use the Python codec, silently, in every mode.
 
 Malformed Native payloads detected by the Rust codec raise `DataError`.
 
@@ -65,7 +65,7 @@ Codec fixes and performance improvements ship as `clickhouse-connect-core` relea
 
 ## Known behavior differences {#known-behavior-differences}
 
-The Rust codec targets cell for cell parity with the Python codec. The deliberate differences:
+The Rust codec targets cell for cell parity with the Python codec. The following differences are known.
 
 - `query_np` and `query_df` results for `Variant` columns contain plain Python objects rather than numpy scalar values. The values are equal, the cell types differ.
 - `Dynamic` values that contain `Time64` materialize as `datetime.timedelta` in Rust `query_np` and `query_df` results. At scales 0, 3, 6, and 9 the values equal the Python codec's `numpy.timedelta64` cells, but the cell types differ. At other scales the Rust codec returns `datetime.timedelta` while the Python codec raises `ProgrammingError` because NumPy has no matching unit. Dynamic member metadata is not exposed to the driver after Rust decoding, so use `native_codec="python"` when NumPy cell types or unsupported-scale validation are required.
@@ -73,3 +73,6 @@ The Rust codec targets cell for cell parity with the Python codec. The deliberat
 - A `LowCardinality` alternative inside a container that materializes per cell, such as `Array(Variant(...))`, produces value-equal cells that do not share the per-dictionary-slot object identity the Python codec exhibits.
 - `Nullable(Tuple(...))` columns with one or more elements decode correctly on the Rust codec. The Python codec misreads this layout and the Rust result is the reference behavior. Both codecs support `Nullable(Tuple())`.
 - `rust_strict` rejects query options the Rust path does not implement, such as custom per-query `query_formats`, rather than silently changing behavior.
+- Rust insert conversion and validation errors can raise `DataError` where the Python codec raises `ValueError`, and the message text can differ. Examples include invalid `Time` and `Time64` values, IPv6 addresses, QBit dimensions, `FixedString` lengths, `Float64` strings, and attempts to insert elements into a `Tuple()` column.
+- The Rust encoder rejects `b""` for `FixedString(N)` and numeric strings such as `"2"` for integer columns. The Python codec zero-fills an empty `FixedString` value and coerces numeric strings.
+- The Rust codec decodes some `Dynamic` shared-variant values to their Python types when the Python codec leaves the value as raw bytes. For example, a stored `Date` can return as `datetime.date` from Rust and as a binary value from Python.

--- a/docs/rust-codec.mdx
+++ b/docs/rust-codec.mdx
@@ -27,6 +27,8 @@ The `rust` extra alone stays lean for applications that use standard Python row 
 pip install "clickhouse-connect[rust]"
 ```
 
+The codec, its packaging, and its dependency set are experimental. A smaller Arrow interoperability dependency is being evaluated for a future release.
+
 If a Rust codec is selected and the compiled module is not installed, client creation raises a `NotSupportedError` naming this install command.
 
 ## Enabling the codec {#enabling-the-codec}

--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -14,7 +14,7 @@ dependencies = [
 [[package]]
 name = "ch-core-rs"
 version = "0.2.0"
-source = "git+https://github.com/ClickHouse/ch-core-rs?tag=v0.2.0#fe1c9fa981ed0844470f4ba59a968cf47ac23349"
+source = "git+https://github.com/ClickHouse/ch-core-rs?tag=v0.2.0#afb8f67cb71a810b83fac9c7b5a43173589e56c1"
 
 [[package]]
 name = "heck"

--- a/tests/integration_tests/test_rust_codec.py
+++ b/tests/integration_tests/test_rust_codec.py
@@ -1,7 +1,8 @@
 import array
+import gc
 import logging
-import threading
 import time
+import weakref
 from datetime import date, datetime, timedelta, timezone
 from decimal import Decimal
 
@@ -1574,31 +1575,43 @@ def test_rust_codec_uuid_df_parity(client_factory, call):
 
 
 def test_rust_codec_abandoned_stream_no_read_ahead_thread(client_factory, call, client_mode):
-    rust_client = client_factory(native_codec="rust_strict")
-    # The result must exceed the read-ahead queue capacity so the producer thread is still blocked at
-    # abandonment. A small result the producer fully buffers would exit on its own and hide a close() leak.
-    stream = call(rust_client.query_column_block_stream, "SELECT number FROM numbers(20000000)")
+    gc_was_enabled = gc.isenabled()
+    gc.disable()
+    read_source_ref = None
+    try:
+        rust_client = client_factory(native_codec="rust_strict")
+        # The result must exceed the read-ahead queue capacity so the producer thread is still blocked at
+        # abandonment. A small result the producer fully buffers would exit on its own and hide a close() leak.
+        stream = call(rust_client.query_column_block_stream, "SELECT number FROM numbers(20000000)")
+        read_source = stream.source.source
+        thread = read_source._thread
+        read_source_ref = weakref.ref(read_source)
+        del read_source
 
-    if client_mode == "sync":
-        with stream as blocks:
-            for _ in blocks:
-                break
-    else:
+        if client_mode == "sync":
+            with pytest.raises(ProgrammingError, match="Stream should be used within a context"):
+                next(stream)
+        else:
 
-        async def abandon():
-            async with stream as blocks:
-                async for _ in blocks:
-                    break
+            async def abandon(stream_context):
+                with pytest.raises(ProgrammingError, match="Stream should be used within a context"):
+                    await stream_context.__anext__()
 
-        call(abandon)
+            call(abandon, stream)
 
-    def read_ahead_threads():
-        return [t for t in threading.enumerate() if t.name == "clickhouse-read-ahead" and t.is_alive()]
-
-    deadline = time.time() + 2.0
-    while time.time() < deadline and read_ahead_threads():
-        time.sleep(0.05)
-    assert not read_ahead_threads()
+        del stream
+        deadline = time.time() + 2.0
+        while time.time() < deadline and thread.is_alive():
+            time.sleep(0.05)
+        assert read_source_ref() is None
+        assert thread.is_alive() is False
+    finally:
+        if read_source_ref is not None:
+            leaked_source = read_source_ref()
+            if leaked_source is not None:
+                leaked_source.close()
+        if gc_was_enabled:
+            gc.enable()
 
 
 def _insert_df_roundtrip(client, python_client, call, table, schema, df):

--- a/tests/integration_tests/test_rust_codec.py
+++ b/tests/integration_tests/test_rust_codec.py
@@ -2191,3 +2191,54 @@ def test_rust_codec_midstream_error_df_parity(client_factory, call, consume_stre
         run(rust_client)
     with pytest.raises(StreamFailureError):
         run(python_client)
+
+
+@pytest.mark.parametrize("mode", [True, "scrub", False])
+def test_rust_codec_stream_error_show_clickhouse_errors_modes(client_factory, call, consume_stream, mode):
+    client = client_factory(native_codec="rust_strict", show_clickhouse_errors=mode)
+    with pytest.raises(StreamFailureError) as excinfo:
+        stream = call(
+            client.query_rows_stream,
+            "SELECT sleepEachRow(0.01), throwIf(number = 100) FROM numbers(200)",
+            settings={"max_block_size": 1, "wait_end_of_query": 0},
+        )
+        consume_stream(stream)
+    error_msg = str(excinfo.value)
+    if mode is False:
+        assert error_msg == "The ClickHouse server returned an error"
+        return
+    assert "FUNCTION_THROW_IF_VALUE_IS_NON_ZERO" in error_msg
+    if mode == "scrub":
+        assert "version" not in error_msg.lower()
+        assert client.url not in error_msg
+
+
+@pytest.mark.parametrize("codec", ["rust", "rust_strict"])
+def test_rust_codec_sqlalchemy_dialect_metadata(test_config, codec):
+    sqlalchemy = pytest.importorskip("sqlalchemy")
+    from sqlalchemy import inspect, text
+
+    table = f"rust_sqla_meta_{codec}"
+    conn_str = (
+        f"clickhousedb://{test_config.username}:{test_config.password}@{test_config.host}:{test_config.port}/{test_config.test_database}"
+    )
+    engine = sqlalchemy.create_engine(conn_str, connect_args={"native_codec": codec})
+    try:
+        with engine.begin() as conn:
+            conn.execute(text(f"DROP TABLE IF EXISTS {table}"))
+            conn.execute(text(f"CREATE TABLE {table} (id UInt32, name String) ENGINE MergeTree ORDER BY id"))
+            conn.execute(text(f"INSERT INTO {table} VALUES (13, 'user_1'), (79, 'user_2')"))
+            inspector = inspect(conn)
+            assert table in inspector.get_table_names()
+            assert [column["name"] for column in inspector.get_columns(table)] == ["id", "name"]
+            assert conn.execute(text(f"SELECT name FROM {table} ORDER BY id")).scalars().all() == ["user_1", "user_2"]
+            # The private option key cannot be spoofed with a public boolean to bypass strict mode.
+            stmt = text(f"SELECT name FROM {table}").execution_options(query_formats={"String": "bytes"}, ch_internal_query=True)
+            if codec == "rust_strict":
+                with pytest.raises(NotSupportedError, match="query_formats"):
+                    conn.execute(stmt)
+            else:
+                assert conn.execute(stmt).scalars().first() == b"user_1"
+            conn.execute(text(f"DROP TABLE {table}"))
+    finally:
+        engine.dispose()

--- a/tests/integration_tests/test_rust_codec.py
+++ b/tests/integration_tests/test_rust_codec.py
@@ -2226,19 +2226,21 @@ def test_rust_codec_sqlalchemy_dialect_metadata(test_config, codec):
     try:
         with engine.begin() as conn:
             conn.execute(text(f"DROP TABLE IF EXISTS {table}"))
-            conn.execute(text(f"CREATE TABLE {table} (id UInt32, name String) ENGINE MergeTree ORDER BY id"))
-            conn.execute(text(f"INSERT INTO {table} VALUES (13, 'user_1'), (79, 'user_2')"))
-            inspector = inspect(conn)
-            assert table in inspector.get_table_names()
-            assert [column["name"] for column in inspector.get_columns(table)] == ["id", "name"]
-            assert conn.execute(text(f"SELECT name FROM {table} ORDER BY id")).scalars().all() == ["user_1", "user_2"]
-            # The private option key cannot be spoofed with a public boolean to bypass strict mode.
-            stmt = text(f"SELECT name FROM {table}").execution_options(query_formats={"String": "bytes"}, ch_internal_query=True)
-            if codec == "rust_strict":
-                with pytest.raises(NotSupportedError, match="query_formats"):
-                    conn.execute(stmt)
-            else:
-                assert conn.execute(stmt).scalars().first() == b"user_1"
-            conn.execute(text(f"DROP TABLE {table}"))
+            try:
+                conn.execute(text(f"CREATE TABLE {table} (id UInt32, name String) ENGINE MergeTree ORDER BY id"))
+                conn.execute(text(f"INSERT INTO {table} VALUES (13, 'user_1'), (79, 'user_2')"))
+                inspector = inspect(conn)
+                assert table in inspector.get_table_names()
+                assert [column["name"] for column in inspector.get_columns(table)] == ["id", "name"]
+                assert conn.execute(text(f"SELECT name FROM {table} ORDER BY id")).scalars().all() == ["user_1", "user_2"]
+                # The private option key cannot be spoofed with a public boolean to bypass strict mode.
+                stmt = text(f"SELECT name FROM {table}").execution_options(query_formats={"String": "bytes"}, ch_internal_query=True)
+                if codec == "rust_strict":
+                    with pytest.raises(NotSupportedError, match="query_formats"):
+                        conn.execute(stmt)
+                else:
+                    assert conn.execute(stmt).scalars().first() == b"user_1"
+            finally:
+                conn.execute(text(f"DROP TABLE IF EXISTS {table}"))
     finally:
         engine.dispose()

--- a/tests/unit_tests/test_driver/test_rustcodec.py
+++ b/tests/unit_tests/test_driver/test_rustcodec.py
@@ -11,6 +11,7 @@ from clickhouse_connect.common import _native_codec_env_default
 from clickhouse_connect.datatypes.registry import get_from_name
 from clickhouse_connect.driver import rustcodec
 from clickhouse_connect.driver.exceptions import (
+    GENERIC_CLICKHOUSE_ERROR,
     DataError,
     NotSupportedError,
     ProgrammingError,
@@ -658,6 +659,50 @@ def test_decode_feed_error_disambiguation(monkeypatch, error, exception_tag, chu
         _RustNativeTransform(strict=True).parse_response(src, eligible_ctx())
     if expected is DataError:
         assert str(excinfo.value) == str(error)
+    assert src.closed is True
+
+
+@pytest.mark.parametrize(
+    ("decoder_error", "mode"),
+    [
+        pytest.param(ValueError("Malformed payload"), False, id="decoder_value_error_false"),
+        pytest.param(EOFError("Truncated payload"), "scrub", id="decoder_eof_scrub"),
+    ],
+)
+def test_decode_untagged_server_error_honors_detail_policy(monkeypatch, decoder_error, mode):
+    core = _fake_decoder_core(feed_error=decoder_error)
+    monkeypatch.setitem(sys.modules, "_ch_core", core)
+    chunk = (
+        b"Code: 62. DB::Exception: Value passed to 'throwIf' function is non-zero. "
+        b"(FUNCTION_THROW_IF_VALUE_IS_NON_ZERO) (version 26.8.1.2041)"
+    )
+    src = FakeSource([chunk])
+    context = eligible_ctx()
+    context.show_clickhouse_errors = mode
+
+    with pytest.raises(StreamFailureError) as excinfo:
+        _RustNativeTransform(strict=True).parse_response(src, context)
+
+    message = str(excinfo.value)
+    if mode is False:
+        assert message == GENERIC_CLICKHOUSE_ERROR
+    else:
+        assert "FUNCTION_THROW_IF_VALUE_IS_NON_ZERO" in message
+        assert "version" not in message.lower()
+        assert "http://" not in message
+    assert src.closed is True
+
+
+def test_decode_tagged_scanner_honors_hidden_detail_policy(monkeypatch):
+    core = _fake_decoder_core(feed_error=AssertionError("decoder must not receive a tagged server exception"))
+    monkeypatch.setitem(sys.modules, "_ch_core", core)
+    src = FakeSource([TAGGED_EXCEPTION_BODY], exception_tag=TAGGED_EXCEPTION_TAG)
+    context = eligible_ctx()
+    context.show_clickhouse_errors = False
+
+    with pytest.raises(StreamFailureError, match=f"^{GENERIC_CLICKHOUSE_ERROR}$"):
+        _RustNativeTransform(strict=True).parse_response(src, context)
+
     assert src.closed is True
 
 

--- a/tests/unit_tests/test_driver/test_rustcodec.py
+++ b/tests/unit_tests/test_driver/test_rustcodec.py
@@ -305,12 +305,22 @@ def test_strict_global_read_format_raises_and_closes_source(clean_formats):
 def test_non_strict_ineligible_delegates_to_python_and_logs_reason(monkeypatch, caplog):
     sentinel = object()
     monkeypatch.setattr(NativeTransform, "parse_response", staticmethod(lambda source, context: sentinel))
-    src = FakeSource([])
+    monkeypatch.setattr(rustcodec.options, "arrow", None, raising=False)
+    pyarrow_src = FakeSource([])
+    option_src = FakeSource([])
     with caplog.at_level(logging.INFO, logger="clickhouse_connect"):
-        result = _RustNativeTransform(strict=False).parse_response(src, eligible_ctx(use_none=False))
-    assert result is sentinel
-    assert src.closed is False
-    assert "fallback to Python for query: use_none=False" in caplog.text
+        pyarrow_result = _RustNativeTransform(strict=False).parse_response(pyarrow_src, eligible_ctx(use_numpy=True))
+        option_result = _RustNativeTransform(strict=False).parse_response(option_src, eligible_ctx(use_none=False))
+
+    assert pyarrow_result is sentinel
+    assert option_result is sentinel
+    assert pyarrow_src.closed is False
+    assert option_src.closed is False
+    fallback_records = [record for record in caplog.records if "fallback to Python for query" in record.getMessage()]
+    assert [(record.getMessage(), record.levelno) for record in fallback_records] == [
+        ("Native codec fallback to Python for query: pyarrow not installed", logging.WARNING),
+        ("Native codec fallback to Python for query: use_none=False", logging.INFO),
+    ]
 
 
 # --- Insert build (FakeCore) -------------------------------------------------

--- a/tests/unit_tests/test_sqlalchemy/test_query_formats.py
+++ b/tests/unit_tests/test_sqlalchemy/test_query_formats.py
@@ -8,7 +8,11 @@ from sqlalchemy import create_engine, text
 from sqlalchemy.engine import Engine
 
 from clickhouse_connect.cc_sqlalchemy.dialect import ClickHouseDialect
-from clickhouse_connect.cc_sqlalchemy.inspector import with_internal_query_formats
+from clickhouse_connect.cc_sqlalchemy.inspector import (
+    _INTERNAL_QUERY_OPTION,
+    _INTERNAL_QUERY_SENTINEL,
+    with_internal_query_formats,
+)
 from clickhouse_connect.datatypes.format import clear_all_formats, set_default_formats
 from clickhouse_connect.dbapi.cursor import Cursor
 from clickhouse_connect.driver.client import _INTERNAL_QUERY_FORMATS
@@ -31,6 +35,40 @@ class _FakeContext:
     def __init__(self, execution_options, invoked_statement=None):
         self.execution_options = execution_options
         self.invoked_statement = invoked_statement
+
+
+class _PreviousSignatureCursor(Cursor):
+    def __init__(self, client):
+        super().__init__(client)
+        self.execute_called = False
+
+    def execute(
+        self,
+        operation: str,
+        parameters: Any = None,
+        settings: dict[str, Any] | None = None,
+        query_formats: dict[str, str] | None = None,
+        *,
+        pyformat_encoded: bool = True,
+    ) -> None:
+        self.execute_called = True
+        super().execute(
+            operation,
+            parameters,
+            settings,
+            query_formats,
+            pyformat_encoded=pyformat_encoded,
+        )
+
+
+class _IncompatiblePrivateExecuteCursor(Cursor):
+    def __init__(self, client):
+        super().__init__(client)
+        self.private_execute_called = False
+
+    def _execute(self, operation):
+        self.private_execute_called = True
+        raise AssertionError(f"subclass private method received {operation}")
 
 
 def _mock_client():
@@ -107,6 +145,81 @@ def test_dialect_statement_query_formats_take_wildcard_precedence():
 def test_with_internal_query_formats_sets_execution_option():
     clause = with_internal_query_formats(text("SHOW TABLES"))
     assert clause.get_execution_options()["query_formats"] == dict(_INTERNAL_QUERY_FORMATS)
+    assert clause.get_execution_options()[_INTERNAL_QUERY_OPTION] is _INTERNAL_QUERY_SENTINEL
+
+
+def test_cursor_private_execute_internal_marks_query_context():
+    client = _mock_client()
+    Cursor(client)._execute(
+        "SHOW TABLES",
+        query_formats=dict(_INTERNAL_QUERY_FORMATS),
+        internal=True,
+    )
+    assert client.create_query_context.return_value.internal is True
+
+
+def test_cursor_execute_is_not_internal():
+    client = _mock_client()
+    Cursor(client).execute("SELECT 13")
+    client.create_query_context.assert_not_called()
+
+
+@pytest.mark.parametrize("statement_level", [True, False])
+def test_dialect_do_execute_forwards_internal_marker(statement_level):
+    client = _mock_client()
+    if statement_level:
+        context = _FakeContext({}, with_internal_query_formats(text("SHOW TABLES")))
+    else:
+        context = _FakeContext({_INTERNAL_QUERY_OPTION: _INTERNAL_QUERY_SENTINEL, "query_formats": dict(_INTERNAL_QUERY_FORMATS)})
+    ClickHouseDialect().do_execute(Cursor(client), "SHOW TABLES", None, context=context)
+    assert client.create_query_context.return_value.internal is True
+
+
+@pytest.mark.parametrize("statement_level", [True, False])
+@pytest.mark.parametrize("marker", [None, True])
+def test_dialect_do_execute_user_statement_is_not_internal(statement_level, marker):
+    client = _mock_client()
+    execution_options: dict[str, Any] = {"query_formats": {"String": "bytes"}}
+    if marker is not None:
+        execution_options[_INTERNAL_QUERY_OPTION] = marker
+    if statement_level:
+        context = _FakeContext({}, text("SELECT 13").execution_options(**execution_options))
+    else:
+        context = _FakeContext(execution_options)
+    ClickHouseDialect().do_execute(Cursor(client), "SELECT 13", None, context=context)
+    client.create_query_context.assert_not_called()
+
+
+@pytest.mark.parametrize("no_params", [False, True])
+def test_dialect_user_statement_uses_previous_cursor_execute_signature(no_params):
+    client = _mock_client()
+    cursor = _PreviousSignatureCursor(client)
+    context = _FakeContext({_INTERNAL_QUERY_OPTION: True, "query_formats": {"String": "bytes"}})
+
+    if no_params:
+        ClickHouseDialect().do_execute_no_params(cursor, "SELECT 13", context=context)
+    else:
+        ClickHouseDialect().do_execute(cursor, "SELECT 13", None, context=context)
+
+    assert cursor.execute_called is True
+    client.create_query_context.assert_not_called()
+
+
+@pytest.mark.parametrize("internal", [False, True])
+def test_dialect_bypasses_incompatible_subclass_private_execute(internal):
+    client = _mock_client()
+    cursor = _IncompatiblePrivateExecuteCursor(client)
+    context = (
+        _FakeContext({}, with_internal_query_formats(text("SHOW TABLES"))) if internal else _FakeContext({_INTERNAL_QUERY_OPTION: True})
+    )
+
+    ClickHouseDialect().do_execute(cursor, "SHOW TABLES", None, context=context)
+
+    assert cursor.private_execute_called is False
+    if internal:
+        assert client.create_query_context.return_value.internal is True
+    else:
+        client.create_query_context.assert_not_called()
 
 
 class _StubColType:

--- a/tests/unit_tests/test_streaming_source.py
+++ b/tests/unit_tests/test_streaming_source.py
@@ -1,8 +1,10 @@
 import asyncio
+import gc
 import gzip
 import logging
 import threading
 import time
+import weakref
 import zlib
 from unittest.mock import Mock
 
@@ -627,6 +629,36 @@ def test_read_ahead_join_on_close():
     read_source.close()
     assert read_source._thread.is_alive() is False
     assert src.closed is True
+
+
+def test_read_ahead_abandoned_source_is_collected():
+    gc_was_enabled = gc.isenabled()
+    gc.disable()
+    read_source_ref = None
+    try:
+        src = MockByteSource([bytes([i % 256]) for i in range(500)])
+        read_source = ReadAheadSource(src, maxsize=2)
+        thread = read_source._thread
+        read_source_ref = weakref.ref(read_source)
+
+        assert next(read_source.gen) == b"\x00"
+        deadline = time.time() + 1.0
+        while time.time() < deadline and not read_source.queue.full():
+            time.sleep(0.01)
+        assert read_source.queue.full()
+
+        del read_source
+        thread.join(timeout=1.0)
+        assert read_source_ref() is None
+        assert thread.is_alive() is False
+        assert src.closed is True
+    finally:
+        if read_source_ref is not None:
+            leaked_source = read_source_ref()
+            if leaked_source is not None:
+                leaked_source.close()
+        if gc_was_enabled:
+            gc.enable()
 
 
 if __name__ == "__main__":

--- a/tests/unit_tests/test_streaming_source.py
+++ b/tests/unit_tests/test_streaming_source.py
@@ -17,6 +17,7 @@ from clickhouse_connect.driver.streaming import (
     ReadAheadSource,
     StreamingInsertSource,
     StreamingResponseSource,
+    _finalize_read_ahead_off_loop,
     _SyncStreamingInsertSource,
 )
 
@@ -577,6 +578,30 @@ class MockByteSource:
         self.closed = True
 
 
+class ReadBlockedByteSource:
+    def __init__(self):
+        self.read_started = threading.Event()
+        self.release_read = threading.Event()
+        self.closed = False
+        self.close_thread_id = None
+
+    @property
+    def gen(self):
+        self.read_started.set()
+        self.release_read.wait(timeout=5.0)
+        yield b"late"
+
+    def close(self):
+        self.close_thread_id = threading.get_ident()
+        self.closed = True
+        self.release_read.set()
+
+
+class RejectingLoop:
+    def call_soon_threadsafe(self, _callback, *_args):
+        raise RuntimeError("loop closed")
+
+
 def test_read_ahead_chunk_order():
     src = MockByteSource([b"a", b"b", b"c"])
     read_source = ReadAheadSource(src)
@@ -659,6 +684,63 @@ def test_read_ahead_abandoned_source_is_collected():
                 leaked_source.close()
         if gc_was_enabled:
             gc.enable()
+
+
+@pytest.mark.asyncio
+async def test_read_ahead_abandoned_source_does_not_block_event_loop():
+    gc_was_enabled = gc.isenabled()
+    gc.disable()
+    read_source_ref = None
+    source = ReadBlockedByteSource()
+    thread = None
+    try:
+        read_source = ReadAheadSource(source)
+        thread = read_source._thread
+        read_source_ref = weakref.ref(read_source)
+        _ = read_source.gen
+        assert await asyncio.to_thread(source.read_started.wait, 1.0)
+
+        loop = asyncio.get_running_loop()
+        loop_thread_id = threading.get_ident()
+        loop_ticked = asyncio.Event()
+        loop.call_soon(loop_ticked.set)
+        started = time.monotonic()
+        del read_source
+
+        await asyncio.wait_for(loop_ticked.wait(), timeout=0.5)
+        assert time.monotonic() - started < 0.5
+        assert read_source_ref() is None
+
+        deadline = loop.time() + 2.0
+        while loop.time() < deadline and not source.closed:
+            await asyncio.sleep(0.01)
+        assert source.closed is True
+        assert source.close_thread_id == loop_thread_id
+        await asyncio.to_thread(thread.join, 1.0)
+        assert thread.is_alive() is False
+    finally:
+        if read_source_ref is not None:
+            leaked_source = read_source_ref()
+            if leaked_source is not None:
+                leaked_source.close()
+        source.release_read.set()
+        if thread is not None:
+            await asyncio.to_thread(thread.join, 1.0)
+        if gc_was_enabled:
+            gc.enable()
+
+
+def test_read_ahead_finalizer_releases_source_when_loop_scheduling_fails():
+    src = MockByteSource([bytes([i % 256]) for i in range(500)])
+    read_source = ReadAheadSource(src, maxsize=2)
+    read_source._stop_event.set()
+    source, read_source.source = read_source.source, None
+    assert source is not None
+
+    _finalize_read_ahead_off_loop(RejectingLoop(), source, read_source.queue, read_source._thread)
+
+    assert read_source._thread.is_alive() is False
+    assert src.closed is True
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary

- make SQLAlchemy and Alembic metadata queries work under `rust_strict`
- apply `show_clickhouse_errors` to Rust streaming failures
- close abandoned Rust streams without leaking threads, sockets, or buffered data
- keep abandoned async stream cleanup off the event loop
- refresh the ch-core-rs v0.2.0 lock revision
- document Rust codec compatibility, workload guidance, and PyArrow requirements
- warn when missing PyArrow causes a Python codec fallback

## Checklist

- [x] Unit and integration tests covering the common scenarios were added
- [x] A human-readable description of the changes was provided to include in CHANGELOG