### PR TITLE
Fix pool cleanup after failed synchronous client construction

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 
 ### Bug Fixes
 
+- Failed synchronous client construction now releases its dedicated HTTPS connection pool. Repeated connection or configuration errors no longer retain unused pool managers. Caller-supplied and shared pools remain open.
 - Async requests waiting for a free connection no longer fail when the pool wait exceeds `connect_timeout`. The timeout still covers DNS, TCP, TLS, and proxy connection setup after a pool slot is available. Closes [#1013](https://github.com/ClickHouse/clickhouse-connect/issues/1013).
 - SQLAlchemy SQL-text inserts, comparisons, and literal rendering now preserve fractional seconds for typed `DateTime64` values, including nested arrays and tuples. `DateTime` formatting, timezone handling, and Native bulk inserts retain their existing behavior. SQLAlchemy column types must match the server schema: declaring `DateTime64` over a server `DateTime` column can now raise conversion errors, including in `IN` comparisons. Closes [#1030](https://github.com/ClickHouse/clickhouse-connect/issues/1030).
 - Native inserts into `Date` and `Date32` columns now accept timezone-aware datetimes and mixed `date` and `datetime` values. They preserve each value's calendar date without converting its timezone, including in nullable and nested columns. Low cardinality columns also preserve different calendar dates when their datetime values represent the same instant. Closes [#1031](https://github.com/ClickHouse/clickhouse-connect/issues/1031).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@
 
 ### Bug Fixes
 
-- Failed synchronous client construction now releases its dedicated HTTPS connection pool. Repeated connection or configuration errors no longer retain unused pool managers. Caller-supplied and shared pools remain open.
+- Failed synchronous client construction now releases its dedicated urllib3 pool manager. Repeated connection or configuration failures no longer leave unused pool managers registered. Caller-supplied and shared pool managers are unchanged.
 - Async requests waiting for a free connection no longer fail when the pool wait exceeds `connect_timeout`. The timeout still covers DNS, TCP, TLS, and proxy connection setup after a pool slot is available. Closes [#1013](https://github.com/ClickHouse/clickhouse-connect/issues/1013).
 - SQLAlchemy SQL-text inserts, comparisons, and literal rendering now preserve fractional seconds for typed `DateTime64` values, including nested arrays and tuples. `DateTime` formatting, timezone handling, and Native bulk inserts retain their existing behavior. SQLAlchemy column types must match the server schema: declaring `DateTime64` over a server `DateTime` column can now raise conversion errors, including in `IN` comparisons. Closes [#1030](https://github.com/ClickHouse/clickhouse-connect/issues/1030).
 - Native inserts into `Date` and `Date32` columns now accept timezone-aware datetimes and mixed `date` and `datetime` values. They preserve each value's calendar date without converting its timezone, including in nullable and nested columns. Low cardinality columns also preserve different calendar dates when their datetime values represent the same instant. Closes [#1031](https://github.com/ClickHouse/clickhouse-connect/issues/1031).

--- a/clickhouse_connect/driver/_backend/http_sync.py
+++ b/clickhouse_connect/driver/_backend/http_sync.py
@@ -37,7 +37,7 @@ from clickhouse_connect.driver._backend.httpcommon import (
 from clickhouse_connect.driver._backend.models import Capabilities, CommandExecution, QueryExecution, QueryRuntime
 from clickhouse_connect.driver.common import ShowClickHouseErrors, dict_copy
 from clickhouse_connect.driver.exceptions import OperationalError, ProgrammingError
-from clickhouse_connect.driver.httputil import ResponseSource, all_managers, check_conn_expiration, get_response_data
+from clickhouse_connect.driver.httputil import ResponseSource, _close_pool_manager, check_conn_expiration, get_response_data
 
 if TYPE_CHECKING:
     from clickhouse_connect.driver._backend.contracts import SyncBackend
@@ -399,8 +399,7 @@ class HttpSyncBackend:
 
     def close(self) -> None:
         if self.owns_pool_manager:
-            cast(PoolManager, self.http).clear()
-            all_managers.pop(cast(PoolManager, self.http), None)
+            _close_pool_manager(cast(PoolManager, self.http))
 
 
 if TYPE_CHECKING:

--- a/clickhouse_connect/driver/httpclient.py
+++ b/clickhouse_connect/driver/httpclient.py
@@ -234,7 +234,7 @@ class HttpClient(SyncBackendClient):
         except BaseException:
             if owned_pool is not None:
                 # Keep the construction error if pool cleanup also fails.
-                with suppress(BaseException):
+                with suppress(Exception):
                     _close_pool_manager(owned_pool)
             raise
 

--- a/clickhouse_connect/driver/httpclient.py
+++ b/clickhouse_connect/driver/httpclient.py
@@ -2,6 +2,7 @@ import logging
 import uuid
 from base64 import b64encode
 from collections.abc import Callable
+from contextlib import suppress
 from typing import Any, cast
 
 from urllib3 import Timeout
@@ -36,6 +37,7 @@ from clickhouse_connect.driver.common import (
 from clickhouse_connect.driver.exceptions import ProgrammingError
 from clickhouse_connect.driver.httputil import (
     ResponseSource,  # noqa: F401  (compatibility re-export)
+    _close_pool_manager,
     check_env_proxy,
     default_pool_manager,
     get_pool_manager,
@@ -122,109 +124,119 @@ class HttpClient(SyncBackendClient):
         self.params = dict_copy(HttpClient.params)
         ch_settings = dict_copy(settings, self.params)
         pool = pool_mgr
-        if interface == "https":
-            if isinstance(verify, str) and verify.lower() == "proxy":
-                verify = True
-                tls_mode = tls_mode or "proxy"
-            if not https_proxy:
-                https_proxy = check_env_proxy("https", host, port)
-            verify = coerce_bool(verify)
-            if client_cert and (tls_mode is None or tls_mode == "mutual"):
-                if not username:
-                    raise ProgrammingError("username parameter is required for Mutual TLS authentication")
-                client_headers["X-ClickHouse-User"] = username
-                client_headers["X-ClickHouse-SSL-Certificate-Auth"] = "on"
+        owned_pool: PoolManager | None = None
+        try:
+            if interface == "https":
+                if isinstance(verify, str) and verify.lower() == "proxy":
+                    verify = True
+                    tls_mode = tls_mode or "proxy"
+                if not https_proxy:
+                    https_proxy = check_env_proxy("https", host, port)
+                verify = coerce_bool(verify)
+                if client_cert and (tls_mode is None or tls_mode == "mutual"):
+                    if not username:
+                        raise ProgrammingError("username parameter is required for Mutual TLS authentication")
+                    client_headers["X-ClickHouse-User"] = username
+                    client_headers["X-ClickHouse-SSL-Certificate-Auth"] = "on"
 
-            if not pool and (server_host_name or ca_cert or client_cert or not verify or https_proxy):
-                options: dict[str, Any] = {"verify": verify}
-                dict_add(options, "ca_cert", ca_cert)
-                dict_add(options, "client_cert", client_cert)
-                dict_add(options, "client_cert_key", client_cert_key)
-                if server_host_name:
-                    if options["verify"]:
-                        options["assert_hostname"] = server_host_name
-                    options["server_hostname"] = server_host_name
-                pool = get_pool_manager(https_proxy=https_proxy, **options)
-                self._owns_pool_manager = True
-        if not pool:
-            if not http_proxy:
-                http_proxy = check_env_proxy("http", host, port)
-            if http_proxy:
-                pool = get_proxy_manager(host, http_proxy)
-            else:
-                pool = default_pool_manager()
+                if not pool and (server_host_name or ca_cert or client_cert or not verify or https_proxy):
+                    options: dict[str, Any] = {"verify": verify}
+                    dict_add(options, "ca_cert", ca_cert)
+                    dict_add(options, "client_cert", client_cert)
+                    dict_add(options, "client_cert_key", client_cert_key)
+                    if server_host_name:
+                        if options["verify"]:
+                            options["assert_hostname"] = server_host_name
+                        options["server_hostname"] = server_host_name
+                    pool = owned_pool = get_pool_manager(https_proxy=https_proxy, **options)
+                    self._owns_pool_manager = True
+            if not pool:
+                if not http_proxy:
+                    http_proxy = check_env_proxy("http", host, port)
+                if http_proxy:
+                    pool = get_proxy_manager(host, http_proxy)
+                else:
+                    pool = default_pool_manager()
 
-        if token_provider:
-            access_token = token_provider()
-        if access_token:
-            client_headers["Authorization"] = f"Bearer {access_token}"
-        elif (not client_cert or tls_mode in ("strict", "proxy")) and username:
-            client_headers["Authorization"] = "Basic " + b64encode(f"{username}:{password}".encode()).decode()
+            if token_provider:
+                access_token = token_provider()
+            if access_token:
+                client_headers["Authorization"] = f"Bearer {access_token}"
+            elif (not client_cert or tls_mode in ("strict", "proxy")) and username:
+                client_headers["Authorization"] = "Basic " + b64encode(f"{username}:{password}".encode()).decode()
 
-        self._reported_libs: set[str] = set()
-        client_headers["User-Agent"] = common.build_client_name(client_name)
-        if headers:
-            client_headers.update(headers)
-        self._write_format = "Native"
-        self._transform = _make_native_transform(native_codec)
-        if not isinstance(self._transform, NativeTransform):
-            # The codec is a client-level choice, so the tag is applied at construction rather than per call.
-            add_integration_tag(client_headers, self._reported_libs, "clickhouse-connect-core")
+            self._reported_libs: set[str] = set()
+            client_headers["User-Agent"] = common.build_client_name(client_name)
+            if headers:
+                client_headers.update(headers)
+            self._write_format = "Native"
+            self._transform = _make_native_transform(native_codec)
+            if not isinstance(self._transform, NativeTransform):
+                # The codec is a client-level choice, so the tag is applied at construction rather than per call.
+                add_integration_tag(client_headers, self._reported_libs, "clickhouse-connect-core")
 
-        # There are use cases when the client needs to disable timeouts.
-        if connect_timeout is not None:
-            connect_timeout = coerce_int(connect_timeout)
-        if send_receive_timeout is not None:
-            send_receive_timeout = coerce_int(send_receive_timeout)
-        self._rename_response_column = rename_response_column
+            # There are use cases when the client needs to disable timeouts.
+            if connect_timeout is not None:
+                connect_timeout = coerce_int(connect_timeout)
+            if send_receive_timeout is not None:
+                send_receive_timeout = coerce_int(send_receive_timeout)
+            self._rename_response_column = rename_response_column
 
-        # allow to override the global autogenerate_session_id setting via the constructor params
-        _autogenerate_session_id = (
-            common.get_setting("autogenerate_session_id") if autogenerate_session_id is None else autogenerate_session_id
-        )
+            # allow to override the global autogenerate_session_id setting via the constructor params
+            _autogenerate_session_id = (
+                common.get_setting("autogenerate_session_id") if autogenerate_session_id is None else autogenerate_session_id
+            )
 
-        if session_id:
-            ch_settings["session_id"] = session_id
-        elif "session_id" not in ch_settings and _autogenerate_session_id:
-            ch_settings["session_id"] = str(uuid.uuid4())
+            if session_id:
+                ch_settings["session_id"] = session_id
+            elif "session_id" not in ch_settings and _autogenerate_session_id:
+                ch_settings["session_id"] = str(uuid.uuid4())
 
-        compression, write_compression = negotiate_compression(compress)
-        if write_compression:
-            self.write_compression = write_compression
+            compression, write_compression = negotiate_compression(compress)
+            if write_compression:
+                self.write_compression = write_compression
 
-        # The backend owns transport state. The params dict is shared by
-        # reference with this facade, so it is mutated in place, never rebound.
-        self._backend = HttpSyncBackend(
-            url=self.url,
-            pool_manager=pool,
-            owns_pool_manager=self._owns_pool_manager,
-            headers=client_headers,
-            params=self.params,
-            timeout=Timeout(connect=connect_timeout, read=send_receive_timeout),
-            server_host_name=server_host_name,
-            token_provider=token_provider,
-            # allow to override the global autogenerate_query_id setting via the constructor params
-            autogenerate_query_id=(common.get_setting("autogenerate_query_id") if autogenerate_query_id is None else autogenerate_query_id),
-            read_format="Native",
-            form_encode_query_params=form_encode_query_params,
-        )
-        self._initial_settings = settings
-        # Stashed for _init_common_settings, which needs the discovered server
-        # settings and so runs as part of the connect step inside super().__init__
-        self._ch_settings = ch_settings
-        self._negotiated_compression = compression
-        self._send_receive_timeout = send_receive_timeout
-        super().__init__(
-            database=database,
-            uri=self.url,
-            query_limit=query_limit,
-            query_retries=query_retries,
-            server_host_name=server_host_name,
-            tz_source=tz_source,
-            tz_mode=cast(TzMode | None, tz_mode),
-            show_clickhouse_errors=show_clickhouse_errors,
-            autoconnect=True,
-        )
+            # The backend owns transport state. The params dict is shared by
+            # reference with this facade, so it is mutated in place, never rebound.
+            self._backend = HttpSyncBackend(
+                url=self.url,
+                pool_manager=pool,
+                owns_pool_manager=self._owns_pool_manager,
+                headers=client_headers,
+                params=self.params,
+                timeout=Timeout(connect=connect_timeout, read=send_receive_timeout),
+                server_host_name=server_host_name,
+                token_provider=token_provider,
+                # allow to override the global autogenerate_query_id setting via the constructor params
+                autogenerate_query_id=(
+                    common.get_setting("autogenerate_query_id") if autogenerate_query_id is None else autogenerate_query_id
+                ),
+                read_format="Native",
+                form_encode_query_params=form_encode_query_params,
+            )
+            self._initial_settings = settings
+            # Stashed for _init_common_settings, which needs the discovered server
+            # settings and so runs as part of the connect step inside super().__init__
+            self._ch_settings = ch_settings
+            self._negotiated_compression = compression
+            self._send_receive_timeout = send_receive_timeout
+            super().__init__(
+                database=database,
+                uri=self.url,
+                query_limit=query_limit,
+                query_retries=query_retries,
+                server_host_name=server_host_name,
+                tz_source=tz_source,
+                tz_mode=cast(TzMode | None, tz_mode),
+                show_clickhouse_errors=show_clickhouse_errors,
+                autoconnect=True,
+            )
+        except BaseException:
+            if owned_pool is not None:
+                # Keep the construction error if pool cleanup also fails.
+                with suppress(BaseException):
+                    _close_pool_manager(owned_pool)
+            raise
 
     def _init_common_settings(self, tz_source: TzSource) -> None:
         super()._init_common_settings(tz_source)

--- a/clickhouse_connect/driver/httputil.py
+++ b/clickhouse_connect/driver/httputil.py
@@ -53,6 +53,13 @@ def close_managers():
         manager.clear()
 
 
+def _close_pool_manager(manager: PoolManager) -> None:
+    try:
+        manager.clear()
+    finally:
+        all_managers.pop(manager, None)
+
+
 def resolve_ca_cert(ca_cert: str | None) -> str | None:
     if ca_cert == "certifi":
         return certifi.where()

--- a/tests/unit_tests/test_driver/test_httpclient_pools.py
+++ b/tests/unit_tests/test_driver/test_httpclient_pools.py
@@ -1,0 +1,219 @@
+import threading
+from concurrent.futures import ThreadPoolExecutor
+from unittest.mock import Mock
+
+import pytest
+from urllib3.poolmanager import PoolManager
+
+from clickhouse_connect.driver import httpclient, httputil
+from clickhouse_connect.driver.client import Client
+from clickhouse_connect.driver.exceptions import OperationalError, ProgrammingError
+from clickhouse_connect.driver.httpclient import HttpClient
+
+
+def make_client(**kwargs):
+    options = {
+        "interface": "https",
+        "host": "localhost",
+        "port": 8443,
+        "username": "default",
+        "password": "",
+        "database": "default",
+        "server_host_name": "localhost",
+        "native_codec": "python",
+    }
+    options.update(kwargs)
+    return HttpClient(**options)
+
+
+@pytest.fixture
+def pools(monkeypatch):
+    managers = []
+    manager_lock = threading.Lock()
+    get_pool_manager = httputil.get_pool_manager
+
+    def track_manager(**kwargs):
+        manager = get_pool_manager(**kwargs)
+        manager.connection_from_host("localhost", 8443, scheme="https")
+        manager.clear = Mock(wraps=manager.clear)
+        with manager_lock:
+            managers.append(manager)
+        return manager
+
+    monkeypatch.setattr(httputil, "get_pool_manager", track_manager)
+    monkeypatch.setattr(httpclient, "get_pool_manager", track_manager)
+    monkeypatch.setattr(httpclient, "check_env_proxy", Mock(return_value=None))
+    monkeypatch.setattr(httputil, "_proxy_managers", {})
+    monkeypatch.setattr(Client, "_init_common_settings", Mock())
+    yield managers
+    for manager in managers:
+        PoolManager.clear(manager)
+        httputil.all_managers.pop(manager, None)
+
+
+@pytest.mark.parametrize(
+    ("options", "error_type"),
+    [
+        ({"connect_timeout": "invalid"}, ValueError),
+        ({"send_receive_timeout": "invalid"}, ValueError),
+        ({"connect_timeout": 0}, ValueError),
+        ({"native_codec": "invalid"}, ProgrammingError),
+        ({"compress": "invalid"}, ProgrammingError),
+        ({"query_limit": "invalid"}, ValueError),
+        ({"tz_mode": "invalid"}, ProgrammingError),
+        ({"settings": {"query": "SELECT 13"}}, ProgrammingError),
+    ],
+)
+def test_invalid_configuration_releases_owned_pool(pools, options, error_type):
+    with pytest.raises(error_type):
+        make_client(**options)
+
+    (manager,) = pools
+    manager.clear.assert_called_once_with()
+    assert len(manager.pools) == 0
+    assert manager not in httputil.all_managers
+
+
+@pytest.mark.parametrize("stage", ["token", "backend", "initialization"])
+@pytest.mark.parametrize("error_type", [OperationalError, KeyboardInterrupt])
+def test_constructor_error_releases_owned_pool(pools, monkeypatch, stage, error_type):
+    error = error_type("construction failed")
+    fail = Mock(side_effect=error)
+    options = {}
+    if stage == "token":
+        options["token_provider"] = fail
+    elif stage == "backend":
+        monkeypatch.setattr(httpclient, "HttpSyncBackend", fail)
+    else:
+        monkeypatch.setattr(Client, "_init_common_settings", fail)
+
+    with pytest.raises(error_type) as caught:
+        make_client(**options)
+
+    assert caught.value is error
+    (manager,) = pools
+    manager.clear.assert_called_once_with()
+    assert len(manager.pools) == 0
+    assert manager not in httputil.all_managers
+
+
+@pytest.mark.parametrize("cleanup_error_type", [RuntimeError, KeyboardInterrupt])
+@pytest.mark.parametrize("stage", ["token", "initialization"])
+def test_cleanup_failure_preserves_construction_error(pools, monkeypatch, cleanup_error_type, stage):
+    error = OperationalError("construction failed")
+
+    def fail(*_args):
+        pools[0].clear.side_effect = cleanup_error_type("cleanup failed")
+        raise error
+
+    options = {"token_provider": fail} if stage == "token" else {}
+    if stage == "initialization":
+        monkeypatch.setattr(Client, "_init_common_settings", fail)
+
+    with pytest.raises(OperationalError) as caught:
+        make_client(**options)
+
+    assert caught.value is error
+    pools[0].clear.assert_called_once_with()
+    assert pools[0] not in httputil.all_managers
+
+
+@pytest.mark.parametrize("pool_kind", ["supplied", "default_http", "default_https", "proxy"])
+@pytest.mark.parametrize("fail_construction", [False, True])
+def test_borrowed_pool_stays_open(pools, monkeypatch, pool_kind, fail_construction):
+    manager = httputil.get_pool_manager()
+    options = {}
+    if pool_kind == "supplied":
+        options["pool_mgr"] = manager
+    elif pool_kind == "proxy":
+        options.update(interface="http", http_proxy="http://proxy.test:8080")
+        httputil._proxy_managers["localhost__http://proxy.test:8080"] = manager
+    else:
+        monkeypatch.setattr(httputil, "_default_pool_manager", manager)
+        options.update(interface="http" if pool_kind == "default_http" else "https", server_host_name=None)
+
+    if fail_construction:
+        with pytest.raises(ProgrammingError, match="tz_mode"):
+            make_client(**options, tz_mode="invalid")
+    else:
+        client = make_client(**options)
+        assert client.http is manager
+        client.close()
+
+    assert pools == [manager]
+    manager.clear.assert_not_called()
+    assert len(manager.pools) == 1
+    assert manager in httputil.all_managers
+
+
+@pytest.mark.parametrize(
+    "options",
+    [
+        {"server_host_name": "localhost"},
+        {"ca_cert": "test-ca.pem"},
+        {"client_cert": "test-client.pem"},
+        {"verify": False},
+        {"https_proxy": "http://proxy.test:8080"},
+    ],
+)
+def test_successful_client_releases_owned_pool_on_close(pools, options):
+    client = make_client(**{"server_host_name": None, **options})
+    (manager,) = pools
+    assert client.http is manager
+    assert manager in httputil.all_managers
+    manager.clear.assert_not_called()
+
+    client.close()
+
+    manager.clear.assert_called_once_with()
+    assert len(manager.pools) == 0
+    assert manager not in httputil.all_managers
+
+
+def test_close_failure_unregisters_owned_pool(pools):
+    client = make_client()
+    (manager,) = pools
+    error = RuntimeError("cleanup failed")
+    manager.clear.side_effect = error
+
+    with pytest.raises(RuntimeError) as caught:
+        client.close()
+
+    assert caught.value is error
+    manager.clear.assert_called_once_with()
+    assert manager not in httputil.all_managers
+
+
+def test_concurrent_failure_preserves_new_successful_client_pool(pools):
+    allocated = threading.Event()
+    release = threading.Event()
+    error = OperationalError("construction failed")
+
+    def fail_token():
+        allocated.set()
+        assert release.wait(timeout=5)
+        raise error
+
+    client = None
+    try:
+        with ThreadPoolExecutor(max_workers=1) as executor:
+            failed_client = executor.submit(make_client, token_provider=fail_token)
+            try:
+                assert allocated.wait(timeout=5)
+                client = make_client()
+            finally:
+                release.set()
+            with pytest.raises(OperationalError) as caught:
+                failed_client.result(timeout=5)
+
+        assert caught.value is error
+        failed_manager, live_manager = pools
+        failed_manager.clear.assert_called_once_with()
+        assert failed_manager not in httputil.all_managers
+        assert client.http is live_manager
+        live_manager.clear.assert_not_called()
+        assert len(live_manager.pools) == 1
+        assert live_manager in httputil.all_managers
+    finally:
+        if client is not None:
+            client.close()

--- a/tests/unit_tests/test_driver/test_httpclient_pools.py
+++ b/tests/unit_tests/test_driver/test_httpclient_pools.py
@@ -97,9 +97,12 @@ def test_constructor_error_releases_owned_pool(pools, monkeypatch, stage, error_
     assert manager not in httputil.all_managers
 
 
-@pytest.mark.parametrize("cleanup_error_type", [RuntimeError, KeyboardInterrupt])
+@pytest.mark.parametrize(
+    ("cleanup_error_type", "raised_type"),
+    [(RuntimeError, OperationalError), (KeyboardInterrupt, KeyboardInterrupt)],
+)
 @pytest.mark.parametrize("stage", ["token", "initialization"])
-def test_cleanup_failure_preserves_construction_error(pools, monkeypatch, cleanup_error_type, stage):
+def test_cleanup_failure_preserves_construction_error(pools, monkeypatch, cleanup_error_type, raised_type, stage):
     error = OperationalError("construction failed")
 
     def fail(*_args):
@@ -110,10 +113,14 @@ def test_cleanup_failure_preserves_construction_error(pools, monkeypatch, cleanu
     if stage == "initialization":
         monkeypatch.setattr(Client, "_init_common_settings", fail)
 
-    with pytest.raises(OperationalError) as caught:
+    with pytest.raises(raised_type) as caught:
         make_client(**options)
 
-    assert caught.value is error
+    if raised_type is OperationalError:
+        assert caught.value is error
+    else:
+        # An interrupt during cleanup propagates and keeps the construction error as context.
+        assert caught.value.__context__ is error
     pools[0].clear.assert_called_once_with()
     assert pools[0] not in httputil.all_managers
 


### PR DESCRIPTION
## Summary

Failed synchronous client construction can leave dedicated urllib3 pool managers registered. Release the client's own manager on every construction failure, including before backend creation. Supplied and shared managers stay open, and interrupts during cleanup still propagate.

Related to https://github.com/ClickHouse/mcp-clickhouse/issues/227

## Checklist

- [x] A human-readable description of the changes was provided to include in CHANGELOG
