### PR TITLE
1.9.0rc2 release prep

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## UNRELEASED
 
+## 1.9.0rc2, 2026-09-10
+
 ### Improvements
 
 - The Rust codec no longer starts a read-ahead thread for responses that fit in a single chunk. The first chunk is delivered immediately, and the thread starts only after the consumer requests and receives a second chunk. This removes a per-query cost that made many small concurrent queries slower than the Python codec.

--- a/clickhouse_connect/_version.py
+++ b/clickhouse_connect/_version.py
@@ -1,1 +1,1 @@
-version = "1.9.0rc1"
+version = "1.9.0rc2"


### PR DESCRIPTION
## Summary

Prepare 1.9.0rc2 with the Rust query and pandas string performance improvements from #1041. Date the changelog section and bump the package version from 1.9.0rc1 to 1.9.0rc2.

## Checklist
- [x] A human-readable description of the changes was provided to include in CHANGELOG
