### PR TITLE
1.9.0rc3 release prep

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## UNRELEASED
 
+## 1.9.0rc3, 2026-09-11
+
 ### Bug Fixes
 
 - SQLAlchemy `Memory`, `Log`, `StripeLog`, `TinyLog`, `Null`, and `Set` engines now accept the zero-argument and `settings=` constructor calls emitted by Alembic. SummingMergeTree engines now accept keyword-only `columns` and preserve explicit summing columns through reflection and Alembic. Existing positional arguments and engine inheritance remain compatible. Closes [#946](https://github.com/ClickHouse/clickhouse-connect/issues/946).

--- a/clickhouse_connect/_version.py
+++ b/clickhouse_connect/_version.py
@@ -1,1 +1,1 @@
-version = "1.9.0rc2"
+version = "1.9.0rc3"


### PR DESCRIPTION
## Summary

Prepare 1.9.0rc3 with the Alembic schema, table engine, and socket buffer fixes merged from main. Date the changelog section and bump the package version from 1.9.0rc2 to 1.9.0rc3.

## Checklist
- [x] A human-readable description of the changes was provided to include in CHANGELOG
