### PR TITLE
Improve Rust codec query and pandas string performance

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@
 ### Improvements
 
 - SQLAlchemy multi-row `Insert.values()` statements now compile and execute. Rows can be dictionaries, tuples in table column order, or rows containing SQL expressions, with client-side or server-side bind parameters. This also enables Pandas `to_sql(method="multi")`. See the SQLAlchemy documentation for column selection rules and the bind parameter ceiling that applies to server-side parameters on ClickHouse 26.4 and newer. Closes [#1024](https://github.com/ClickHouse/clickhouse-connect/issues/1024).
+- The Rust codec no longer starts a read-ahead thread for responses that fit in a single chunk. The first chunk is delivered immediately, and the thread starts only after the consumer requests and receives a second chunk. This removes a per-query cost that made many small concurrent queries slower than the Python codec.
+- The Rust codec now builds pandas `StringDtype` columns for `query_df` and `query_df_stream` directly from its Arrow buffers instead of materializing Python strings first. Output values and dtypes are unchanged. String columns that contain invalid UTF-8 keep the existing hex rendering.
 
 ### Bug Fixes
 

--- a/clickhouse_connect/driver/rustnumpy.py
+++ b/clickhouse_connect/driver/rustnumpy.py
@@ -4,9 +4,9 @@ The rust Arrow export is raw: Date is uint16 days, DateTime is uint32 seconds wi
 Enum is raw ints. A naive to_pandas() therefore yields wrong dtypes. These converters are resolved once
 per query from the driver's own ClickHouseType (np_type, tzinfo, nullability) so the produced columns match
 the Python codec by construction. Non-nullable numeric and temporal columns take the Arrow exit. Time and
-Time64 keep their declared duration units through NumPy and extended pandas output. Strings, enums,
-and remaining nullable columns take the rust python-object exit and are finalized through the driver's own
-_finalize_column.
+Time64 keep their declared duration units through NumPy and extended pandas output. Extended pandas output
+builds String columns from the Arrow buffers. Other strings, enums, and remaining nullable columns take the rust
+python-object exit and are finalized through the driver's own _finalize_column.
 """
 
 import logging
@@ -18,6 +18,7 @@ from clickhouse_connect.datatypes.base import ClickHouseType
 from clickhouse_connect.datatypes.container import Array, Map, Nested, Tuple
 from clickhouse_connect.datatypes.numeric import BFloat16, Interval
 from clickhouse_connect.datatypes.special import SimpleAggregateFunction
+from clickhouse_connect.datatypes.string import String
 from clickhouse_connect.datatypes.temporal import Date, DateTime, DateTime64, DateTimeBase, Time, Time64
 from clickhouse_connect.driver import options
 from clickhouse_connect.driver.common import first_value
@@ -636,6 +637,23 @@ def _make_object_convert(ch_type: ClickHouseType, context: QueryContext) -> Bloc
     return convert
 
 
+def _make_string_convert(ch_type: ClickHouseType, context: QueryContext) -> BlockConverter:
+    # Extended pandas String output built from the Arrow buffers instead of a Python str list. The rust export
+    # does not validate UTF-8, so a block with invalid bytes takes the object exit and renders them as hex.
+    pd_dtype = options.pd.StringDtype()
+    object_convert = _make_object_convert(ch_type, context)
+
+    def convert(arrow_table: Any, col_batch: Any, index: int) -> Any:
+        column = arrow_table.column(index)
+        try:
+            column.validate(full=True)
+        except options.arrow.ArrowInvalid:
+            return object_convert(arrow_table, col_batch, index)
+        return pd_dtype.__from_arrow__(column)
+
+    return convert
+
+
 def _make_nullable_int_convert(pd_dtype: Any) -> BlockConverter:
     def convert(arrow_table: Any, _col_batch: Any, index: int) -> Any:
         return pd_dtype.__from_arrow__(_arrow_column(arrow_table, index))
@@ -690,6 +708,14 @@ def _build_converter(ch_type: ClickHouseType, context: QueryContext) -> _Convert
         return _Converter(True, _make_array_time_convert(leaf, depth, context))
     if _contains_nested_time(ch_type):
         return _Converter(False, _make_nested_time_convert(ch_type, context))
+    if (
+        isinstance(ch_type, String)
+        and not ch_type.low_card
+        and context.as_pandas
+        and context.use_extended_dtypes
+        and ch_type.read_format(context) == "native"
+    ):
+        return _Converter(True, _make_string_convert(ch_type, context))
     if not ch_type.nullable and not ch_type.low_card:
         if isinstance(ch_type, DateTime64):
             _ = ch_type.np_type  # ProgrammingError for precisions outside {0,3,6,9}, matching the Python codec

--- a/clickhouse_connect/driver/streaming.py
+++ b/clickhouse_connect/driver/streaming.py
@@ -2,6 +2,7 @@ import asyncio
 import logging
 import queue
 import threading
+import weakref
 import zlib
 from collections.abc import Callable, Iterable, Iterator
 from typing import cast
@@ -443,7 +444,7 @@ class StreamingInsertSource:
 
 
 def _read_ahead_producer(
-    source: ByteSource,
+    src_gen: Iterator[bytes],
     out: queue.Queue[tuple[str, object]],
     stop_event: threading.Event,
 ) -> None:
@@ -457,7 +458,7 @@ def _read_ahead_producer(
         return False
 
     try:
-        for chunk in source.gen:
+        for chunk in src_gen:
             if not put(("data", chunk)):
                 return
     except BaseException as ex:  # noqa: BLE001 - forwarded to the consumer thread verbatim
@@ -475,6 +476,44 @@ def _read_ahead_consumer(source_queue: queue.Queue[tuple[str, object]]) -> Itera
             raise cast(BaseException, payload)
         else:  # eof
             return
+
+
+def _read_ahead_stream(
+    owner_ref: "weakref.ref[ReadAheadSource]",
+    source: ByteSource,
+    out: queue.Queue[tuple[str, object]],
+    stop_event: threading.Event,
+) -> Iterator[bytes]:
+    # Return the first chunk immediately. Read the second only when the consumer asks for more, so empty and
+    # single-chunk responses never start a producer. The weak owner reference lets abandoned sources finalize.
+    if stop_event.is_set():
+        return
+    src_gen = source.gen
+    try:
+        first = next(src_gen)
+    except StopIteration:
+        return
+    yield first
+    if stop_event.is_set():
+        return
+    try:
+        second = next(src_gen)
+    except StopIteration:
+        return
+    owner = owner_ref()
+    if owner is None or stop_event.is_set():
+        return
+    thread = threading.Thread(
+        target=_read_ahead_producer,
+        args=(src_gen, out, stop_event),
+        name="clickhouse-read-ahead",
+        daemon=True,
+    )
+    owner._thread = thread
+    del owner
+    thread.start()
+    yield second
+    yield from _read_ahead_consumer(out)
 
 
 def _drain_read_ahead_queue(source_queue: queue.Queue[tuple[str, object]]) -> None:
@@ -499,10 +538,10 @@ def _finalize_read_ahead_off_loop(
     loop: asyncio.AbstractEventLoop,
     source: ByteSource,
     source_queue: queue.Queue[tuple[str, object]],
-    producer_thread: threading.Thread,
+    producer_thread: threading.Thread | None,
 ) -> None:
     try:
-        if producer_thread.is_alive():
+        if producer_thread is not None and producer_thread.is_alive():
             producer_thread.join(timeout=1.0)
     except Exception:  # noqa: BLE001 - finalizers must not raise
         pass
@@ -515,8 +554,10 @@ def _finalize_read_ahead_off_loop(
 class ReadAheadSource(Closable):
     """Reads chunks from a byte source on a daemon thread into a bounded queue so transport overlaps decode.
 
-    The consumer generator re-raises any producer-side exception verbatim, in stream order, so the wrapping
-    codec's error mapping, exception-tag scanning, and last-chunk heuristics run unchanged on the consumer thread.
+    The producer thread starts lazily, once the source yields a second chunk, so empty and single-chunk responses
+    never pay for it. The consumer generator re-raises any producer-side exception verbatim, in stream order, so
+    the wrapping codec's error mapping, exception-tag scanning, and last-chunk heuristics run unchanged on the
+    consumer thread.
     """
 
     def __init__(self, source: ByteSource, maxsize: int = 16):
@@ -525,13 +566,7 @@ class ReadAheadSource(Closable):
         self.queue: queue.Queue[tuple[str, object]] = queue.Queue(maxsize=maxsize)
         self._stop_event = threading.Event()
         self._gen_cache: Iterator[bytes] | None = None
-        self._thread = threading.Thread(
-            target=_read_ahead_producer,
-            args=(source, self.queue, self._stop_event),
-            name="clickhouse-read-ahead",
-            daemon=True,
-        )
-        self._thread.start()
+        self._thread: threading.Thread | None = None
 
     def __del__(self) -> None:
         try:
@@ -564,7 +599,10 @@ class ReadAheadSource(Closable):
     @property
     def gen(self) -> Iterator[bytes]:
         if self._gen_cache is None:
-            self._gen_cache = _read_ahead_consumer(self.queue)
+            source = self.source
+            if source is None:
+                raise RuntimeError("ReadAheadSource is closed")
+            self._gen_cache = _read_ahead_stream(weakref.ref(self), source, self.queue, self._stop_event)
         return self._gen_cache
 
     def _drain(self):
@@ -581,16 +619,18 @@ class ReadAheadSource(Closable):
         # the source only after the join keeps the transport single-reader: the sync source drains on close,
         # which would race a producer still reading it.
         self._stop_event.set()
-        if self._thread.is_alive():
-            self._thread.join(timeout=1.0)
+        thread = self._thread
+        if thread is not None and thread.is_alive():
+            thread.join(timeout=1.0)
         self._drain()
         self._release_source()
 
     async def aclose(self) -> None:
         self._stop_event.set()
-        if self._thread.is_alive():
+        thread = self._thread
+        if thread is not None and thread.is_alive():
             # Join off the event loop so the worst-case wait never blocks it.
-            await asyncio.get_running_loop().run_in_executor(None, self._thread.join, 1.0)
+            await asyncio.get_running_loop().run_in_executor(None, thread.join, 1.0)
         self._drain()
         # Release on the loop thread: the async source's close cancels its producer task, which must not
         # run from an executor thread.

--- a/docs/rust-codec.mdx
+++ b/docs/rust-codec.mdx
@@ -81,7 +81,7 @@ Malformed Native payloads detected by the Rust codec raise `DataError`.
 pip install --upgrade clickhouse-connect-core
 ```
 
-Codec fixes and performance improvements ship as `clickhouse-connect-core` releases and can be picked up with a wheel upgrade alone, without waiting for a `clickhouse-connect` release.
+Fixes and performance improvements in the compiled codec ship as `clickhouse-connect-core` releases and can be picked up with a compatible core wheel upgrade. Changes to the driver's Rust integration require a `clickhouse-connect` upgrade.
 
 ## Known behavior differences {#known-behavior-differences}
 

--- a/tests/integration_tests/test_rust_codec.py
+++ b/tests/integration_tests/test_rust_codec.py
@@ -1,4 +1,5 @@
 import array
+import asyncio
 import gc
 import logging
 import time
@@ -1296,6 +1297,7 @@ NP_DF_MATRIX = {
     "nullable_uint64": "CAST(if(number % 3 = 0, NULL, number) AS Nullable(UInt64))",
     "nullable_float": "CAST(if(number % 3 = 0, NULL, toFloat64(number) / 2) AS Nullable(Float64))",
     "nullable_string": "CAST(if(number % 3 = 0, NULL, toString(number)) AS Nullable(String))",
+    "invalid_utf8_string": "if(number % 2 = 0, unhex('ff'), toString(number))",
     "nullable_datetime": "CAST(if(number % 3 = 0, NULL, toDateTime(number)) AS Nullable(DateTime))",
     "nullable_datetime64": "CAST(if(number % 3 = 0, NULL, toDateTime64(number, 3)) AS Nullable(DateTime64(3)))",
     "low_card_string": "CAST(toString(number % 3) AS LowCardinality(String))",
@@ -1584,8 +1586,19 @@ def test_rust_codec_abandoned_stream_no_read_ahead_thread(client_factory, call, 
         # abandonment. A small result the producer fully buffers would exit on its own and hide a close() leak.
         stream = call(rust_client.query_column_block_stream, "SELECT number FROM numbers(20000000)")
         read_source = stream.source.source
-        thread = read_source._thread
         read_source_ref = weakref.ref(read_source)
+
+        def start_read_ahead(stream_context):
+            # Decode until the second transport chunk starts the producer, then abandon the active stream.
+            while stream_context.source.source._thread is None:
+                next(stream_context.gen)
+
+        if client_mode == "sync":
+            start_read_ahead(stream)
+        else:
+            call(asyncio.to_thread, start_read_ahead, stream)
+        thread = read_source._thread
+        assert thread is not None
         del read_source
 
         if client_mode == "sync":

--- a/tests/unit_tests/test_driver/test_rustnumpy.py
+++ b/tests/unit_tests/test_driver/test_rustnumpy.py
@@ -541,3 +541,62 @@ def test_refinalize_nullable_named_timezone_datetimes(type_name):
 
     assert result[0][0] is pd.NaT
     assert result[0][1] == pd.Timestamp(value)
+
+
+class _ColBatch:
+    """Mock ColBatch exposing the python-object exit."""
+
+    def __init__(self, columns):
+        self._columns = columns
+
+    def column_data(self, index):
+        return list(self._columns[index])
+
+
+def _extended_pandas_context():
+    return QueryContext(use_numpy=True, as_pandas=True, use_extended_dtypes=True)
+
+
+def test_string_converter_extended_pandas_builds_from_arrow():
+    pa = pytest.importorskip("pyarrow")
+    pd = pytest.importorskip("pandas")
+    converter = rustnumpy._build_converter(get_from_name("String"), _extended_pandas_context())
+    assert converter.needs_arrow is True
+    values = ["a", "", "\u00e9", "b" * 40]
+    result = converter(pa.table({"c": pa.array(values)}), _ColBatch([values]), 0)
+    pd.testing.assert_extension_array_equal(result, pd.array(values, dtype=pd.StringDtype()))
+
+
+def test_nullable_string_converter_extended_pandas_uses_na():
+    pa = pytest.importorskip("pyarrow")
+    pd = pytest.importorskip("pandas")
+    converter = rustnumpy._build_converter(get_from_name("Nullable(String)"), _extended_pandas_context())
+    assert converter.needs_arrow is True
+    values = ["a", None, "", "b"]
+    result = converter(pa.table({"c": pa.array(values)}), _ColBatch([values]), 0)
+    pd.testing.assert_extension_array_equal(result, pd.array(values, dtype=pd.StringDtype()))
+
+
+def test_string_converter_invalid_utf8_falls_back_to_object_exit():
+    pa = pytest.importorskip("pyarrow")
+    pd = pytest.importorskip("pandas")
+    converter = rustnumpy._build_converter(get_from_name("String"), _extended_pandas_context())
+    binary = pa.array([b"\xff", b"ok"], type=pa.binary())
+    forged = pa.Array.from_buffers(pa.string(), len(binary), binary.buffers(), null_count=0)
+    # The binding renders invalid UTF-8 as hex, so the object exit sees these values.
+    result = converter(pa.table({"c": forged}), _ColBatch([["ff", "ok"]]), 0)
+    pd.testing.assert_extension_array_equal(result, pd.array(["ff", "ok"], dtype=pd.StringDtype()))
+
+
+@pytest.mark.parametrize(
+    ("type_name", "context"),
+    [
+        ("String", QueryContext(use_numpy=True)),
+        ("String", QueryContext(use_numpy=True, as_pandas=True, use_extended_dtypes=False)),
+        ("LowCardinality(String)", QueryContext(use_numpy=True, as_pandas=True, use_extended_dtypes=True)),
+        ("FixedString(3)", QueryContext(use_numpy=True, as_pandas=True, use_extended_dtypes=True)),
+    ],
+    ids=["numpy", "pandas_plain", "low_card", "fixed_string"],
+)
+def test_string_converter_other_outputs_keep_object_exit(type_name, context):
+    assert rustnumpy._build_converter(get_from_name(type_name), context).needs_arrow is False

--- a/tests/unit_tests/test_streaming_source.py
+++ b/tests/unit_tests/test_streaming_source.py
@@ -6,6 +6,7 @@ import threading
 import time
 import weakref
 import zlib
+from concurrent.futures import ThreadPoolExecutor
 from unittest.mock import Mock
 
 import lz4.frame
@@ -579,7 +580,8 @@ class MockByteSource:
 
 
 class ReadBlockedByteSource:
-    def __init__(self):
+    def __init__(self, early_chunks=(b"early_1", b"early_2")):
+        self.early_chunks = early_chunks
         self.read_started = threading.Event()
         self.release_read = threading.Event()
         self.closed = False
@@ -587,6 +589,8 @@ class ReadBlockedByteSource:
 
     @property
     def gen(self):
+        # By default, two immediate chunks start the producer before the third read blocks.
+        yield from self.early_chunks
         self.read_started.set()
         self.release_read.wait(timeout=5.0)
         yield b"late"
@@ -606,7 +610,9 @@ def test_read_ahead_chunk_order():
     src = MockByteSource([b"a", b"b", b"c"])
     read_source = ReadAheadSource(src)
     assert list(read_source.gen) == [b"a", b"b", b"c"]
+    assert read_source._thread is not None
     read_source.close()
+    assert read_source._thread.is_alive() is False
     assert src.closed is True
 
 
@@ -614,6 +620,23 @@ def test_read_ahead_gen_cached():
     read_source = ReadAheadSource(MockByteSource([b"a"]))
     assert read_source.gen is read_source.gen
     read_source.close()
+
+
+def test_read_ahead_first_chunk_does_not_wait_for_second():
+    src = ReadBlockedByteSource(early_chunks=(b"early_1",))
+    read_source = ReadAheadSource(src)
+    with ThreadPoolExecutor(max_workers=1) as executor:
+        first = executor.submit(next, read_source.gen)
+        try:
+            assert first.result(timeout=1.0) == b"early_1"
+            assert read_source._thread is None
+            assert not src.read_started.is_set()
+        finally:
+            src.release_read.set()
+            first.result(timeout=1.0)
+            read_source.close()
+    assert list(read_source.gen) == []
+    assert not src.read_started.is_set()
 
 
 def test_read_ahead_error_forwarded_verbatim():
@@ -643,39 +666,53 @@ def test_read_ahead_close_during_block_terminates_thread():
     src = MockByteSource([bytes([i % 256]) for i in range(500)])
     read_source = ReadAheadSource(src, maxsize=2)
     assert next(read_source.gen) == b"\x00"
+    assert next(read_source.gen) == b"\x01"
     read_source.close()
     assert src.closed is True
     assert read_source._thread.is_alive() is False
 
 
-def test_read_ahead_join_on_close():
-    src = MockByteSource([b"a", b"b"])
+@pytest.mark.parametrize("chunks", [[], [b"a"], [b"a", b"b", b"c"]])
+def test_read_ahead_close_before_consumption_never_starts_thread(chunks):
+    src = MockByteSource(chunks)
     read_source = ReadAheadSource(src)
+    consumer = read_source.gen
     read_source.close()
-    assert read_source._thread.is_alive() is False
     assert src.closed is True
+    assert list(consumer) == []
+    assert read_source._thread is None
+
+    closed = ReadAheadSource(MockByteSource([b"a"]))
+    closed.close()
+    with pytest.raises(RuntimeError, match="closed"):
+        _ = closed.gen
 
 
-def test_read_ahead_abandoned_source_is_collected():
+@pytest.mark.parametrize("chunks_consumed", [1, 2])
+def test_read_ahead_abandoned_source_is_collected(chunks_consumed):
     gc_was_enabled = gc.isenabled()
     gc.disable()
     read_source_ref = None
     try:
         src = MockByteSource([bytes([i % 256]) for i in range(500)])
         read_source = ReadAheadSource(src, maxsize=2)
-        thread = read_source._thread
         read_source_ref = weakref.ref(read_source)
 
-        assert next(read_source.gen) == b"\x00"
-        deadline = time.time() + 1.0
-        while time.time() < deadline and not read_source.queue.full():
-            time.sleep(0.01)
-        assert read_source.queue.full()
+        for i in range(chunks_consumed):
+            assert next(read_source.gen) == bytes([i])
+        thread = read_source._thread
+        assert (thread is not None) is (chunks_consumed == 2)
+        if thread is not None:
+            deadline = time.time() + 1.0
+            while time.time() < deadline and not read_source.queue.full():
+                time.sleep(0.01)
+            assert read_source.queue.full()
 
         del read_source
-        thread.join(timeout=1.0)
+        if thread is not None:
+            thread.join(timeout=1.0)
+            assert thread.is_alive() is False
         assert read_source_ref() is None
-        assert thread.is_alive() is False
         assert src.closed is True
     finally:
         if read_source_ref is not None:
@@ -695,9 +732,10 @@ async def test_read_ahead_abandoned_source_does_not_block_event_loop():
     thread = None
     try:
         read_source = ReadAheadSource(source)
-        thread = read_source._thread
         read_source_ref = weakref.ref(read_source)
-        _ = read_source.gen
+        assert next(read_source.gen) == b"early_1"
+        assert next(read_source.gen) == b"early_2"
+        thread = read_source._thread
         assert await asyncio.to_thread(source.read_started.wait, 1.0)
 
         loop = asyncio.get_running_loop()
@@ -733,6 +771,8 @@ async def test_read_ahead_abandoned_source_does_not_block_event_loop():
 def test_read_ahead_finalizer_releases_source_when_loop_scheduling_fails():
     src = MockByteSource([bytes([i % 256]) for i in range(500)])
     read_source = ReadAheadSource(src, maxsize=2)
+    assert next(read_source.gen) == b"\x00"
+    assert next(read_source.gen) == b"\x01"
     read_source._stop_event.set()
     source, read_source.source = read_source.source, None
     assert source is not None
@@ -740,6 +780,46 @@ def test_read_ahead_finalizer_releases_source_when_loop_scheduling_fails():
     _finalize_read_ahead_off_loop(RejectingLoop(), source, read_source.queue, read_source._thread)
 
     assert read_source._thread.is_alive() is False
+    assert src.closed is True
+
+
+@pytest.mark.parametrize("chunks", [[], [b"only"]])
+def test_read_ahead_short_stream_no_thread(chunks):
+    src = MockByteSource(chunks)
+    read_source = ReadAheadSource(src)
+    assert list(read_source.gen) == chunks
+    assert read_source._thread is None
+    read_source.close()
+    assert src.closed is True
+
+
+@pytest.mark.parametrize("chunk_count", [0, 1, 2, 3])
+def test_read_ahead_error_at_any_position_forwarded_verbatim(chunk_count):
+    # Errors before the handoff propagate directly from the consuming thread, later ones through the queue.
+    err = ValueError("boom")
+    chunks = [bytes([i]) for i in range(chunk_count)]
+    src = MockByteSource(chunks, error=err)
+    read_source = ReadAheadSource(src)
+    collected = []
+    with pytest.raises(ValueError, match="boom") as excinfo:
+        for chunk in read_source.gen:
+            collected.append(chunk)
+    assert collected == chunks
+    assert excinfo.value is err
+    assert (read_source._thread is not None) is (chunk_count >= 2)
+    read_source.close()
+    assert src.closed is True
+
+
+@pytest.mark.asyncio
+async def test_read_ahead_aclose_after_multi_chunk_stream():
+    src = MockByteSource([b"a", b"b", b"c", b"d"])
+    read_source = ReadAheadSource(src, maxsize=2)
+    assert await asyncio.to_thread(list, read_source.gen) == [b"a", b"b", b"c", b"d"]
+    thread = read_source._thread
+    assert thread is not None
+    await read_source.aclose()
+    assert thread.is_alive() is False
     assert src.closed is True
 
 


### PR DESCRIPTION
## Summary

Skip the Rust read-ahead thread for single-chunk responses and build pandas StringDtype columns directly from Arrow buffers. This reduces overhead for small concurrent queries and string-heavy `query_df` and `query_df_stream` results.

The first chunk is delivered immediately. Output values, dtypes, and invalid UTF-8 hex rendering stay unchanged.

## Checklist
- [x] Unit and integration tests covering the common scenarios were added
- [x] A human-readable description of the changes was provided to include in CHANGELOG
