### PR TITLE
Fix table engine constructors and summing column replay

### DIFF
--- a/.github/workflows/on_push.yml
+++ b/.github/workflows/on_push.yml
@@ -87,8 +87,8 @@ jobs:
           "$RUNNER_TEMP/consumer/bin/mypy" --strict --follow-imports=silent consumer_smoke.py
       - name: Public type completeness ratchet
         # SQLAlchemy must be installed while verifytypes scans the public cc_sqlalchemy annotations.
-        # Local measurement is 1066 with that optional surface resolved, plus 1 headroom for stub drift.
-        run: python scripts/check_public_types.py clickhouse_connect --max-untyped 1067 --python "$RUNNER_TEMP/consumer/bin/python"
+        # Local measurement is 1049 with that optional surface resolved, plus 1 headroom for stub drift.
+        run: python scripts/check_public_types.py clickhouse_connect --max-untyped 1050 --python "$RUNNER_TEMP/consumer/bin/python"
       - name: SQLAlchemy Select typing smoke test
         run: |
           cp tests/type_check/sqlalchemy_select_smoke.py "$RUNNER_TEMP"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 
 ### Bug Fixes
 
+- SQLAlchemy `Memory`, `Log`, `StripeLog`, `TinyLog`, `Null`, and `Set` engines now accept the zero-argument and `settings=` constructor calls emitted by Alembic. SummingMergeTree engines now accept keyword-only `columns` and preserve explicit summing columns through reflection and Alembic. Existing positional arguments and engine inheritance remain compatible. Closes [#946](https://github.com/ClickHouse/clickhouse-connect/issues/946).
 - Synchronous HTTP connections no longer set `SO_SNDBUF` to 256 KiB, which disabled automatic buffer sizing and could slow large uploads. The operating system now sizes the buffer. The pool manager helpers also honor explicit `socket_options` instead of replacing them with defaults. Closes [#1044](https://github.com/ClickHouse/clickhouse-connect/issues/1044).
 - Alembic offline SQL generation no longer fails when `include_schemas=True` and `version_table_schema` is unset. Offline mode now skips the current database lookup. Online version table updates and deletes also work when `version_table_schema=""`. Closes [#1045](https://github.com/ClickHouse/clickhouse-connect/issues/1045).
 - Failed synchronous client construction now releases its dedicated urllib3 pool manager. Repeated connection or configuration failures no longer leave unused pool managers registered. Caller-supplied and shared pool managers are unchanged.

--- a/clickhouse_connect/cc_sqlalchemy/ddl/tableengine.py
+++ b/clickhouse_connect/cc_sqlalchemy/ddl/tableengine.py
@@ -1,7 +1,7 @@
 import logging
 import threading
 from collections.abc import Sequence
-from typing import Any
+from typing import TYPE_CHECKING, Any
 
 from sqlalchemy import Column
 from sqlalchemy.engine.default import DefaultDialect
@@ -11,14 +11,20 @@ from sqlalchemy.sql.elements import ClauseElement, ColumnElement, TextClause
 from sqlalchemy.sql.schema import SchemaItem
 
 from clickhouse_connect.cc_sqlalchemy.sql.sqlparse import split_top_level, walk_sql
-from clickhouse_connect.driver.binding import _decode_ch_string_literal, format_str, quote_identifier
+from clickhouse_connect.driver.binding import _decode_ch_string_literal, _format_identifier, format_str, quote_identifier
 from clickhouse_connect.driver.parser import parse_callable
 
 logger = logging.getLogger(__name__)
 
 engine_map: dict[str, type["TableEngine"]] = {}
-EngineExpr = str | TextClause | ColumnElement | InstrumentedAttribute
+if TYPE_CHECKING:
+    EngineExpr = str | TextClause | ColumnElement[Any] | InstrumentedAttribute[Any]
+    _SummingColumn = str | Column[Any] | InstrumentedAttribute[Any]
+else:
+    EngineExpr = str | TextClause | ColumnElement | InstrumentedAttribute
+    _SummingColumn = str | Column | InstrumentedAttribute
 EngineParam = EngineExpr | Sequence[EngineExpr] | None
+_SummingColumns = _SummingColumn | Sequence[_SummingColumn]
 ENGINE_CLAUSES = ("ORDER BY", "PARTITION BY", "PRIMARY KEY", "SAMPLE BY", "TTL", "SETTINGS")
 
 _engine_render_dialect: DefaultDialect | None = None
@@ -71,6 +77,27 @@ def _render_setting_value(value: Any) -> str:
     return format_str(str(value))
 
 
+def _render_summing_column(value: _SummingColumn) -> str:
+    value = _coerce_clause_element(value)
+    if isinstance(value, Column):
+        if not value.name:
+            raise ArgumentError("Summing columns must be named columns")
+        value = value.name
+    if isinstance(value, str):
+        return _format_identifier(value)
+    raise ArgumentError(f"Summing columns must be column names or mapped columns, got {type(value).__name__}")
+
+
+def _render_summing_columns(value: _SummingColumns | None) -> str | None:
+    if value is None or isinstance(value, str):
+        return value
+    if isinstance(value, Sequence):
+        if not value:
+            raise ArgumentError("Summing columns must not be empty")
+        return f"({', '.join(_render_summing_column(column) for column in value)})"
+    return _render_summing_column(value)
+
+
 def tuple_expr(expr_name: str, value: EngineParam) -> str:
     """
     Create a table parameter with a tuple or list correctly formatted
@@ -120,8 +147,12 @@ class TableEngine(SchemaItem):
     def __init_subclass__(cls, **kwargs):
         engine_map[cls.__name__] = cls
 
-    def __init__(self, kwargs):
+    def __init__(self, kwargs: dict[str, Any] | None = None, *, settings: dict[str, Any] | None = None) -> None:
         super().__init__()
+        if kwargs is None:
+            kwargs = {}
+        if settings is not None:
+            kwargs["settings"] = settings
         self.name = self.__class__.__name__
         te_name = f"{self.name} Table Engine"
         self._orig_kwargs = kwargs.copy()
@@ -260,7 +291,25 @@ class SharedMergeTree(MergeTree):
 
 
 class SummingMergeTree(MergeTree):
-    pass
+    arg_names: Sequence[str] = ["columns"]
+    optional_args: set[str] = set(arg_names)
+
+    def __init__(
+        self,
+        order_by: EngineParam = None,
+        primary_key: EngineParam = None,
+        partition_by: EngineParam = None,
+        sample_by: EngineParam = None,
+        ttl: EngineExpr | None = None,
+        settings: dict[str, Any] | None = None,
+        *,
+        columns: _SummingColumns | None = None,
+    ) -> None:
+        if order_by is None and primary_key is None:
+            raise ArgumentError(None, "Either PRIMARY KEY or ORDER BY must be specified")
+        columns = _render_summing_columns(columns)
+        # Bypasses MergeTree.__init__, which has no columns parameter.
+        TableEngine.__init__(self, locals())
 
 
 class AggregatingMergeTree(MergeTree):
@@ -386,7 +435,27 @@ class ReplicatedAggregatingMergeTree(ReplicatedMergeTree):
 
 
 class ReplicatedSummingMergeTree(ReplicatedMergeTree):
-    pass
+    arg_names: list[str] = ["zk_path", "replica", "columns"]
+    optional_args: set[str] = set(arg_names)
+
+    def __init__(
+        self,
+        order_by: EngineParam = None,
+        primary_key: EngineParam = None,
+        partition_by: EngineParam = None,
+        sample_by: EngineParam = None,
+        zk_path: str | None = None,
+        replica: str | None = None,
+        ttl: EngineExpr | None = None,
+        settings: dict[str, Any] | None = None,
+        *,
+        columns: _SummingColumns | None = None,
+    ) -> None:
+        if order_by is None and primary_key is None:
+            raise ArgumentError(None, "Either PRIMARY KEY or ORDER BY must be specified")
+        columns = _render_summing_columns(columns)
+        # Bypasses ReplicatedMergeTree.__init__, which has no columns parameter.
+        TableEngine.__init__(self, locals())
 
 
 class ReplicatedReplacingMergeTree(TableEngine):

--- a/docs/sqlalchemy.mdx
+++ b/docs/sqlalchemy.mdx
@@ -370,6 +370,19 @@ String values in `DEFAULT`, `MATERIALIZED`, `ALIAS`, and `TTL` clauses use Click
 
 MergeTree key arguments such as `order_by`, `partition_by`, `primary_key`, `sample_by`, and `ttl` accept SQLAlchemy column and SQL expressions as well as plain strings.
 
+`Memory()`, `Log()`, `StripeLog()`, `TinyLog()`, `Null()`, and `Set()` accept zero arguments and round-trip through Alembic autogeneration. The existing dictionary argument remains supported. Use `settings={...}` to supply engine settings.
+
+`SummingMergeTree` and `ReplicatedSummingMergeTree` accept an optional, keyword-only `columns` argument. Existing positional arguments keep their meaning, so `SummingMergeTree("id")` still sets `ORDER BY id`.
+
+```python
+from clickhouse_connect.cc_sqlalchemy.ddl.tableengine import SummingMergeTree
+
+engine_clause = SummingMergeTree("id", columns=("delta", "n_tx"))
+# Sum delta and n_tx for rows with the same id.
+```
+
+Pass a string, a SQLAlchemy column, a mapped column attribute, or a non-empty list or tuple of those values. List and tuple string items are quoted as identifiers. A scalar string supplies raw SQL, such as `"delta"` or `"(delta, n_tx)"`. The server requires identifiers for these columns. Omit `columns` to let ClickHouse select the columns to sum. Reflection and Alembic autogeneration preserve an explicit column list.
+
 ## Inserts and basic ORM use {#sqlalchemy-inserts}
 
 Core inserts and simple ORM models are supported. Prefer Core inserts for bulk data paths.

--- a/tests/integration_tests/test_sqlalchemy/test_alembic.py
+++ b/tests/integration_tests/test_sqlalchemy/test_alembic.py
@@ -31,11 +31,14 @@ from clickhouse_connect.cc_sqlalchemy.datatypes.sqltypes import (
     String,
     Tuple,
     UInt32,
+    UInt64,
 )
 from clickhouse_connect.cc_sqlalchemy.ddl.dictionary import Dictionary
 from clickhouse_connect.cc_sqlalchemy.ddl.tableengine import (
+    Memory,
     MergeTree,
     ReplacingMergeTree,
+    SummingMergeTree,
 )
 
 logging.getLogger("alembic").setLevel(logging.WARNING)
@@ -491,6 +494,56 @@ def test_alembic_autogenerate_positional_engine_live(test_engine: Engine, test_d
         assert "index_granularity = 1024" in engine_full
         rows = conn.execute(text(f"SELECT version_num FROM `{test_db}`.`alembic_version`")).fetchall()
         assert rows
+
+
+@pytest.mark.parametrize(
+    "engine_factory,rendered_engine,engine_fragments",
+    [
+        (
+            lambda amount: Memory({"settings": {"max_rows_to_keep": 13}}),
+            "clickhouse_engine=Memory(settings={'max_rows_to_keep': 13})",
+            ("Memory", "max_rows_to_keep = 13"),
+        ),
+        (
+            lambda amount: SummingMergeTree("id", columns=[amount, "n_tx"]),
+            "clickhouse_engine=SummingMergeTree(order_by='id', columns='(`net amount`, `n_tx`)')",
+            ("SummingMergeTree", "`net amount`", "n_tx", "ORDER BY id"),
+        ),
+    ],
+    ids=["memory-settings", "summing-columns"],
+)
+def test_alembic_autogenerate_engine_upgrade_downgrade_live(
+    test_engine: Engine, test_db: str, tmp_path: Path, ch_name, engine_factory, rendered_engine, engine_fragments
+):
+    table_name = ch_name("alembic_engine")
+    metadata = MetaData(schema=test_db)
+    amount = Column("net amount", UInt64, nullable=False)
+    Table(
+        table_name,
+        metadata,
+        Column("id", UInt64, nullable=False),
+        amount,
+        Column("n_tx", UInt64, nullable=False),
+        engine_factory(amount),
+    )
+    count_sql = text("SELECT count() FROM system.tables WHERE database = :database AND name = :table_name")
+    params = {"database": test_db, "table_name": table_name}
+
+    with test_engine.connect() as conn:
+        config = _alembic_config(tmp_path, conn, metadata, frozenset({table_name}))
+        revision = command.revision(config, message="create engine table", autogenerate=True)
+        assert revision is not None
+        assert not isinstance(revision, list)
+        contents = Path(revision.path).read_text(encoding="utf-8")
+        assert rendered_engine in contents
+        command.upgrade(config, "head")
+        engine_full = conn.execute(
+            text("SELECT engine_full FROM system.tables WHERE database = :database AND name = :table_name"), params
+        ).scalar()
+        for fragment in engine_fragments:
+            assert fragment in engine_full
+        command.downgrade(config, "base")
+        assert conn.execute(count_sql, params).scalar() == 0
 
 
 def test_alembic_named_container_types_round_trip_live(test_engine: Engine, test_db: str, tmp_path: Path, ch_name):

--- a/tests/integration_tests/test_sqlalchemy/test_tableengine.py
+++ b/tests/integration_tests/test_sqlalchemy/test_tableengine.py
@@ -1,0 +1,61 @@
+from uuid import uuid4
+
+import pytest
+import sqlalchemy as sa
+from sqlalchemy.engine import Engine
+
+from clickhouse_connect.cc_sqlalchemy import engines, types
+
+
+def test_memory_engine_reflection(test_engine: Engine, test_db: str):
+    metadata = sa.MetaData(schema=test_db)
+    table = sa.Table(
+        f"memory_engine_{uuid4().hex[:8]}", metadata, sa.Column("id", types.UInt64), engines.Memory(settings={"max_rows_to_keep": 13})
+    )
+    with test_engine.begin() as conn:
+        try:
+            table.create(conn)
+            reflected = sa.Table(table.name, sa.MetaData(schema=test_db), autoload_with=conn)
+            assert reflected.engine.settings["max_rows_to_keep"] == 13
+            replay = sa.Table(table.name + "_replay", metadata, sa.Column("id", types.UInt64), eval(repr(reflected.engine), vars(engines)))
+            replay.create(conn)
+            for target in (table, replay):
+                conn.execute(target.insert(), [{"id": 13}, {"id": 79}])
+                assert conn.execute(sa.select(target).order_by(target.c.id)).all() == [(13,), (79,)]
+        finally:
+            metadata.drop_all(conn, checkfirst=True)
+
+
+@pytest.mark.parametrize("amount_name", ["amount", "net amount, total"])
+def test_summing_engine_reflection(test_engine: Engine, test_db: str, amount_name: str):
+    metadata = sa.MetaData(schema=test_db)
+    amount = sa.Column(amount_name, types.UInt64)
+    table = sa.Table(
+        f"summing_engine_{uuid4().hex[:8]}",
+        metadata,
+        sa.Column("id", types.UInt64),
+        amount,
+        sa.Column("other", types.UInt64),
+        engines.SummingMergeTree("id", columns=[amount], settings={"index_granularity": 1024}),
+    )
+    with test_engine.begin() as conn:
+        try:
+            table.create(conn)
+            reflected = sa.Table(table.name, sa.MetaData(schema=test_db), autoload_with=conn)
+            replay = sa.Table(
+                table.name + "_replay",
+                metadata,
+                sa.Column("id", types.UInt64),
+                sa.Column(amount_name, types.UInt64),
+                sa.Column("other", types.UInt64),
+                eval(repr(reflected.engine), vars(engines)),
+            )
+            replay.create(conn)
+            for target in (table, replay):
+                conn.execute(target.insert(), [{"id": 13, amount_name: 13, "other": 7}, {"id": 13, amount_name: 79, "other": 11}])
+                rows = conn.execute(sa.select(target).final()).all()
+                assert len(rows) == 1
+                assert rows[0][:2] == (13, 92)
+                assert rows[0][2] in (7, 11)
+        finally:
+            metadata.drop_all(conn, checkfirst=True)

--- a/tests/type_check/sqlalchemy_select_smoke.py
+++ b/tests/type_check/sqlalchemy_select_smoke.py
@@ -1,11 +1,19 @@
 from __future__ import annotations
 
 import sqlalchemy as sa
+from sqlalchemy.orm import InstrumentedAttribute
 from sqlalchemy.sql import ColumnElement
 from typing_extensions import assert_type
 
 import clickhouse_connect.cc_sqlalchemy as cc_sa
 from clickhouse_connect.cc_sqlalchemy.datatypes.sqltypes import JSON, UInt32
+from clickhouse_connect.cc_sqlalchemy.ddl.tableengine import (
+    Memory,
+    MergeTree,
+    ReplicatedMergeTree,
+    ReplicatedSummingMergeTree,
+    SummingMergeTree,
+)
 
 book = sa.table(
     "book",
@@ -61,3 +69,24 @@ assert_type(typed_json_path, ColumnElement[int])
 typed_json_path_from_class = cc_sa.json_subcolumn(json_payload, "request_id", type_=UInt32)
 assert_type(typed_json_path_from_class, ColumnElement[int])
 cc_sa.json_subcolumn(json_payload, 13)  # type: ignore[call-overload]
+
+assert_type(Memory(), Memory)
+assert_type(Memory({"settings": {"max_rows_to_keep": 13}}), Memory)
+assert_type(Memory(kwargs={}, settings={"max_rows_to_keep": 13}), Memory)
+
+
+def summing_engine_columns(attribute: InstrumentedAttribute[int]) -> None:
+    column = sa.Column("amount", UInt32)
+    names: list[str] = ["amount", "count"]
+    columns: list[sa.Column[int]] = [column]
+    assert_type(SummingMergeTree("id", columns="amount"), SummingMergeTree)
+    assert_type(SummingMergeTree("id", columns=names), SummingMergeTree)
+    assert_type(SummingMergeTree("id", columns=columns), SummingMergeTree)
+    assert_type(SummingMergeTree("id", columns=attribute), SummingMergeTree)
+    assert_type(SummingMergeTree("id", columns=[column, attribute, "count"]), SummingMergeTree)
+    merge_tree: MergeTree = SummingMergeTree("id", columns=(column, "count"))
+    replicated: ReplicatedMergeTree = ReplicatedSummingMergeTree("id", columns=[column])
+    assert_type(merge_tree, MergeTree)
+    assert_type(replicated, ReplicatedMergeTree)
+    SummingMergeTree("id", columns=13)  # type: ignore[arg-type]
+    SummingMergeTree("id", columns=sa.text("amount"))  # type: ignore[arg-type]

--- a/tests/unit_tests/test_sqlalchemy/test_tableengine.py
+++ b/tests/unit_tests/test_sqlalchemy/test_tableengine.py
@@ -1,0 +1,165 @@
+from io import StringIO
+
+import pytest
+import sqlalchemy as sa
+from alembic.autogenerate.api import render_python_code
+from alembic.operations import Operations, ops
+from alembic.runtime.migration import MigrationContext
+from sqlalchemy.exc import ArgumentError
+from sqlalchemy.orm import declarative_base
+
+from clickhouse_connect.cc_sqlalchemy import engines, types
+from clickhouse_connect.cc_sqlalchemy.alembic import clickhouse_writer
+from clickhouse_connect.cc_sqlalchemy.ddl.tableengine import build_engine
+from clickhouse_connect.cc_sqlalchemy.dialect import ClickHouseDialect
+
+simple_engines = (engines.Memory, engines.Log, engines.StripeLog, engines.TinyLog, engines.Null, engines.Set)
+summing_engines = (engines.SummingMergeTree, engines.ReplicatedSummingMergeTree, engines.SharedSummingMergeTree)
+
+
+@pytest.mark.parametrize("engine_cls", simple_engines)
+def test_simple_engine_construction(engine_cls):
+    engine = engine_cls()
+    assert engine.compile() == f"Engine {engine_cls.__name__}"
+    assert repr(engine) == f"{engine_cls.__name__}()"
+    assert eval(repr(engine), vars(engines)).compile() == engine.compile()
+
+
+@pytest.mark.parametrize("engine_cls", simple_engines)
+@pytest.mark.parametrize("keyword", [False, True])
+def test_simple_engine_legacy_mapping(engine_cls, keyword):
+    kwargs = {"settings": {"persistent": 0}}
+    engine = engine_cls(kwargs=kwargs) if keyword else engine_cls(kwargs)
+    assert engine.compile() == f"Engine {engine_cls.__name__} SETTINGS persistent = 0"
+    assert eval(repr(engine), vars(engines)).compile() == engine.compile()
+
+
+@pytest.mark.parametrize("settings", [None, {}, {"max_rows_to_keep": 79}])
+def test_memory_settings_keyword(settings):
+    kwargs = {"settings": {"max_rows_to_keep": 13}}
+    engine = engines.Memory(kwargs, settings=settings)
+    expected = {"max_rows_to_keep": 13} if settings is None else settings
+    assert engine.settings == expected
+    assert eval(repr(engine), vars(engines)).compile() == engine.compile()
+    assert engines.Memory(settings=settings).settings == (settings or {})
+
+
+@pytest.mark.parametrize("engine_cls", summing_engines)
+@pytest.mark.parametrize(
+    "columns,expected",
+    [
+        (None, ""),
+        ("amount", "(amount)"),
+        ("(amount, count)", "((amount, count))"),
+        (["amount"], "((`amount`))"),
+        (("amount", "count"), "((`amount`, `count`))"),
+        (sa.Column("amount", types.UInt64), "(`amount`)"),
+        ([sa.Column("amount", types.UInt64), "count"], "((`amount`, `count`))"),
+        ((sa.Column("net amount", types.UInt64), "count, total"), "((`net amount`, `count, total`))"),
+        (["select", "tick`name", "back\\name"], "((`select`, `tick\\`name`, `back\\\\name`))"),
+        (['"amount"', "`count`"], '((`"amount"`, `\\`count\\``))'),
+        (sa.Column('"amount"', types.UInt64), '(`"amount"`)'),
+    ],
+)
+def test_summing_columns(engine_cls, columns, expected):
+    engine = engine_cls("id", columns=columns)
+    assert engine.compile() == f"Engine {engine_cls.__name__}{expected} ORDER BY id"
+    assert eval(repr(engine), vars(engines)).compile() == engine.compile()
+
+
+@pytest.mark.parametrize("engine_cls", summing_engines)
+def test_summing_orm_columns(engine_cls):
+    base = declarative_base()
+
+    class Metric(base):
+        __tablename__ = "metric"
+        id = sa.Column(types.UInt64, primary_key=True)
+        amount = sa.Column("net amount", types.UInt64)
+
+    scalar = engine_cls("id", columns=Metric.amount)
+    assert scalar.compile() == f"Engine {engine_cls.__name__}(`net amount`) ORDER BY id"
+    multiple = engine_cls("id", columns=[Metric.amount, "count"])
+    assert multiple.compile() == f"Engine {engine_cls.__name__}((`net amount`, `count`)) ORDER BY id"
+    assert eval(repr(multiple), vars(engines)).compile() == multiple.compile()
+
+
+@pytest.mark.parametrize("engine_cls", summing_engines)
+@pytest.mark.parametrize(
+    "columns",
+    [
+        [],
+        (),
+        13,
+        ["amount", 79],
+        [["amount"]],
+        sa.text("amount"),
+        sa.column("amount") + 1,
+        sa.func.sum(sa.column("amount")),
+        sa.Column(types.UInt64),
+        [sa.Column(types.UInt64)],
+    ],
+)
+def test_summing_columns_reject_invalid_inputs(engine_cls, columns):
+    with pytest.raises(ArgumentError, match="columns"):
+        engine_cls("id", columns=columns)
+
+
+@pytest.mark.parametrize("engine_cls", summing_engines)
+def test_summing_preserves_merge_tree_contract(engine_cls):
+    base = engines.ReplicatedMergeTree if engine_cls is engines.ReplicatedSummingMergeTree else engines.MergeTree
+    assert issubclass(engine_cls, base)
+    positional = ["id", "id", "toYYYYMM(ts)", "id"]
+    if base is engines.ReplicatedMergeTree:
+        positional += ["/tables/metrics", "replica_1"]
+    positional += ["ts + INTERVAL 1 DAY", {"index_granularity": 1024}]
+    engine = engine_cls(*positional)
+    assert engine.compile() == base(*positional).compile().replace(f"Engine {base.__name__}", f"Engine {engine_cls.__name__}", 1)
+    assert eval(repr(engine), vars(engines)).compile() == engine.compile()
+    with pytest.raises(ArgumentError, match="Either PRIMARY KEY or ORDER BY"):
+        engine_cls()
+
+
+@pytest.mark.parametrize("prefix", ["", "Replicated", "Shared"])
+@pytest.mark.parametrize("columns", ["", "amount", "(amount, count)", "(`net amount`, `count, total`)"])
+def test_reflected_summing_columns(prefix, columns):
+    args = ["'/tables/metrics'", "'replica_1'"] if prefix else []
+    if columns:
+        args.append(columns)
+    argument_sql = f"({', '.join(args)})" if args else ""
+    reflected = build_engine(f"{prefix}SummingMergeTree{argument_sql} ORDER BY id SETTINGS index_granularity = 1024")
+    assert reflected is not None
+    if prefix == "Shared":
+        args = [columns] if columns else []
+        prefix = ""
+    argument_sql = f"({', '.join(args)})" if args else ""
+    reconstructed = eval(repr(reflected), vars(engines))
+    assert reconstructed.compile() == f"Engine {prefix}SummingMergeTree{argument_sql} ORDER BY id SETTINGS index_granularity = 1024"
+
+
+@pytest.mark.parametrize(
+    "engine_sql",
+    [
+        *(cls.__name__ for cls in simple_engines),
+        "Memory SETTINGS max_rows_to_keep = 13",
+        "SummingMergeTree((`net amount`, count)) ORDER BY id",
+    ],
+)
+def test_reflected_engine_alembic_execution(engine_sql):
+    engine = build_engine(engine_sql)
+    table = sa.Table(
+        "metrics",
+        sa.MetaData(),
+        sa.Column("id", types.UInt64),
+        sa.Column("net amount", types.UInt64),
+        sa.Column("count", types.UInt64),
+        clickhouse_engine=engine,
+    )
+    context = MigrationContext.configure(dialect=ClickHouseDialect())
+    directive = ops.MigrationScript("rev_1", ops.UpgradeOps([ops.CreateTableOp.from_table(table)]), ops.DowngradeOps([]))
+    clickhouse_writer(context, (), [directive])
+    generated = render_python_code(directive.upgrade_ops, migration_context=context)
+    output = StringIO()
+    offline = MigrationContext.configure(dialect=ClickHouseDialect(), opts={"as_sql": True, "output_buffer": output})
+    namespace = {"sa": sa, "op": Operations(offline), **vars(engines), **vars(types)}
+    exec("def upgrade():\n" + generated + "\nupgrade()", namespace)
+    assert "Engine " + engine_sql in output.getvalue()


### PR DESCRIPTION
## Summary

Alembic-generated constructors for simple table engines now run, including zero-argument calls and `settings=`.

Summing engines now accept keyword-only `columns` and preserve the selection through reflection and migration replay. Replayed tables retain the original aggregation behavior. Existing positional arguments and inheritance stay compatible.

Closes #946

## Checklist

- [x] Unit and integration tests covering the common scenarios were added
- [x] A human-readable description of the changes was provided to include in CHANGELOG
