### PR TITLE
Let the OS size synchronous HTTP send buffers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 
 ### Bug Fixes
 
+- Synchronous HTTP connections no longer set `SO_SNDBUF` to 256 KiB, which disabled automatic buffer sizing and could slow large uploads. The operating system now sizes the buffer. The pool manager helpers also honor explicit `socket_options` instead of replacing them with defaults. Closes [#1044](https://github.com/ClickHouse/clickhouse-connect/issues/1044).
 - Alembic offline SQL generation no longer fails when `include_schemas=True` and `version_table_schema` is unset. Offline mode now skips the current database lookup. Online version table updates and deletes also work when `version_table_schema=""`. Closes [#1045](https://github.com/ClickHouse/clickhouse-connect/issues/1045).
 - Failed synchronous client construction now releases its dedicated urllib3 pool manager. Repeated connection or configuration failures no longer leave unused pool managers registered. Caller-supplied and shared pool managers are unchanged.
 - Async requests waiting for a free connection no longer fail when the pool wait exceeds `connect_timeout`. The timeout still covers DNS, TCP, TLS, and proxy connection setup after a pool slot is available. Closes [#1013](https://github.com/ClickHouse/clickhouse-connect/issues/1013).

--- a/clickhouse_connect/driver/httputil.py
+++ b/clickhouse_connect/driver/httputil.py
@@ -37,8 +37,6 @@ SOCKET_TCP = socket.IPPROTO_TCP
 core_socket_options = [
     (socket.SOL_SOCKET, socket.SO_KEEPALIVE, 1),
     (SOCKET_TCP, socket.TCP_NODELAY, 1),
-    (socket.SOL_SOCKET, socket.SO_SNDBUF, 1024 * 256),
-    (socket.SOL_SOCKET, socket.SO_SNDBUF, 1024 * 256),
 ]
 
 logging.getLogger("urllib3").setLevel(logging.WARNING)
@@ -95,7 +93,7 @@ def get_pool_manager_options(
         options["cert_file"] = client_cert
     if client_cert_key:
         options["key_file"] = client_cert_key
-    options["socket_options"] = socket_options
+    options.setdefault("socket_options", socket_options)
     options["block"] = options.get("block", False)
     return options
 

--- a/docs/advanced-usage.mdx
+++ b/docs/advanced-usage.mdx
@@ -163,6 +163,8 @@ In this case ClickHouse Connect doesn't send a `session_id`; the server doesn't 
 
 ClickHouse Connect uses `urllib3` connection pools to handle the underlying HTTP connection to the server. By default, all synchronous client instances in a process share the same connection pool, which is sufficient for the majority of use cases. Each multiprocessing worker gets its own process-local default pool and reuses it across clients created in that worker. A client created before a fork keeps the parent's pool and should not be used in the child. The default pool maintains up to 8 HTTP Keep Alive connections to each ClickHouse server used by the application.
 
+The default socket options enable TCP keepalive and `TCP_NODELAY`. The operating system manages socket send and receive buffer sizes.
+
 For large multi-threaded applications, separate connection pools may be appropriate. Customized connection pools can be provided as the `pool_mgr` keyword argument to the main `clickhouse_connect.get_client` function:
 
 ```python
@@ -176,6 +178,8 @@ client2 = clickhouse_connect.get_client(pool_mgr=big_pool_mgr)
 ```
 
 Clients can share a pool manager, or each client can use a separate manager. For more details, see the [`urllib3` PoolManager documentation](https://urllib3.readthedocs.io/en/stable/advanced-usage.html#customizing-pool-behavior).
+
+To set socket options, pass `socket_options` to `httputil.get_pool_manager` or `httputil.get_pool_manager_options`. This replaces the entire default list, including keepalive options and `TCP_NODELAY`. Pass `[]` or `None` to apply no explicit socket options.
 
 The async client owns an aiohttp pool rather than using `urllib3`. Configure it through `connector_limit`, `connector_limit_per_host`, and `keepalive_timeout` on `get_async_client`. Calling `await async_client.close_connections()` rotates the pool without interrupting in-flight requests.
 

--- a/tests/unit_tests/test_driver/test_httputil.py
+++ b/tests/unit_tests/test_driver/test_httputil.py
@@ -1,5 +1,7 @@
 import multiprocessing
 import os
+import socket
+import sys
 import threading
 import weakref
 from concurrent.futures import ThreadPoolExecutor
@@ -97,6 +99,61 @@ def restore_default_pool_manager(restore_manager_registries):
     httputil._default_pool_pid = pid
     httputil._default_pool_lock = lock
     httputil._inherited_managers[:] = inherited
+
+
+def test_default_socket_options():
+    options = httputil.get_pool_manager_options(keep_interval=13, keep_count=7, keep_idle=79)["socket_options"]
+
+    assert (socket.SOL_SOCKET, socket.SO_KEEPALIVE, 1) in options
+    assert (socket.IPPROTO_TCP, socket.TCP_NODELAY, 1) in options
+    assert not any(level == socket.SOL_SOCKET and option in (socket.SO_SNDBUF, socket.SO_RCVBUF) for level, option, _ in options)
+    for name, value in (("TCP_KEEPINTVL", 13), ("TCP_KEEPCNT", 7), ("TCP_KEEPIDLE", 79)):
+        if hasattr(socket, name):
+            assert (socket.IPPROTO_TCP, getattr(socket, name), value) in options
+    if sys.platform == "darwin":
+        assert (socket.IPPROTO_TCP, getattr(socket, "TCP_KEEPALIVE", 0x10), 13) in options
+
+
+@pytest.mark.parametrize(
+    "socket_options",
+    [None, [], [(socket.SOL_SOCKET, socket.SO_SNDBUF, 128 * 1024), (socket.IPPROTO_TCP, socket.TCP_NODELAY, 0)]],
+    ids=["none", "empty", "custom"],
+)
+def test_explicit_socket_options(socket_options):
+    original = None if socket_options is None else socket_options.copy()
+    options = httputil.get_pool_manager_options(socket_options=socket_options)
+
+    assert options["socket_options"] == original
+    assert socket_options == original
+
+
+@pytest.mark.parametrize(
+    ("scheme", "proxy_options"),
+    [
+        ("http", {}),
+        ("https", {}),
+        ("http", {"http_proxy": "http://proxy.test:8080"}),
+        ("https", {"https_proxy": "https://proxy.test:8443"}),
+    ],
+    ids=["http", "https", "http_proxy", "https_proxy"],
+)
+@pytest.mark.parametrize(
+    "options",
+    [{}, {"socket_options": None}, {"socket_options": []}, {"socket_options": [(socket.SOL_SOCKET, socket.SO_SNDBUF, 128 * 1024)]}],
+    ids=["default", "none", "empty", "custom"],
+)
+def test_pool_socket_options(scheme, proxy_options, options):
+    expected = options.get("socket_options", httputil.get_pool_manager_options()["socket_options"])
+    manager = httputil.get_pool_manager(**proxy_options, **options)
+    try:
+        pool = manager.connection_from_host("clickhouse.test", scheme=scheme)
+        connection = pool._new_conn()
+        try:
+            assert connection.socket_options == expected
+        finally:
+            connection.close()
+    finally:
+        httputil._close_pool_manager(manager)
 
 
 class TestDefaultPoolManager:


### PR DESCRIPTION
## Summary

Remove the synchronous HTTP client's fixed 256 KiB send-buffer setting so the operating system can size the buffer for the connection. This avoids limiting large uploads while preserving the existing keepalive and `TCP_NODELAY` defaults.

The pool helpers now honor explicit `socket_options` as a complete replacement, including `None` and `[]`. Custom pools are still supported through `pool_mgr`.

Closes #1044

## Checklist

- [x] Unit and integration tests covering the common scenarios were added
- [x] A human-readable description of the changes was provided to include in CHANGELOG
