### PR TITLE
Fix false LIMIT 0 metadata probes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,7 +31,7 @@
 
 ### Bug Fixes
 
-- Queries whose text only appears to end in `LIMIT 0` because of `//` comments, quoted identifiers, or escaped string contents no longer take the columns-only metadata path and discard returned rows. Metadata probes now confirm a real trailing `LIMIT 0` against the bound SQL, including chDB, while binary-bound queries use the normal Native path. Closes [#925](https://github.com/ClickHouse/clickhouse-connect/issues/925).
+- Queries whose text only appears to end in `LIMIT 0` because of `//` comments, quoted identifiers, or escaped string contents no longer take the columns-only metadata path and discard returned rows. Metadata probes now confirm a real trailing `LIMIT 0` against the bound SQL, including chDB, while binary-bound queries use the normal Native path. This addresses the false metadata-probe cases in [#925](https://github.com/ClickHouse/clickhouse-connect/issues/925).
 - SQLAlchemy and Alembic now connect and reflect with `native_codec="rust_strict"`. Dialect metadata statements are marked as driver-internal, so they decode with the Python codec in every codec mode instead of tripping the strict `query_formats` check. Compatible ordinary statements still use the Rust codec.
 - Rust codec streaming queries now honor `show_clickhouse_errors`. Mid-stream server errors return the generic message when the setting is `False` and drop the server version trailer when it is `"scrub"`, matching the Python codec on both the sync and async clients.
 - Rust codec streams that are discarded without entering their context now close their response and stop the read-ahead thread as soon as the stream is discarded. Previously each abandoned stream retained a thread, socket, and buffered response data for the life of the process.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,7 @@
 
 ### Bug Fixes
 
+- Queries whose text only appears to end in `LIMIT 0` because of `//` comments, quoted identifiers, or escaped string contents no longer take the columns-only metadata path and discard returned rows. Metadata probes now confirm a real trailing `LIMIT 0` against the bound SQL, including chDB, while binary-bound queries use the normal Native path. Closes [#925](https://github.com/ClickHouse/clickhouse-connect/issues/925).
 - SQLAlchemy and Alembic now connect and reflect with `native_codec="rust_strict"`. Dialect metadata statements are marked as driver-internal, so they decode with the Python codec in every codec mode instead of tripping the strict `query_formats` check. Compatible ordinary statements still use the Rust codec.
 - Rust codec streaming queries now honor `show_clickhouse_errors`. Mid-stream server errors return the generic message when the setting is `False` and drop the server version trailer when it is `"scrub"`, matching the Python codec on both the sync and async clients.
 - Rust codec streams that are discarded without entering their context now close their response and stop the read-ahead thread as soon as the stream is discarded. Previously each abandoned stream retained a thread, socket, and buffered response data for the life of the process.

--- a/clickhouse_connect/driver/_backend/chdb_backend.py
+++ b/clickhouse_connect/driver/_backend/chdb_backend.py
@@ -34,7 +34,7 @@ from typing import TYPE_CHECKING, Any
 
 import chdb
 
-from clickhouse_connect.driver._backend.httpcommon import columns_only_re
+from clickhouse_connect.driver._backend.httpcommon import columns_only_meta, is_columns_only_query
 from clickhouse_connect.driver._backend.models import Capabilities, CommandExecution, QueryExecution, QueryRuntime
 from clickhouse_connect.driver.binding import quote_identifier
 from clickhouse_connect.driver.common import ShowClickHouseErrors
@@ -588,14 +588,14 @@ class ChdbBackend:
         params = _strip_param_prefix(context.bind_params)
         settings = self._engine_settings(runtime.settings)
 
-        if not context.is_insert and columns_only_re.search(context.uncommented_query):
+        if is_columns_only_query(context):
             # chdb emits zero Native bytes for LIMIT 0, so probe the column
             # metadata with FORMAT JSON like the HTTP backend does.
             probe_sql = context.final_query
             if settings:
                 probe_sql = f"{probe_sql}\n SETTINGS {_settings_clause(settings)}"
             result = self._run(f"{probe_sql}\n FORMAT JSON", "JSON", params=params, database=runtime.database)
-            return QueryExecution(columns=json.loads(result.bytes())["meta"])
+            return QueryExecution(columns=columns_only_meta(json.loads(result.bytes())))
 
         if context.is_insert:
             # Inline VALUES data must stay the final clause, so settings go

--- a/clickhouse_connect/driver/_backend/http_async.py
+++ b/clickhouse_connect/driver/_backend/http_async.py
@@ -25,6 +25,7 @@ from clickhouse_connect import common
 from clickhouse_connect.driver._backend.httpcommon import (
     auth_failed_ex_code,
     build_http_error,
+    columns_only_meta,
     decompress_response,
     ex_header,
     ex_tag_header,
@@ -304,7 +305,7 @@ class HttpAsyncBackend:
                 return json.loads(decompressed_body)
 
             json_result = await loop.run_in_executor(None, decompress_and_parse_json)
-            return QueryExecution(columns=json_result["meta"])
+            return QueryExecution(columns=columns_only_meta(json_result))
         response = await self.request(
             plan.body,
             plan.params,

--- a/clickhouse_connect/driver/_backend/http_sync.py
+++ b/clickhouse_connect/driver/_backend/http_sync.py
@@ -24,6 +24,7 @@ from urllib3.response import HTTPResponse
 from clickhouse_connect.driver._backend.httpcommon import (
     auth_failed_ex_code,
     build_http_error,
+    columns_only_meta,
     ex_header,
     ex_tag_header,
     plan_command_request,
@@ -153,7 +154,7 @@ class HttpSyncBackend:
                 retries=runtime.retries,
                 fields=_plan_fields(plan),
             )
-            return QueryExecution(columns=json.loads(response.data)["meta"])
+            return QueryExecution(columns=columns_only_meta(json.loads(response.data)))
         response = self.request(
             plan.body if plan.body is not None else b"",
             plan.params,

--- a/clickhouse_connect/driver/_backend/httpcommon.py
+++ b/clickhouse_connect/driver/_backend/httpcommon.py
@@ -28,12 +28,13 @@ if TYPE_CHECKING:
 
 from clickhouse_connect import common
 from clickhouse_connect.driver._backend.models import QueryRuntime
-from clickhouse_connect.driver.binding import quote_identifier, use_form_encoding
+from clickhouse_connect.driver.binding import _query_has_trailing_limit_zero, quote_identifier, use_form_encoding
 from clickhouse_connect.driver.common import ShowClickHouseErrors, coerce_bool, dict_copy
 from clickhouse_connect.driver.compression import _zstd_decompress, available_compression
 from clickhouse_connect.driver.exceptions import (
     GENERIC_CLICKHOUSE_ERROR,
     DatabaseError,
+    InternalError,
     OperationalError,
     ProgrammingError,
     error_code_from_header,
@@ -50,6 +51,21 @@ retryable_http_statuses = (429, 503, 504)
 
 # A removed comment leaves a space behind, so the gap before the 0 is not always a single space
 columns_only_re = re.compile(r"LIMIT\s+0\s*(?:;\s*)*$", re.IGNORECASE)
+
+
+def is_columns_only_query(context: QueryContext) -> bool:
+    if context.is_insert or not columns_only_re.search(context.uncommented_query):
+        return False
+
+    final_query = context.final_query
+    return isinstance(final_query, str) and _query_has_trailing_limit_zero(final_query)
+
+
+def columns_only_meta(json_result: dict[str, Any]) -> list[dict[str, Any]]:
+    if json_result.get("data"):
+        raise InternalError("LIMIT 0 metadata probe unexpectedly returned rows")
+    return json_result["meta"]
+
 
 if "br" in available_compression:
     import brotli
@@ -250,7 +266,7 @@ def plan_query_request(
     headers: dict[str, Any] = {}
     use_form = use_form_encoding(context.final_query, context.bind_params, form_encode_query_params)
 
-    if not context.is_insert and columns_only_re.search(context.uncommented_query):
+    if is_columns_only_query(context):
         fmt_json_query = f"{context.final_query}\n FORMAT JSON"
         if use_form:
             form_values: dict[str, Any] = {"query": fmt_json_query}

--- a/clickhouse_connect/driver/binding.py
+++ b/clickhouse_connect/driver/binding.py
@@ -166,6 +166,60 @@ def _next_sql_token(query: str, index: int, heredoc_ends: dict[str, int]) -> tup
     return _SQL_TOKEN_OTHER, index + 1
 
 
+def _query_has_trailing_limit_zero(query: str) -> bool:
+    """Return whether the query ends in a real lexical LIMIT 0."""
+    heredoc_ends = {match.group(1): match.start() for match in _heredoc_start_re.finditer(query)} if "$" in query else {}
+
+    previous = None
+    current = None
+    candidate_before_semicolon = False
+    after_semicolon = False
+    index = 0
+    end = len(query)
+
+    def suffix_is_limit_zero() -> bool:
+        if previous is None or current is None:
+            return False
+
+        previous_token, previous_start, previous_end = previous
+        current_token, current_start, current_end = current
+
+        return (
+            previous_token == _SQL_TOKEN_WORD
+            and query[previous_start:previous_end].upper() == "LIMIT"
+            and current_token == _SQL_TOKEN_OTHER
+            and query[current_start:current_end] == "0"
+        )
+
+    while index < end:
+        token, token_end = _next_sql_token(query, index, heredoc_ends)
+
+        if token == _SQL_TOKEN_INVALID:
+            return False
+
+        if token == _SQL_TOKEN_TRIVIA:
+            index = token_end
+            continue
+
+        if token == _SQL_TOKEN_SEMICOLON:
+            if not after_semicolon:
+                candidate_before_semicolon = suffix_is_limit_zero()
+            after_semicolon = True
+            index = token_end
+            continue
+
+        if after_semicolon:
+            previous = None
+            current = None
+            candidate_before_semicolon = False
+            after_semicolon = False
+
+        previous, current = current, (token, index, token_end)
+        index = token_end
+
+    return candidate_before_semicolon if after_semicolon else suffix_is_limit_zero()
+
+
 def _strip_trailing_semicolons(query: str) -> str:
     """Remove query-final statement terminators while preserving trailing SQL trivia.
 

--- a/tests/integration_tests/test_client.py
+++ b/tests/integration_tests/test_client.py
@@ -281,6 +281,73 @@ def test_get_columns_only(param_client, call):
     call(param_client.query, "INSERT INTO test_zero_insert SELECT 1 LIMIT 0")
 
 
+@pytest.mark.parametrize(
+    "sql, expected_rows, expected_name, expected_type",
+    [
+        (
+            "SELECT number FROM numbers(9) // LIMIT 0",
+            [(i,) for i in range(9)],
+            "number",
+            "UInt64",
+        ),
+        (
+            "SELECT number AS `LIMIT 0--` FROM numbers(9)",
+            [(i,) for i in range(9)],
+            "LIMIT 0--",
+            "UInt64",
+        ),
+        (
+            "SELECT 'foo\\' LIMIT 0--bar' AS value",
+            [("foo' LIMIT 0--bar",)],
+            "value",
+            "String",
+        ),
+        (
+            "SELECT number FROM numbers(9) LIMIT 0",
+            [],
+            "number",
+            "UInt64",
+        ),
+    ],
+)
+def test_limit_zero_probe_classification(
+    param_client,
+    call,
+    client_mode,
+    monkeypatch,
+    sql,
+    expected_rows,
+    expected_name,
+    expected_type,
+):
+    backend = param_client._backend
+    original_request = backend.request
+    execution_count = 0
+
+    if client_mode == "sync":
+
+        def counted_request(*args, **kwargs):
+            nonlocal execution_count
+            execution_count += 1
+            return original_request(*args, **kwargs)
+
+    else:
+
+        async def counted_request(*args, **kwargs):
+            nonlocal execution_count
+            execution_count += 1
+            return await original_request(*args, **kwargs)
+
+    monkeypatch.setattr(backend, "request", counted_request)
+
+    result = call(param_client.query, sql)
+
+    assert execution_count == 1
+    assert result.result_rows == expected_rows
+    assert result.column_names == (expected_name,)
+    assert result.column_types[0].name == expected_type
+
+
 def test_no_limit(param_client, call):
     old_limit = param_client.query_limit
     param_client.limit = 0

--- a/tests/unit_tests/test_driver/test_backend_http.py
+++ b/tests/unit_tests/test_driver/test_backend_http.py
@@ -8,6 +8,7 @@ from clickhouse_connect.driver._backend.http_async import HttpAsyncBackend, _pla
 from clickhouse_connect.driver._backend.http_sync import HttpSyncBackend, _plan_fields
 from clickhouse_connect.driver._backend.httpcommon import (
     QueryRequestPlan,
+    columns_only_meta,
     plan_command_request,
     plan_data_insert_request,
     plan_query_request,
@@ -15,7 +16,7 @@ from clickhouse_connect.driver._backend.httpcommon import (
     plan_raw_query_request,
 )
 from clickhouse_connect.driver._backend.models import Capabilities, QueryRuntime
-from clickhouse_connect.driver.exceptions import ProgrammingError
+from clickhouse_connect.driver.exceptions import InternalError, ProgrammingError
 
 
 def make_context(
@@ -204,6 +205,41 @@ class TestProbePlan:
         assert result.columns_only is True
         assert result.body == "SELECT * FROM t LIMIT 0 /* trailing */\n FORMAT JSON"
 
+    @pytest.mark.parametrize(
+        "final_query, uncommented_query",
+        [
+            (
+                "SELECT number FROM numbers(9) // LIMIT 0",
+                "SELECT number FROM numbers(9) // LIMIT 0",
+            ),
+            (
+                "SELECT number AS `LIMIT 0--` FROM numbers(9)",
+                "SELECT number AS `LIMIT 0",
+            ),
+            (
+                "SELECT 'foo\\' LIMIT 0--bar' AS value",
+                "SELECT 'foo\\' LIMIT 0",
+            ),
+        ],
+    )
+    def test_probe_rejects_false_limit_zero_candidates(self, final_query, uncommented_query):
+        context = self.probe_context(final_query=final_query, uncommented_query=uncommented_query)
+        result = plan(context)
+
+        assert result.columns_only is False
+        assert result.body == f"{final_query}\n FORMAT Native"
+
+    def test_bytes_candidate_never_probes(self):
+        final_query = b"SELECT * FROM t LIMIT 0"
+        context = self.probe_context(
+            final_query=final_query,
+            uncommented_query="SELECT * FROM t LIMIT 0",
+        )
+        result = plan(context, prepped_query=final_query)
+
+        assert result.columns_only is False
+        assert result.body == b"SELECT * FROM t LIMIT 0\n FORMAT Native"
+
     def test_probe_rejects_genuine_multi_statement_query(self):
         context = self.probe_context(uncommented_query="SELECT * FROM t LIMIT 0; SELECT 13")
         result = plan(context)
@@ -213,6 +249,21 @@ class TestProbePlan:
         context = make_context(final_query="INSERT INTO t LIMIT 0", is_insert=True)
         result = plan(context)
         assert result.columns_only is False
+
+
+def test_columns_only_meta_accepts_empty_data():
+    meta = [{"name": "value", "type": "UInt64"}]
+    assert columns_only_meta({"meta": meta, "data": []}) == meta
+
+
+def test_columns_only_meta_rejects_rows():
+    with pytest.raises(InternalError, match="metadata probe unexpectedly returned rows"):
+        columns_only_meta(
+            {
+                "meta": [{"name": "value", "type": "UInt64"}],
+                "data": [{"value": 13}],
+            }
+        )
 
 
 def command_plan(bound_cmd="CREATE TABLE t (id UInt32) ENGINE Memory", **overrides):

--- a/tests/unit_tests/test_driver/test_chdb.py
+++ b/tests/unit_tests/test_driver/test_chdb.py
@@ -181,6 +181,62 @@ class TestChdbQuery:
         assert result.column_names == ("number", "s")
         assert [ch_type.name for ch_type in result.column_types] == ["UInt64", "String"]
 
+    @pytest.mark.parametrize(
+        "sql, expected_rows, expected_name, expected_type",
+        [
+            (
+                "SELECT number FROM numbers(9) // LIMIT 0",
+                [(i,) for i in range(9)],
+                "number",
+                "UInt64",
+            ),
+            (
+                "SELECT number AS `LIMIT 0--` FROM numbers(9)",
+                [(i,) for i in range(9)],
+                "LIMIT 0--",
+                "UInt64",
+            ),
+            (
+                "SELECT 'foo\\' LIMIT 0--bar' AS value",
+                [("foo' LIMIT 0--bar",)],
+                "value",
+                "String",
+            ),
+            (
+                "SELECT number FROM numbers(9) LIMIT 0",
+                [],
+                "number",
+                "UInt64",
+            ),
+        ],
+    )
+    def test_limit_zero_probe_classification(
+        self,
+        client,
+        monkeypatch,
+        sql,
+        expected_rows,
+        expected_name,
+        expected_type,
+    ):
+        backend = client._backend
+        original_run = backend._run
+        execution_count = 0
+
+        def counted_run(*args, **kwargs):
+            nonlocal execution_count
+            execution_count += 1
+            return original_run(*args, **kwargs)
+
+        monkeypatch.setattr(backend, "_run", counted_run)
+
+        result = client.query(sql)
+
+        assert execution_count == 1
+        assert result.result_rows == expected_rows
+        assert result.column_names == (expected_name,)
+        assert result.column_types[0].name == expected_type
+
     def test_per_query_settings(self, client):
         result = client.query("SELECT value FROM system.settings WHERE name = 'max_threads'", settings={"max_threads": 2})
         assert result.result_rows == [("2",)]

--- a/tests/unit_tests/test_driver/test_httpclient.py
+++ b/tests/unit_tests/test_driver/test_httpclient.py
@@ -1327,13 +1327,13 @@ class TestQuery:
         # Create external data and context
         external_data = self.create_mock_external_data()
         context = self.create_mock_query_context(
-            query="SELECT * FROM file1 WHERE value > 10",
+            query="SELECT * FROM file1 WHERE value > 10 LIMIT 0",
             bind_params={"param_min_val": 10},
             external_data=external_data,
         )
-        context.uncommented_query = "SELECT * FROM file1 WHERE value > 10"
+        context.uncommented_query = "SELECT * FROM file1 WHERE value > 10 LIMIT 0"
         context.is_insert = False
-        context.final_query = "SELECT * FROM file1 WHERE value > 10"
+        context.final_query = "SELECT * FROM file1 WHERE value > 10 LIMIT 0"
         context.settings = {}
         context.transport_settings = {}
         context.streaming = False


### PR DESCRIPTION
## Summary

Prevents comments and quoted text that resemble a trailing `LIMIT 0` from causing the client to silently throw away returned rows. It also addresses the false metadata-probe cases in [#925](https://github.com/ClickHouse/clickhouse-connect/issues/925).

Only existing metadata-probe candidates receive lexical validation against the bound SQL. False candidates and binary-bound queries use Native directly. Sync HTTP, async HTTP, and chDB all share this. If a metadata probe still returns rows, the client raises `InternalError` with guidance to use `raw_query()`. It doesn't replay the query.

General comment removal and SELECT/LIMIT classification hasn't changed. Regular queries skip this additional scan. Automatic `query_limit` handling still has the original limitations. For example, with `query_limit=2`, `SELECT number FROM numbers(9) // LIMIT 0` will now return all nine rows instead of an empty result because the classifier still sees the commented LIMIT. Broader classification fixes are outside this PR.

## Checklist

- [x] Unit and integration tests covering the common scenarios were added
- [x] A human-readable description of the changes was provided to include in CHANGELOG
