### PR TITLE
Fix Alembic version table schema initialization

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 
 ### Bug Fixes
 
+- Alembic offline SQL generation no longer fails when `include_schemas=True` and `version_table_schema` is unset. Offline mode now skips the current database lookup. Explicit version table schemas are preserved. Closes [#1045](https://github.com/ClickHouse/clickhouse-connect/issues/1045).
 - Failed synchronous client construction now releases its dedicated urllib3 pool manager. Repeated connection or configuration failures no longer leave unused pool managers registered. Caller-supplied and shared pool managers are unchanged.
 - Async requests waiting for a free connection no longer fail when the pool wait exceeds `connect_timeout`. The timeout still covers DNS, TCP, TLS, and proxy connection setup after a pool slot is available. Closes [#1013](https://github.com/ClickHouse/clickhouse-connect/issues/1013).
 - SQLAlchemy SQL-text inserts, comparisons, and literal rendering now preserve fractional seconds for typed `DateTime64` values, including nested arrays and tuples. `DateTime` formatting, timezone handling, and Native bulk inserts retain their existing behavior. SQLAlchemy column types must match the server schema: declaring `DateTime64` over a server `DateTime` column can now raise conversion errors, including in `IN` comparisons. Closes [#1030](https://github.com/ClickHouse/clickhouse-connect/issues/1030).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@
 
 ### Bug Fixes
 
-- Alembic offline SQL generation no longer fails when `include_schemas=True` and `version_table_schema` is unset. Offline mode now skips the current database lookup. Explicit version table schemas are preserved. Closes [#1045](https://github.com/ClickHouse/clickhouse-connect/issues/1045).
+- Alembic offline SQL generation no longer fails when `include_schemas=True` and `version_table_schema` is unset. Offline mode now skips the current database lookup. Online version table updates and deletes also work when `version_table_schema=""`. Closes [#1045](https://github.com/ClickHouse/clickhouse-connect/issues/1045).
 - Failed synchronous client construction now releases its dedicated urllib3 pool manager. Repeated connection or configuration failures no longer leave unused pool managers registered. Caller-supplied and shared pool managers are unchanged.
 - Async requests waiting for a free connection no longer fail when the pool wait exceeds `connect_timeout`. The timeout still covers DNS, TCP, TLS, and proxy connection setup after a pool slot is available. Closes [#1013](https://github.com/ClickHouse/clickhouse-connect/issues/1013).
 - SQLAlchemy SQL-text inserts, comparisons, and literal rendering now preserve fractional seconds for typed `DateTime64` values, including nested arrays and tuples. `DateTime` formatting, timezone handling, and Native bulk inserts retain their existing behavior. SQLAlchemy column types must match the server schema: declaring `DateTime64` over a server `DateTime` column can now raise conversion errors, including in `IN` comparisons. Closes [#1030](https://github.com/ClickHouse/clickhouse-connect/issues/1030).

--- a/clickhouse_connect/cc_sqlalchemy/alembic/impl.py
+++ b/clickhouse_connect/cc_sqlalchemy/alembic/impl.py
@@ -119,7 +119,12 @@ class ClickHouseImpl(DefaultImpl):
     def __init__(self, *args: Any, **kwargs: Any) -> None:
         super().__init__(*args, **kwargs)
         self._add_integration_tag()
-        if self.context_opts.get("include_schemas") and not self.context_opts.get("version_table_schema") and self.connection is not None:
+        if (
+            not self.as_sql
+            and self.context_opts.get("include_schemas")
+            and not self.context_opts.get("version_table_schema")
+            and self.connection is not None
+        ):
             current_database = self.connection.execute(with_internal_query_formats(text("SELECT currentDatabase()"))).scalar()
             if current_database:
                 self.context_opts["version_table_schema"] = current_database

--- a/clickhouse_connect/cc_sqlalchemy/alembic/impl.py
+++ b/clickhouse_connect/cc_sqlalchemy/alembic/impl.py
@@ -122,7 +122,7 @@ class ClickHouseImpl(DefaultImpl):
         if (
             not self.as_sql
             and self.context_opts.get("include_schemas")
-            and not self.context_opts.get("version_table_schema")
+            and self.context_opts.get("version_table_schema") is None
             and self.connection is not None
         ):
             current_database = self.connection.execute(with_internal_query_formats(text("SELECT currentDatabase()"))).scalar()

--- a/tests/integration_tests/test_sqlalchemy/test_alembic.py
+++ b/tests/integration_tests/test_sqlalchemy/test_alembic.py
@@ -167,13 +167,17 @@ def _drop_version_table(conn, database: str):
     conn.execute(text(f"DROP TABLE IF EXISTS `{database}`.`alembic_version`"))
 
 
-def test_alembic_version_table_live(test_engine: Engine, test_db: str, ch_name):
+@pytest.mark.parametrize("schema_setting", ["omitted", "none", "empty", "explicit"])
+def test_alembic_version_table_live(test_engine: Engine, test_db: str, ch_name, schema_setting):
     version_table = ch_name("alembic_version")
+    opts = {"version_table": version_table, "include_schemas": True}
+    if schema_setting != "omitted":
+        opts["version_table_schema"] = {"none": None, "empty": "", "explicit": test_db}[schema_setting]
 
     with test_engine.begin() as conn:
         context = MigrationContext.configure(
             connection=conn,
-            opts={"version_table": version_table},
+            opts=opts,
         )
         assert isinstance(context.impl, ClickHouseImpl)
 
@@ -194,6 +198,10 @@ def test_alembic_version_table_live(test_engine: Engine, test_db: str, ch_name):
 
         rows = conn.execute(text(f"SELECT version_num FROM `{test_db}`.`{version_table}` ORDER BY version_num")).fetchall()
         assert rows == [("head",)]
+
+        context.impl._exec(version.delete().where(version.c.version_num == literal_column("'head'")))
+        rows = conn.execute(text(f"SELECT version_num FROM `{test_db}`.`{version_table}`")).fetchall()
+        assert rows == []
 
 
 def test_alembic_user_agent_integration_tag(test_engine: Engine):

--- a/tests/unit_tests/test_sqlalchemy/test_alembic.py
+++ b/tests/unit_tests/test_sqlalchemy/test_alembic.py
@@ -260,8 +260,13 @@ def test_clickhouse_impl_current_database_uses_internal_query_formats():
 
 @pytest.mark.parametrize(
     "opts",
-    [{}, {"include_schemas": False}, {"include_schemas": True, "version_table_schema": "migration_db"}],
-    ids=["default", "schemas-disabled", "explicit-schema"],
+    [
+        {},
+        {"include_schemas": False},
+        {"include_schemas": True, "version_table_schema": ""},
+        {"include_schemas": True, "version_table_schema": "migration_db"},
+    ],
+    ids=["default", "schemas-disabled", "empty-schema", "explicit-schema"],
 )
 def test_clickhouse_impl_skips_unneeded_current_database_lookup(opts):
     connection = Mock()

--- a/tests/unit_tests/test_sqlalchemy/test_alembic.py
+++ b/tests/unit_tests/test_sqlalchemy/test_alembic.py
@@ -258,6 +258,48 @@ def test_clickhouse_impl_current_database_uses_internal_query_formats():
     assert opts["version_table_schema"] == "default"
 
 
+@pytest.mark.parametrize(
+    "opts",
+    [{}, {"include_schemas": False}, {"include_schemas": True, "version_table_schema": "migration_db"}],
+    ids=["default", "schemas-disabled", "explicit-schema"],
+)
+def test_clickhouse_impl_skips_unneeded_current_database_lookup(opts):
+    connection = Mock()
+    original_opts = opts.copy()
+
+    ClickHouseImpl(ClickHouseDialect(), connection, False, False, StringIO(), opts)
+
+    connection.execute.assert_not_called()
+    assert opts == original_opts
+
+
+@pytest.mark.parametrize("include_schemas", [False, True])
+@pytest.mark.parametrize(
+    "schema_opts",
+    [{}, {"version_table_schema": None}, {"version_table_schema": ""}, {"version_table_schema": "migration_db"}],
+    ids=["omitted-schema", "none-schema", "empty-schema", "explicit-schema"],
+)
+def test_alembic_offline_schema_configuration(include_schemas, schema_opts):
+    buffer = StringIO()
+    context = MigrationContext.configure(
+        dialect=ClickHouseDialect(),
+        opts={"as_sql": True, "output_buffer": buffer, "include_schemas": include_schemas, **schema_opts},
+    )
+
+    assert buffer.getvalue() == ""
+    assert context._version.schema == schema_opts.get("version_table_schema")
+
+    context._ensure_version_table()
+    Operations(context).add_column("events", Column("value", types.UInt32(), nullable=False))
+
+    sql = buffer.getvalue()
+    version_table = "`migration_db`.`alembic_version`" if schema_opts.get("version_table_schema") else "`alembic_version`"
+    assert f"CREATE TABLE {version_table}" in sql
+    assert "Engine MergeTree" in sql
+    assert "ALTER TABLE `events` ADD COLUMN `value` UInt32;" in sql
+    assert "SELECT" not in sql
+
+
 def test_render_type_uses_clickhouse_names():
     context = MigrationContext.configure(dialect=ClickHouseDialect(), opts={"target_metadata": MetaData()})
     assert context.impl.render_type(types.Int32(), None) == "Int32"


### PR DESCRIPTION
## Summary

Skip the database lookup during offline initialization so `include_schemas=True` works with `--sql`. Preserve explicit `version_table_schema` values, including empty strings, so online version updates and deletes use the correct SQL.

Closes #1045

## Checklist

- [x] Unit and integration tests covering the common scenarios were added
- [x] A human-readable description of the changes was provided to include in CHANGELOG
