### PR TITLE
Fix Cloud JSON flake and SQLAlchemy 1.x CI dependencies

### DIFF
--- a/.github/workflows/on_push.yml
+++ b/.github/workflows/on_push.yml
@@ -267,8 +267,11 @@ jobs:
         run:  python -m pip install --upgrade pip
       - name: Install Test Dependencies
         run: pip install -r tests/test_requirements.txt
-      - name: Install sqlalchemy 1.x
-        run: pip install "sqlalchemy>=1.4.40,<2.0" # Override sqa version
+      - name: Install SQLAlchemy 1.x and compatible Alembic
+        run: |
+          # Resolve both together because newer Alembic versions require SQLAlchemy 2.x.
+          pip install "sqlalchemy>=1.4.40,<2.0" "alembic>=1.18"
+          pip check
       - name: Build cython extensions
         run: python setup.py build_ext --inplace
       - name: "Add distribution info"  #  This lets SQLAlchemy find entry points

--- a/tests/integration_tests/test_dynamic.py
+++ b/tests/integration_tests/test_dynamic.py
@@ -243,10 +243,8 @@ def test_json_escaped_dots_roundtrip(param_client: Client, call, table_context: 
     if param_client.server_settings.get("json_type_escape_dots_in_keys") is None:
         pytest.skip("json_type_escape_dots_in_keys setting unavailable on this server version")
 
-    # with escaping enabled dots are preserved in keys
-    if not param_client.get_client_setting("session_id"):
-        param_client.set_client_setting("session_id", str(UUID(int=0)))
-    call(param_client.command, "SET json_type_escape_dots_in_keys=1")
+    # Sent per request. A session SET only reaches one Cloud replica.
+    param_client.set_client_setting("json_type_escape_dots_in_keys", 1)
     with table_context("json_dots_escape", ["value JSON"], order_by="()"):
         payload = {"a.b": 123, "c": {"d.e": 456}}
         call(param_client.insert, "json_dots_escape", [[payload]])
@@ -260,7 +258,7 @@ def test_json_escaped_dots_roundtrip(param_client: Client, call, table_context: 
         assert returned["c"]["d.e"] == 456
 
     # with escaping disabled dots create nested structure
-    call(param_client.command, "SET json_type_escape_dots_in_keys=0")
+    param_client.set_client_setting("json_type_escape_dots_in_keys", 0)
     with table_context("json_dots_no_escape", ["value JSON"], order_by="()"):
         payload = {"a.b": 789}
         call(param_client.insert, "json_dots_no_escape", [[payload]])


### PR DESCRIPTION
## Summary

The JSON dotted-key test can fail on Cloud when a new connection sends the insert to a replica that did not receive the session `SET`. Send `json_type_escape_dots_in_keys` with every request through `set_client_setting` and remove the session-id setup.

Cherry-pick the workflow fix from #1049 to resolve SQLAlchemy 1.x and Alembic together, then run `pip check`. The previous install left Alembic 1.20 alongside SQLAlchemy 1.4 and failed test collection. Both fixes are needed for the compatibility and Cloud jobs to pass on the same branch.

Fixes the flaky test in [this Cloud job](https://github.com/ClickHouse/clickhouse-connect/actions/runs/34645239734/job/103415638660).
