### PR TITLE
fix: retry aiohttp.ConnectionTimeoutError in async backend (#1012)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Bug Fixes
 
 - Multiprocessing workers now reuse one process-local urllib3 `PoolManager`. Creating and closing clients inside workers no longer retains one unused manager per client. Closes [#1016](https://github.com/ClickHouse/clickhouse-connect/issues/1016).
+- The async client now retries connection timeouts once for queries, rebuildable inserts, and `raw_insert` with bytes or strings. Raw generator and file bodies still raise the timeout because redirects may have consumed them. Socket read timeouts, connector errors, and certificate errors remain non-retryable. Closes [#1012](https://github.com/ClickHouse/clickhouse-connect/issues/1012).
 
 ## 1.8.0, 2026-09-02
 

--- a/clickhouse_connect/driver/_backend/http_async.py
+++ b/clickhouse_connect/driver/_backend/http_async.py
@@ -132,6 +132,8 @@ def release_lease(response: aiohttp.ClientResponse | None) -> None:
 
 
 def _is_retryable_async_connection_error(error: aiohttp.ClientConnectionError) -> bool:
+    if isinstance(error, aiohttp.ConnectionTimeoutError):
+        return True
     if isinstance(error, (aiohttp.ServerTimeoutError, aiohttp.ClientConnectorError, aiohttp.ServerFingerprintMismatch)):
         return False
     if isinstance(error, aiohttp.ServerDisconnectedError):

--- a/clickhouse_connect/driver/_backend/http_async.py
+++ b/clickhouse_connect/driver/_backend/http_async.py
@@ -50,6 +50,7 @@ if TYPE_CHECKING:
 logger = logging.getLogger(__name__)
 
 _REMOTE_CLOSE_ERRORS = (ConnectionResetError, BrokenPipeError)
+_CONNECTION_TIMEOUT_ERROR: type[aiohttp.ServerTimeoutError] | None = getattr(aiohttp, "ConnectionTimeoutError", None)
 
 
 def _plan_files(plan: QueryRequestPlan) -> dict[str, Any] | None:
@@ -131,9 +132,13 @@ def release_lease(response: aiohttp.ClientResponse | None) -> None:
         release()
 
 
-def _is_retryable_async_connection_error(error: aiohttp.ClientConnectionError) -> bool:
-    if isinstance(error, aiohttp.ConnectionTimeoutError):
-        return True
+def _is_async_connection_timeout(error: aiohttp.ClientConnectionError) -> bool:
+    if _CONNECTION_TIMEOUT_ERROR is not None:
+        return isinstance(error, _CONNECTION_TIMEOUT_ERROR)
+    return isinstance(error, aiohttp.ServerTimeoutError) and isinstance(error.__cause__, asyncio.TimeoutError)
+
+
+def _is_retryable_async_remote_close(error: aiohttp.ClientConnectionError) -> bool:
     if isinstance(error, (aiohttp.ServerTimeoutError, aiohttp.ClientConnectorError, aiohttp.ServerFingerprintMismatch)):
         return False
     if isinstance(error, aiohttp.ServerDisconnectedError):
@@ -452,6 +457,7 @@ class HttpAsyncBackend:
         query_session = final_params.get("session_id")
         attempts = 0
         auth_retried = False
+        connection_timeout_retried = False
 
         while True:
             attempts += 1
@@ -537,7 +543,20 @@ class HttpAsyncBackend:
 
             except aiohttp.ClientConnectionError as e:
                 msg = str(e)
-                if _is_retryable_async_connection_error(e):
+                if _is_async_connection_timeout(e):
+                    # A redirect may consume the body before a later connection times out.
+                    if not connection_timeout_retried and (
+                        retry_body is not None or data is None or isinstance(data, (bytes, bytearray, str, dict))
+                    ):
+                        connection_timeout_retried = True
+                        # The one connect retry does not consume the request retry budget.
+                        attempts -= 1
+                        if retry_body is not None:
+                            data = await retry_body()
+                        logger.debug("Retrying after connection timeout (attempt 1/2)")
+                        await asyncio.sleep(0.1)
+                        continue
+                elif _is_retryable_async_remote_close(e):
                     # Always allow at least one retry on a clean connection error so a single stale
                     # keep-alive socket doesn't surface to the caller, and additionally honor the
                     # retries budget when it is larger (e.g. query_retries for reads), so that
@@ -553,7 +572,7 @@ class HttpAsyncBackend:
                             logger.debug("Retrying after connection error from remote host (attempt %s/%s)", attempts, max_attempts)
                             await asyncio.sleep(0.1 * attempts)
                             continue
-                logger.debug("Non-retryable aiohttp connection error type=%s", type(e).__name__)
+                logger.debug("Not retrying aiohttp connection error type=%s", type(e).__name__)
                 if self.show_clickhouse_errors is True:
                     raise OperationalError(f"Network Error: {msg}") from e
                 logger.warning("Unexpected aiohttp connection error", exc_info=True)

--- a/tests/integration_tests/test_error_handling.py
+++ b/tests/integration_tests/test_error_handling.py
@@ -1,4 +1,7 @@
+import asyncio
+import io
 import logging
+import ssl
 from types import SimpleNamespace
 
 import aiohttp
@@ -30,6 +33,23 @@ def _client_connector_reset_error() -> aiohttp.ClientConnectorError:
     )
     error.__cause__ = error.os_error
     return error
+
+
+def _client_certificate_error() -> aiohttp.ClientConnectorCertificateError:
+    connection_key = SimpleNamespace(host="localhost", port=8123, ssl=True, is_ssl=True)
+    return aiohttp.ClientConnectorCertificateError(connection_key, ssl.CertificateError("certificate verify failed"))
+
+
+def _connection_timeout_error() -> aiohttp.ServerTimeoutError:
+    error_class = getattr(aiohttp, "ConnectionTimeoutError", aiohttp.ServerTimeoutError)
+    error = error_class("Connection timeout to host http://localhost:8123/")
+    error.__cause__ = asyncio.TimeoutError()
+    return error
+
+
+def _socket_timeout_error() -> aiohttp.ServerTimeoutError:
+    error_class = getattr(aiohttp, "SocketTimeoutError", aiohttp.ServerTimeoutError)
+    return error_class("Timeout on reading data from socket")
 
 
 def test_wrong_port_error_message(client_factory, test_config: TestConfig):
@@ -193,12 +213,16 @@ async def test_async_retry_on_remote_close_client_connection_error(test_native_a
             id="generic_connection_error",
         ),
         pytest.param(
-            lambda: aiohttp.SocketTimeoutError("Timeout on reading data from socket"),
+            _socket_timeout_error,
             id="socket_timeout",
         ),
         pytest.param(
             _client_connector_reset_error,
             id="connector_reset_error",
+        ),
+        pytest.param(
+            _client_certificate_error,
+            id="certificate_error",
         ),
         pytest.param(
             lambda: aiohttp.ServerFingerprintMismatch(b"expected", b"got", "localhost", 8123),
@@ -227,7 +251,7 @@ async def test_async_non_remote_close_connection_errors_are_not_retried(test_nat
 
 @pytest.mark.asyncio
 async def test_async_connection_timeout_is_retried(test_native_async_client, mocker):
-    """aiohttp.ConnectionTimeoutError is a connect-phase error; like urllib3's connect retry, it should be retried once."""
+    """A connect-phase timeout gets the same one retry as the sync transport."""
     real_request = test_native_async_client._session.request
     attempts = 0
 
@@ -235,7 +259,7 @@ async def test_async_connection_timeout_is_retried(test_native_async_client, moc
         nonlocal attempts
         attempts += 1
         if attempts == 1:
-            raise aiohttp.ConnectionTimeoutError("Connection timeout to host http://localhost:8123/")
+            raise _connection_timeout_error()
         return await real_request(*args, **kwargs)
 
     mocker.patch.object(test_native_async_client._session, "request", side_effect=flaky_request)
@@ -244,6 +268,193 @@ async def test_async_connection_timeout_is_retried(test_native_async_client, moc
 
     assert attempts == 2
     assert result.result_rows[0][0] == 13
+
+
+@pytest.mark.asyncio
+async def test_async_connection_timeout_stops_after_one_retry(test_native_async_client, mocker):
+    """The connect retry is independent of the larger query retry budget."""
+    errors = []
+
+    async def failing_request(*args, **kwargs):
+        error = _connection_timeout_error()
+        errors.append(error)
+        raise error
+
+    request = mocker.patch.object(test_native_async_client._session, "request", side_effect=failing_request)
+
+    with pytest.raises(OperationalError) as excinfo:
+        await test_native_async_client.query("SELECT 13")
+
+    assert request.call_count == 2
+    assert excinfo.value.__cause__ is errors[-1]
+
+
+@pytest.mark.asyncio
+async def test_async_connection_timeout_does_not_consume_query_retry_budget(test_native_async_client, mocker):
+    """A connect timeout leaves both query retries available for HTTP status failures."""
+    real_request = test_native_async_client._session.request
+    response_503 = mocker.Mock(status=503, headers={})
+    attempts = 0
+
+    async def flaky_request(*args, **kwargs):
+        nonlocal attempts
+        attempts += 1
+        if attempts == 1:
+            raise _connection_timeout_error()
+        if attempts < 4:
+            return response_503
+        return await real_request(*args, **kwargs)
+
+    mocker.patch.object(test_native_async_client._session, "request", side_effect=flaky_request)
+
+    result = await test_native_async_client.query("SELECT 13")
+
+    assert attempts == 4
+    assert response_503.close.call_count == 2
+    assert result.result_rows == [(13,)]
+
+
+@pytest.mark.asyncio
+async def test_async_remote_close_keeps_shared_query_retry_budget(test_native_async_client, mocker):
+    """An earlier HTTP retry still counts against later stale connection failures."""
+    response_503 = mocker.Mock(status=503, headers={})
+    attempts = 0
+
+    async def failing_request(*args, **kwargs):
+        nonlocal attempts
+        attempts += 1
+        if attempts == 1:
+            return response_503
+        raise aiohttp.ServerDisconnectedError()
+
+    mocker.patch.object(test_native_async_client._session, "request", side_effect=failing_request)
+
+    with pytest.raises(OperationalError) as excinfo:
+        await test_native_async_client.query("SELECT 13")
+
+    assert attempts == 3
+    assert response_503.close.call_count == 1
+    assert isinstance(excinfo.value.__cause__, aiohttp.ServerDisconnectedError)
+
+
+@pytest.mark.asyncio
+async def test_async_connection_timeout_does_not_replay_consumed_generator(test_native_async_client, mocker, table_context):
+    """A redirect can consume a raw generator before a connection timeout."""
+    real_request = test_native_async_client._session.request
+    consumed = 0
+    attempts = 0
+
+    async def chunks():
+        nonlocal consumed
+        consumed += 1
+        yield b"13\n"
+
+    body = chunks()
+
+    async def flaky_request(*args, **kwargs):
+        nonlocal attempts
+        data = kwargs.get("data")
+        if data is body:
+            attempts += 1
+            if attempts == 1:
+                async for _ in data:
+                    pass
+                raise _connection_timeout_error()
+        return await real_request(*args, **kwargs)
+
+    with table_context("raw_insert_generator_connect_timeout", ["key Int32"]):
+        mocker.patch.object(test_native_async_client._session, "request", side_effect=flaky_request)
+        with pytest.raises(OperationalError):
+            await test_native_async_client.raw_insert("raw_insert_generator_connect_timeout", ["key"], body, fmt="CSV")
+        rows = (await test_native_async_client.query("SELECT key FROM raw_insert_generator_connect_timeout")).result_rows
+
+    assert attempts == 1
+    assert consumed == 1
+    assert rows == []
+
+
+@pytest.mark.asyncio
+async def test_async_connection_timeout_does_not_replay_consumed_binary_io(test_native_async_client, mocker, table_context):
+    """A redirect can consume a raw file body before a connection timeout."""
+    real_request = test_native_async_client._session.request
+    body = io.BytesIO(b"13\n")
+    attempts = 0
+
+    async def flaky_request(*args, **kwargs):
+        nonlocal attempts
+        data = kwargs.get("data")
+        if data is body:
+            attempts += 1
+            if attempts == 1:
+                assert data.read() == b"13\n"
+                raise _connection_timeout_error()
+        return await real_request(*args, **kwargs)
+
+    with table_context("raw_insert_connect_timeout", ["key Int32"]):
+        mocker.patch.object(test_native_async_client._session, "request", side_effect=flaky_request)
+        with pytest.raises(OperationalError):
+            await test_native_async_client.raw_insert("raw_insert_connect_timeout", ["key"], body, fmt="CSV")
+        rows = (await test_native_async_client.query("SELECT key FROM raw_insert_connect_timeout")).result_rows
+
+    assert attempts == 1
+    assert rows == []
+
+
+@pytest.mark.parametrize("body", [b"13\n79\n", bytearray(b"13\n79\n"), "13\n79\n"], ids=["bytes", "bytearray", "str"])
+@pytest.mark.asyncio
+async def test_async_connection_timeout_retries_replayable_body(test_native_async_client, mocker, table_context, body):
+    """A consumed wrapper is replaced before retrying a replayable raw insert."""
+    real_request = test_native_async_client._session.request
+    attempts = 0
+
+    async def flaky_request(*args, **kwargs):
+        nonlocal attempts
+        data = kwargs.get("data")
+        if isinstance(data, io.BytesIO):
+            attempts += 1
+            if attempts == 1:
+                assert data.read().endswith(b"13\n79\n")
+                raise _connection_timeout_error()
+        return await real_request(*args, **kwargs)
+
+    with table_context("raw_insert_replayable_connect_timeout", ["key Int32"]):
+        request = mocker.patch.object(test_native_async_client._session, "request", side_effect=flaky_request)
+        await test_native_async_client.raw_insert("raw_insert_replayable_connect_timeout", ["key"], body, fmt="CSV")
+        mocker.stop(request)
+        rows = (await test_native_async_client.query("SELECT key FROM raw_insert_replayable_connect_timeout ORDER BY key")).result_rows
+
+    assert attempts == 2
+    assert rows == [(13,), (79,)]
+
+
+@pytest.mark.asyncio
+async def test_async_connection_timeout_rebuilds_consumed_insert_body(test_native_async_client, mocker, table_context):
+    """A consumed Native insert body is rebuilt before retrying a connection timeout."""
+    real_request = test_native_async_client._session.request
+    attempts = 0
+
+    async def flaky_request(*args, **kwargs):
+        nonlocal attempts
+        data = kwargs.get("data")
+        if hasattr(data, "__aiter__"):
+            attempts += 1
+            if attempts == 1:
+                chunks = [chunk async for chunk in data]
+                assert b"".join(chunks)
+                raise _connection_timeout_error()
+        return await real_request(*args, **kwargs)
+
+    with table_context("insert_rebuild_connect_timeout", ["key Int32", "name String"]):
+        mocker.patch.object(test_native_async_client._session, "request", side_effect=flaky_request)
+        await test_native_async_client.insert(
+            "insert_rebuild_connect_timeout",
+            [[13, "user_1"], [79, "user_2"]],
+            column_names=["key", "name"],
+        )
+        rows = (await test_native_async_client.query("SELECT key, name FROM insert_rebuild_connect_timeout ORDER BY key")).result_rows
+
+    assert attempts == 2
+    assert rows == [(13, "user_1"), (79, "user_2")]
 
 
 @pytest.mark.parametrize(

--- a/tests/integration_tests/test_error_handling.py
+++ b/tests/integration_tests/test_error_handling.py
@@ -197,10 +197,6 @@ async def test_async_retry_on_remote_close_client_connection_error(test_native_a
             id="socket_timeout",
         ),
         pytest.param(
-            lambda: aiohttp.ConnectionTimeoutError("Connection timeout to host http://localhost:8123/"),
-            id="connection_timeout",
-        ),
-        pytest.param(
             _client_connector_reset_error,
             id="connector_reset_error",
         ),
@@ -227,6 +223,27 @@ async def test_async_non_remote_close_connection_errors_are_not_retried(test_nat
 
     assert attempts == 1
     assert isinstance(excinfo.value.__cause__, aiohttp.ClientConnectionError)
+
+
+@pytest.mark.asyncio
+async def test_async_connection_timeout_is_retried(test_native_async_client, mocker):
+    """aiohttp.ConnectionTimeoutError is a connect-phase error; like urllib3's connect retry, it should be retried once."""
+    real_request = test_native_async_client._session.request
+    attempts = 0
+
+    async def flaky_request(*args, **kwargs):
+        nonlocal attempts
+        attempts += 1
+        if attempts == 1:
+            raise aiohttp.ConnectionTimeoutError("Connection timeout to host http://localhost:8123/")
+        return await real_request(*args, **kwargs)
+
+    mocker.patch.object(test_native_async_client._session, "request", side_effect=flaky_request)
+
+    result = await test_native_async_client.query("SELECT 13")
+
+    assert attempts == 2
+    assert result.result_rows[0][0] == 13
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
## Summary

Fixes #1012.

`aiohttp.ConnectionTimeoutError` is a connect-phase timeout (TCP handshake did not complete). It is a strict subclass of `aiohttp.ServerTimeoutError`. The existing `_is_retryable_async_connection_error` guard caught it via the `ServerTimeoutError` branch and returned `False` (not retryable).

The sync backend uses urllib3's `Retry(1)` which retries connect errors once. This fix makes the async client consistent: add an explicit early check so `ConnectionTimeoutError` returns `True` before reaching the `ServerTimeoutError` branch.

**Change:**
- `clickhouse_connect/driver/_backend/http_async.py`: guard `ConnectionTimeoutError` before `ServerTimeoutError`
- `tests/integration_tests/test_error_handling.py`: remove `connection_timeout` from the "not retried" parametrize list; add `test_async_connection_timeout_is_retried` asserting a single `ConnectionTimeoutError` on the first attempt succeeds on the second (attempts == 2)

## Checklist
- [x] Unit and integration tests covering the common scenarios were added
- [x] A human-readable description of the changes was provided to include in CHANGELOG

Prepared with AI assistance (Claude Code, Anthropic), reviewed for correctness before submission.