### PR TITLE
Fix async connection timeouts during pool waits

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 
 ### Bug Fixes
 
+- Async requests waiting for a free connection no longer fail when the pool wait exceeds `connect_timeout`. The timeout still covers DNS, TCP, TLS, and proxy connection setup after a pool slot is available. Closes [#1013](https://github.com/ClickHouse/clickhouse-connect/issues/1013).
 - SQLAlchemy SQL-text inserts, comparisons, and literal rendering now preserve fractional seconds for typed `DateTime64` values, including nested arrays and tuples. `DateTime` formatting, timezone handling, and Native bulk inserts retain their existing behavior. SQLAlchemy column types must match the server schema: declaring `DateTime64` over a server `DateTime` column can now raise conversion errors, including in `IN` comparisons. Closes [#1030](https://github.com/ClickHouse/clickhouse-connect/issues/1030).
 - Native inserts into `Date` and `Date32` columns now accept timezone-aware datetimes and mixed `date` and `datetime` values. They preserve each value's calendar date without converting its timezone, including in nullable and nested columns. Low cardinality columns also preserve different calendar dates when their datetime values represent the same instant. Closes [#1031](https://github.com/ClickHouse/clickhouse-connect/issues/1031).
 - SQLAlchemy arithmetic on ClickHouse `Decimal` columns and aggregates no longer raises an invalid precision or scale error. Expressions preserve configured operand types and existing numeric promotion behavior. Closes [#1027](https://github.com/ClickHouse/clickhouse-connect/issues/1027).

--- a/clickhouse_connect/driver/__init__.py
+++ b/clickhouse_connect/driver/__init__.py
@@ -230,7 +230,7 @@ def create_client(
     :param compress: Enable compression for ClickHouse HTTP inserts and query results.  True will select the preferred
       compression method (lz4).  A str of 'lz4', 'zstd', 'br', or 'gzip' can be used to use a specific compression type
     :param query_limit: Default LIMIT on returned rows.  0 means no limit
-    :param connect_timeout:  Timeout in seconds for the http connection
+    :param connect_timeout: Timeout in seconds for establishing a new HTTP connection, excluding pool wait time.
     :param send_receive_timeout: Read timeout in seconds for http connection
     :param client_name: client_name prepended to the HTTP User Agent header. Set this to track client queries
       in the ClickHouse system.query_log.
@@ -394,7 +394,7 @@ async def create_async_client(
     :param compress: Enable compression for ClickHouse HTTP inserts and query results.  True will select the preferred
       compression method (lz4).  A str of 'lz4', 'zstd', 'br', or 'gzip' can be used to use a specific compression type
     :param query_limit: Default LIMIT on returned rows.  0 means no limit
-    :param connect_timeout:  Timeout in seconds for the http connection
+    :param connect_timeout: Timeout in seconds for establishing a new HTTP connection, excluding pool wait time.
     :param send_receive_timeout: Read timeout in seconds for http connection
     :param client_name: client_name prepended to the HTTP User Agent header. Set this to track client queries
       in the ClickHouse system.query_log.

--- a/clickhouse_connect/driver/_backend/http_async.py
+++ b/clickhouse_connect/driver/_backend/http_async.py
@@ -19,6 +19,7 @@ from collections.abc import Awaitable, Callable, Sequence
 from typing import TYPE_CHECKING, Any, cast
 
 import aiohttp
+from aiohttp.helpers import ceil_timeout
 
 from clickhouse_connect import common
 from clickhouse_connect.driver._backend.httpcommon import (
@@ -41,6 +42,9 @@ from clickhouse_connect.driver.exceptions import OperationalError, ProgrammingEr
 from clickhouse_connect.driver.streaming import start_streaming_response
 
 if TYPE_CHECKING:
+    from aiohttp.client_proto import ResponseHandler
+    from aiohttp.tracing import Trace
+
     from clickhouse_connect.driver._backend.contracts import AsyncBackend
     from clickhouse_connect.driver._backend.httpcommon import QueryRequestPlan
     from clickhouse_connect.driver.external import ExternalData
@@ -150,6 +154,16 @@ def _is_retryable_async_remote_close(error: aiohttp.ClientConnectionError) -> bo
     return isinstance(error.__context__, _REMOTE_CLOSE_ERRORS)
 
 
+class _TCPConnector(aiohttp.TCPConnector):
+    """Apply the connection deadline after acquiring a pool slot."""
+
+    # This adapter uses aiohttp's private _create_connection and helpers.ceil_timeout hooks.
+    async def _create_connection(self, req: aiohttp.ClientRequest, traces: list[Trace], timeout: aiohttp.ClientTimeout) -> ResponseHandler:
+        # Include DNS, TLS, and proxy negotiation in the connection budget.
+        async with ceil_timeout(timeout.sock_connect, ceil_threshold=timeout.ceil_threshold):
+            return await super()._create_connection(req, traces, timeout)
+
+
 class HttpAsyncBackend:
     capabilities = Capabilities(native_async=True, sessions=True)
 
@@ -202,7 +216,7 @@ class HttpAsyncBackend:
         self.session_lease = SessionLease(value) if value is not None else None
 
     def _new_session(self) -> aiohttp.ClientSession:
-        connector = aiohttp.TCPConnector(**self.connector_kwargs)
+        connector = _TCPConnector(**self.connector_kwargs)
         return aiohttp.ClientSession(
             connector=connector,
             timeout=self.timeout,

--- a/clickhouse_connect/driver/asyncclient.py
+++ b/clickhouse_connect/driver/asyncclient.py
@@ -204,7 +204,7 @@ class AsyncClient(Client):
 
         self._timeout = aiohttp.ClientTimeout(
             total=None,
-            connect=connect_timeout_val,
+            connect=None,
             sock_connect=connect_timeout_val,
             sock_read=send_receive_timeout_val,
         )

--- a/docs/advanced-usage.mdx
+++ b/docs/advanced-usage.mdx
@@ -178,3 +178,5 @@ client2 = clickhouse_connect.get_client(pool_mgr=big_pool_mgr)
 Clients can share a pool manager, or each client can use a separate manager. For more details, see the [`urllib3` PoolManager documentation](https://urllib3.readthedocs.io/en/stable/advanced-usage.html#customizing-pool-behavior).
 
 The async client owns an aiohttp pool rather than using `urllib3`. Configure it through `connector_limit`, `connector_limit_per_host`, and `keepalive_timeout` on `get_async_client`. Calling `await async_client.close_connections()` rotates the pool without interrupting in-flight requests.
+
+For async queries and inserts, waiting for a free pool slot has no timeout. Fully read or close streaming responses to release their pool slots. `connect_timeout` starts after a slot is available and covers DNS resolution, TCP and TLS setup, and proxy negotiation. `send_receive_timeout` limits socket reads. To set a deadline for the whole operation, including pool waiting, use `asyncio.wait_for`, for example `await asyncio.wait_for(client.query("SELECT 13"), timeout=30)`.

--- a/docs/driver-api.mdx
+++ b/docs/driver-api.mdx
@@ -36,7 +36,7 @@ Use `clickhouse_connect.get_client` to create a synchronous `Client`, or install
 | `compress` | bool or str | `True` | Enable compression or select `"lz4"`, `"zstd"`, `"br"`, or `"gzip"`. See [Compression](/integrations/language-clients/python/additional-options#compression). |
 | `query_limit` | int | `0` | Default row limit appended to eligible queries. Zero means unlimited. Stream large results instead of materializing them all in memory. |
 | `query_retries` | int | `2` | Retry budget for retryable read failures. Commands and inserts are not generally retried because replay can duplicate side effects. |
-| `connect_timeout` | int | `10` | Connection timeout in seconds. |
+| `connect_timeout` | int | `10` | Timeout in seconds for establishing a new connection. Waiting for a free connection pool slot is excluded. |
 | `send_receive_timeout` | int | `300` | Socket read timeout in seconds. |
 | `client_name` | str or None | `None` | Prefix added to the HTTP User-Agent for identification in `system.query_log`. |
 | `session_id` | str or None | Generated for sync | Explicit ClickHouse session ID. Synchronous clients generate one by default; async clients do not. |

--- a/tests/integration_tests/test_async_features.py
+++ b/tests/integration_tests/test_async_features.py
@@ -2,6 +2,7 @@ import asyncio
 import time
 from collections.abc import Callable
 
+import aiohttp
 import pytest
 
 from clickhouse_connect import get_async_client
@@ -154,6 +155,64 @@ async def test_connection_pool_reuse(test_config):
             assert result.result_rows[0][0] == i
 
         assert elapsed < 10.0
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("limits", [(1, 0), (2, 1)], ids=["global", "per_host"])
+async def test_pool_wait_does_not_use_connect_timeout(test_config, mocker, limits):
+    async with await get_async_client(
+        **make_client_config(
+            test_config,
+            connect_timeout=1,
+            connector_limit=limits[0],
+            connector_limit_per_host=limits[1],
+            autogenerate_session_id=False,
+        )
+    ) as client:
+        session = client._session
+        connector = session.connector
+        queued = asyncio.Event()
+        queue_entries = 0
+
+        async def on_queued(*_):
+            nonlocal queue_entries
+            queue_entries += 1
+            if queue_entries == 2:
+                queued.set()
+
+        trace = aiohttp.TraceConfig()
+        trace.on_connection_queued_start.append(on_queued)
+        trace.freeze()
+        session.trace_configs.append(trace)
+        connect = mocker.spy(connector, "connect")
+        await client.query("SELECT 13")
+        request = connect.call_args.args[0]
+        mocker.stop(connect)
+        # Hold the real pool slot until both requests have queued.
+        held = await connector.connect(request, traces=[], timeout=session.timeout)
+        query = asyncio.create_task(client.query("SELECT 13"))
+        cancelled = asyncio.create_task(client.query("SELECT 79"))
+        try:
+            try:
+                await asyncio.wait_for(queued.wait(), 5)
+                cancelled.cancel()
+                with pytest.raises(asyncio.CancelledError):
+                    await cancelled
+
+                # Exceed both connect deadlines and the driver's retry delay.
+                await asyncio.sleep(2.5)
+                assert not query.done()
+                assert queue_entries == 2
+            finally:
+                held.release()
+            result = await asyncio.wait_for(query, 10)
+            assert result.result_rows == [(13,)]
+            assert client._backend.session_lease._inflight == 0
+            assert (await client.query("SELECT 79")).result_rows == [(79,)]
+        finally:
+            query.cancel()
+            cancelled.cancel()
+            await asyncio.gather(query, cancelled, return_exceptions=True)
 
 
 @pytest.mark.asyncio

--- a/tests/unit_tests/test_driver/test_async_timeouts.py
+++ b/tests/unit_tests/test_driver/test_async_timeouts.py
@@ -1,0 +1,96 @@
+import asyncio
+
+import aiohttp
+import pytest
+
+from clickhouse_connect.driver.asyncclient import AsyncClient
+from clickhouse_connect.driver.exceptions import OperationalError
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("connect_timeout", [0.05, 0, None])
+async def test_dns_connection_deadline(mocker, connect_timeout):
+    started = asyncio.Event()
+    resolving = set()
+
+    async def resolve(*_args, **_kwargs):
+        resolving.add(asyncio.current_task())
+        started.set()
+        await asyncio.Event().wait()
+
+    resolver = aiohttp.resolver.ThreadedResolver()
+    resolve_mock = mocker.patch.object(resolver, "resolve", side_effect=resolve)
+    client = AsyncClient("http", "timeout.invalid", 8123, connect_timeout=connect_timeout)
+    backend = client._backend
+    backend.connector_kwargs.update(resolver=resolver, use_dns_cache=False)
+    backend.ensure_session()
+    connector = backend.session.connector
+    task = asyncio.create_task(backend.request(b"SELECT 13", {}))
+    try:
+        await asyncio.wait_for(started.wait(), 5)
+        if connect_timeout:
+            with pytest.raises(OperationalError) as exc_info:
+                await asyncio.wait_for(task, 5)
+            assert isinstance(exc_info.value.__cause__, aiohttp.ServerTimeoutError)
+            assert isinstance(exc_info.value.__cause__.__cause__, asyncio.TimeoutError)
+            assert resolve_mock.call_count == 2
+        else:
+            await asyncio.sleep(0.15)
+            assert not task.done()
+            task.cancel()
+            with pytest.raises(asyncio.CancelledError):
+                await task
+            assert resolve_mock.call_count == 1
+        assert not connector._acquired
+        assert backend.session_lease._inflight == 0
+    finally:
+        task.cancel()
+        await asyncio.gather(task, return_exceptions=True)
+        for resolve_task in resolving:
+            resolve_task.cancel()
+        await asyncio.gather(*resolving, return_exceptions=True)
+        await client.close()
+        await resolver.close()
+
+
+@pytest.mark.asyncio
+async def test_proxy_connect_deadline():
+    requests = []
+    handlers = set()
+
+    async def proxy(reader, writer):
+        task = asyncio.current_task()
+        handlers.add(task)
+        try:
+            request = await reader.readuntil(b"\r\n\r\n")
+            requests.append(request.split(b"\r\n", 1)[0])
+            await reader.read()
+        finally:
+            writer.close()
+            await writer.wait_closed()
+            handlers.remove(task)
+
+    server = await asyncio.start_server(proxy, "127.0.0.1", 0)
+    port = server.sockets[0].getsockname()[1]
+    client = AsyncClient(
+        "https",
+        "timeout.invalid",
+        443,
+        https_proxy=f"http://127.0.0.1:{port}",
+        connect_timeout=0.1,
+        send_receive_timeout=10,
+    )
+    client._backend.ensure_session()
+    connector = client._session.connector
+    try:
+        async with server:
+            with pytest.raises(OperationalError) as exc_info:
+                await asyncio.wait_for(client._backend.request(b"SELECT 13", {}), 5)
+            assert isinstance(exc_info.value.__cause__, aiohttp.ServerTimeoutError)
+            assert isinstance(exc_info.value.__cause__.__cause__, asyncio.TimeoutError)
+            assert requests == [b"CONNECT timeout.invalid:443 HTTP/1.1"] * 2
+            assert not connector._acquired
+            assert client._backend.session_lease._inflight == 0
+    finally:
+        await client.close()
+        await asyncio.gather(*handlers)


### PR DESCRIPTION
## Summary

Async requests can hit `connect_timeout` while they wait for a free pool slot, even when the server is healthy. This change starts the timeout after the client gets a slot. The deadline covers DNS, TCP, TLS, and proxy setup.

The tests cover long pool waits and cancellation, plus DNS and proxy deadline preservation. The docs explain pool waits, stream cleanup, and how to set a deadline for the whole operation.

Closes #1013

## Checklist
Delete items not relevant to your PR:

- [X] Unit and integration tests covering the common scenarios were added
- [X] A human-readable description of the changes was provided to include in CHANGELOG

This PR updates the Python docs in this repository under `docs/`. No separate change to `clickhouse-docs` is required.
