### PR TITLE
fix(sqlalchemy): support explicit multi-row inserts (#1024)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## UNRELEASED
 
+### Improvements
+
+- SQLAlchemy multi-row `Insert.values()` statements now compile and execute. Rows can be dictionaries, tuples in table column order, or rows containing SQL expressions, with client-side or server-side bind parameters. This also enables Pandas `to_sql(method="multi")`. See the SQLAlchemy documentation for column selection rules and the bind parameter ceiling that applies to server-side parameters on ClickHouse 26.4 and newer. Closes [#1024](https://github.com/ClickHouse/clickhouse-connect/issues/1024).
+
 ## 1.8.0, 2026-09-02
 
 ### Improvements

--- a/clickhouse_connect/cc_sqlalchemy/MIGRATING_FROM_CLICKHOUSE_SQLALCHEMY.md
+++ b/clickhouse_connect/cc_sqlalchemy/MIGRATING_FROM_CLICKHOUSE_SQLALCHEMY.md
@@ -151,6 +151,10 @@ ClickHouse does not behave like a row-store OLTP database with meaningful row-le
 - Pandas / Arrow: `client.insert_df("t", df)` or `client.insert_arrow("t", arrow_table)`
 - Schema changes: Alembic `op.execute(...)`
 
+`clickhouse-connect` also accepts explicit multi-row Core inserts, such as `engine.connect().execute(t.insert().values(list_of_row_dicts))`. Rows can be dictionaries, tuples in table column order, or rows with SQL expressions. Pandas `to_sql(method="multi")` uses this form. It inserts the rows but returns `0` because textual INSERT statements report a row count of `0` through the DB-API cursor. SQLAlchemy determines the column list from the first row. Extra dictionary keys in later rows and tuple values outside that selected column list are ignored. A later row missing a selected value fails compilation. Give every row the same columns.
+
+With the default HTTP form limits in ClickHouse 26.4 and newer, `server_side_params=True` is suitable only for small explicit batches, below about 1000 bind values with headroom for other fields. Server configuration can raise this ceiling. For large plain batches, keep the rows as the second `execute()` argument so the driver can use its Native bulk insert path.
+
 Session for reads (`session.execute(select(...))`) is fine. Custom `Session` or `Query` subclasses for event hooks, telemetry, or filter helpers (not `clickhouse-sqlalchemy`'s `ClickHouseQuery`, which you drop per the rewrite table) still compose: `sessionmaker(bind=engine, class_=YourSession, query_cls=YourQuery)`.
 
 ### Escaper

--- a/clickhouse_connect/cc_sqlalchemy/dialect.py
+++ b/clickhouse_connect/cc_sqlalchemy/dialect.py
@@ -34,6 +34,7 @@ class ClickHouseDialect(DefaultDialect):
     default_schema_name = "default"
     supports_native_decimal = True
     supports_native_boolean = True
+    supports_multivalues_insert = True
     supports_statement_cache = False
     supports_comments = True
     inline_comments = True

--- a/docs/sqlalchemy.mdx
+++ b/docs/sqlalchemy.mdx
@@ -377,6 +377,10 @@ with engine.connect() as conn:
     )
 ```
 
+Explicit multi-row `insert(events).values([...])` statements work with dictionary rows, tuples in table column order, and per-row SQL expressions. Pandas `to_sql(method="multi")` uses this form. It inserts the rows but returns `0` because textual INSERT statements report a row count of `0` through the DB-API cursor. SQLAlchemy determines the column list from the first row. Extra dictionary keys in later rows and tuple values outside that selected column list are ignored. A later row missing a selected value fails compilation. Give every row the same columns.
+
+With the default HTTP form limits in ClickHouse 26.4 and newer, `server_side_params=True` is suitable only for small explicit batches, below about 1000 bind values with headroom for other fields. Server configuration can raise this ceiling. For large plain batches, pass rows as the second argument to `execute()` so the driver can use its Native bulk insert path.
+
 ```python
 import sqlalchemy as db
 from sqlalchemy import MetaData

--- a/tests/integration_tests/test_sqlalchemy/test_server_side_params.py
+++ b/tests/integration_tests/test_sqlalchemy/test_server_side_params.py
@@ -1,10 +1,10 @@
-"""End-to-end tests for the opt-in server_side_params mode (issue #735)."""
+"""End-to-end SQLAlchemy parameter and multi-row INSERT tests."""
 
 from collections.abc import Iterator
 
 import pytest
 from pytest import fixture
-from sqlalchemy import Integer, MetaData, Table, bindparam, insert, inspect, select, text, tuple_
+from sqlalchemy import Integer, MetaData, Table, bindparam, func, insert, inspect, select, text, tuple_
 from sqlalchemy.engine import Engine, create_engine
 
 from clickhouse_connect.cc_sqlalchemy.datatypes.sqltypes import Int32
@@ -112,6 +112,52 @@ def test_insert_then_select(server_side_engine: Engine, ssp_table: Table):
     stmt = select(ssp_table.c.name).where(ssp_table.c.id == 21)
     with server_side_engine.connect() as conn:
         assert [row[0] for row in conn.execute(stmt)] == ["user_3"]
+
+
+@pytest.mark.parametrize(
+    ("server_side", "first_id"),
+    [(False, 101), (True, 111)],
+    ids=["client-side", "server-side"],
+)
+def test_multivalues_insert(
+    server_side: bool,
+    first_id: int,
+    test_engine: Engine,
+    server_side_engine: Engine,
+    ssp_table: Table,
+):
+    engine = server_side_engine if server_side else test_engine
+    statements = [
+        insert(ssp_table).values(
+            [{"id": first_id, "name": "dict_1"}, {"id": first_id + 1, "name": "dict_2"}],
+        ),
+        insert(ssp_table).values([(first_id + 2, "tuple_1"), (first_id + 3, "tuple_2")]),
+        insert(ssp_table).values(
+            [
+                {"id": first_id + 4, "name": func.lower("EXPRESSION_1")},
+                {"id": first_id + 5, "name": func.lower("EXPRESSION_2")},
+            ],
+        ),
+    ]
+
+    with engine.begin() as conn:
+        for statement in statements:
+            conn.execute(statement)
+        rows = conn.execute(
+            select(ssp_table.c.id, ssp_table.c.name)
+            .where(ssp_table.c.id >= first_id)
+            .where(ssp_table.c.id < first_id + 6)
+            .order_by(ssp_table.c.id),
+        ).all()
+
+    assert rows == [
+        (first_id, "dict_1"),
+        (first_id + 1, "dict_2"),
+        (first_id + 2, "tuple_1"),
+        (first_id + 3, "tuple_2"),
+        (first_id + 4, "expression_1"),
+        (first_id + 5, "expression_2"),
+    ]
 
 
 def test_reflection_has_table(server_side_engine: Engine, test_db: str):

--- a/tests/unit_tests/test_sqlalchemy/test_server_side_params.py
+++ b/tests/unit_tests/test_sqlalchemy/test_server_side_params.py
@@ -1,9 +1,11 @@
-"""Compile-time tests for the opt-in server_side_params mode (issue #735)."""
+"""SQLAlchemy parameter compilation and multi-row INSERT tests."""
 
 from datetime import timedelta
+from unittest.mock import Mock, patch
 
 import pytest
-from sqlalchemy import Integer, String, TypeDecorator, bindparam, column, select, table, text, tuple_
+from sqlalchemy import Integer, String, TypeDecorator, bindparam, column, create_engine, func, insert, select, table, text, tuple_
+from sqlalchemy.engine import Engine
 from sqlalchemy.exc import CompileError
 
 from clickhouse_connect import dbapi
@@ -81,6 +83,87 @@ def test_flag_off_keeps_pyformat():
     sql = _sql(select(events.c.id).where(events.c.id == 13), server_side=False)
     assert "%(id_1)s" in sql
     assert "{id_1:" not in sql
+
+
+@pytest.mark.parametrize("server_side", [False, True], ids=["client-side", "server-side"])
+@pytest.mark.parametrize(
+    ("values", "client_sql", "server_sql", "expected_params"),
+    [
+        (
+            [{"id": 13, "name": "user_1"}, {"id": 79, "name": "user_2"}],
+            "INSERT INTO `events` (`id`, `name`) VALUES (%(id_m0)s, %(name_m0)s), (%(id_m1)s, %(name_m1)s)",
+            "INSERT INTO `events` (`id`, `name`) VALUES ({id_m0:Int32}, {name_m0:String}), ({id_m1:Int32}, {name_m1:String})",
+            {"id_m0": 13, "name_m0": "user_1", "id_m1": 79, "name_m1": "user_2"},
+        ),
+        (
+            [(13, "user_1"), (79, "user_2")],
+            "INSERT INTO `events` (`id`, `name`) VALUES (%(id_m0)s, %(name_m0)s), (%(id_m1)s, %(name_m1)s)",
+            "INSERT INTO `events` (`id`, `name`) VALUES ({id_m0:Int32}, {name_m0:String}), ({id_m1:Int32}, {name_m1:String})",
+            {"id_m0": 13, "name_m0": "user_1", "id_m1": 79, "name_m1": "user_2"},
+        ),
+        (
+            [{"id": 13, "name": func.lower("USER_1")}, {"id": 79, "name": func.lower("USER_2")}],
+            "INSERT INTO `events` (`id`, `name`) VALUES (%(id_m0)s, lower(%(lower_1)s)), (%(id_m1)s, lower(%(lower_2)s))",
+            "INSERT INTO `events` (`id`, `name`) VALUES ({id_m0:Int32}, lower({lower_1:String})), ({id_m1:Int32}, lower({lower_2:String}))",
+            {"id_m0": 13, "lower_1": "USER_1", "id_m1": 79, "lower_2": "USER_2"},
+        ),
+    ],
+    ids=["dicts", "tuples", "per-row-expressions"],
+)
+def test_multivalues_insert_compiles(server_side, values, client_sql, server_sql, expected_params):
+    compiled = _compile(insert(events).values(values), server_side=server_side)
+
+    assert str(compiled) == (server_sql if server_side else client_sql)
+    assert compiled.params == expected_params
+
+
+class _StubColumnType:
+    name = "String"
+
+
+class _StubQueryResult:
+    result_set = [["default"]]
+    column_names = ["currentDatabase()"]
+    column_types = [_StubColumnType()]
+    summary = {}
+
+
+class _StubInsertResult:
+    written_rows = 2
+    summary = {}
+
+
+@pytest.fixture(name="routing_engine")
+def routing_engine_fixture():
+    client = Mock()
+    client.server_tz = "UTC"
+    client.query.return_value = _StubQueryResult()
+    client.insert.return_value = _StubInsertResult()
+    with patch("clickhouse_connect.dbapi.connection.create_client", return_value=client):
+        engine: Engine = create_engine("clickhousedb://user_1:pwd@localhost:8123/default")
+        try:
+            yield engine, client
+        finally:
+            engine.dispose()
+
+
+def test_multivalues_insert_dispatch(routing_engine):
+    engine, client = routing_engine
+    rows = [{"id": 13, "name": "user_1"}, {"id": 79, "name": "user_2"}]
+
+    with engine.begin() as conn:
+        client.query.reset_mock()
+        client.insert.reset_mock()
+        conn.execute(insert(events).values(rows))
+
+        client.query.assert_called_once()
+        client.insert.assert_not_called()
+
+        client.query.reset_mock()
+        conn.execute(insert(events), rows)
+
+        client.query.assert_not_called()
+        client.insert.assert_called_once_with("`events`", [[13, "user_1"], [79, "user_2"]], ["id", "name"], settings=None)
 
 
 def test_double_percents_disabled_only_when_enabled():


### PR DESCRIPTION
## Summary

Enable SQLAlchemy multi-row `insert.values()`, including per-row expressions. 

Closes #1024

## Checklist
Delete items not relevant to your PR:
- [X] Unit and integration tests covering the common scenarios were added
- [X] A human-readable description of the changes was provided to include in CHANGELOG
- [X] For significant changes, documentation in https://github.com/ClickHouse/clickhouse-docs was updated with further explanations or tutorials
